### PR TITLE
General fixes

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/SubclassOf.cs
+++ b/Managed/UnrealSharp/UnrealSharp/SubclassOf.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.InteropServices;
+using System.Runtime.InteropServices;
 using UnrealSharp.Interop;
 
 namespace UnrealSharp;
@@ -52,14 +52,14 @@ public readonly struct SubclassOf<T>
         return Valid ? ManagedType.Name : "null";
     }
     
-    public SubclassOf<T> As<T>()
+    public SubclassOf<TChildClass> As<TChildClass>()
     {
-        if (!IsChildOf(typeof(T)))
+        if (!IsChildOf(typeof(TChildClass)))
         {
             throw new InvalidOperationException();
         }
 
-        return new SubclassOf<T>(NativeClass);
+        return new SubclassOf<TChildClass>(NativeClass);
     }
 
     public bool IsChildOf(Type type)

--- a/Source/GlueGenerator/CSGenerator.h
+++ b/Source/GlueGenerator/CSGenerator.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "CSNameMapper.h"
@@ -57,10 +57,7 @@ public:
 	
 	bool CanExportProperty(const UStruct* Struct, const FProperty* Property) const;
 	bool CanExportPropertyShared(const FProperty* Property) const;
-	
-	const FCSModule& FindModule(const UObject* Object);
-	const FCSModule& FindModule(FName ModuleFName);
-	
+		
 	void ExportStructMarshaller(FCSScriptBuilder& Builder, const UScriptStruct* Struct);
 
 	// Helper methods
@@ -83,11 +80,11 @@ public:
 
 	void ExportStructProperties(FCSScriptBuilder& Builder, const UStruct* Struct, const TSet<FProperty*>& ExportedProperties, bool bSuppressOffsets) const;
 
-	void RegisterClassToModule(UStruct* Struct);
+	void RegisterClassToModule(const UObject* Struct);
 
 	const FString& GetNamespace(const UObject* Object);
 
-	FCSModule& FindOrRegisterModule(const FName& ModuleName);
+	FCSModule& FindOrRegisterModule(const UObject* Object);
 
 	// Public data structures
 	struct ExtensionMethod

--- a/Source/GlueGenerator/CSModule.cpp
+++ b/Source/GlueGenerator/CSModule.cpp
@@ -1,10 +1,12 @@
-﻿#include "CSModule.h"
+#include "CSModule.h"
 #include "CSScriptBuilder.h"
 #include "Misc/Paths.h"
 
 FCSModule::FCSModule(FName InModuleName, const FString& SourceDirectory) : ModuleName(InModuleName)
 {
 	Namespace = FString::Printf(UNREAL_SHARP_NAMESPACE TEXT(".%s"), *InModuleName.ToString());
+	Namespace.ReplaceCharInline(TCHAR('-'), TCHAR('_'));
+
 	Directory = FPaths::Combine(*SourceDirectory, *InModuleName.ToString());
 
 	IFileManager& FileManager = IFileManager::Get();

--- a/Source/GlueGenerator/CSNameMapper.cpp
+++ b/Source/GlueGenerator/CSNameMapper.cpp
@@ -1,23 +1,23 @@
-﻿#include "CSNameMapper.h"
+#include "CSNameMapper.h"
 #include "CSModule.h"
 #include "CSGenerator.h"
 #include "UObject/Class.h"
 
 FString FCSNameMapper::GetQualifiedName(const UClass* Class) const
 {
-	const FCSModule& BindingsModule = ScriptGenerator->FindModule(Class);
+	const FCSModule& BindingsModule = ScriptGenerator->FindOrRegisterModule(Class);
 	return FString::Printf(TEXT("%s.%s"), *BindingsModule.GetNamespace(), *GetScriptClassName(Class));
 }
 
 FString FCSNameMapper::GetQualifiedName(const UScriptStruct* Struct) const
 {
-	const FCSModule& BindingsModule = ScriptGenerator->FindModule(Struct);
+	const FCSModule& BindingsModule = ScriptGenerator->FindOrRegisterModule(Struct);
 	return FString::Printf(TEXT("%s.%s"), *BindingsModule.GetNamespace(), *GetStructScriptName(Struct));
 }
 
 FString FCSNameMapper::GetQualifiedName(const UEnum* Enum) const
 {
-	const FCSModule& BindingsModule = ScriptGenerator->FindModule(Enum->GetPackage());
+	const FCSModule& BindingsModule = ScriptGenerator->FindOrRegisterModule(Enum);
 	return FString::Printf(TEXT("%s.%s"), *BindingsModule.GetNamespace(), *Enum->GetName());
 }
 
@@ -94,7 +94,7 @@ FString DeSnakifyName(const FString &SnakeCaseString, bool uppercaseFirst = fals
 
 	bool uppercaseNext = uppercaseFirst;
 	int len = SnakeCaseString.Len();
-	int uppercaseCount;
+	int uppercaseCount = 0;
 	for (int i = 0; i < len; i++)
 	{
 		auto ch = SnakeCaseString[i];

--- a/Source/GlueGenerator/CSScriptBuilder.cpp
+++ b/Source/GlueGenerator/CSScriptBuilder.cpp
@@ -1,4 +1,4 @@
-﻿#include "CSScriptBuilder.h"
+#include "CSScriptBuilder.h"
 #include "Internationalization/Regex.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
@@ -17,12 +17,13 @@ const FName NAME_ToolTip(TEXT("ToolTip"));
 
 void FCSScriptBuilder::GenerateScriptSkeleton(const FString& Namespace)
 {
-	AppendLine(FString::Printf(TEXT("using %s;"), UNREAL_SHARP_ENGINE_NAMESPACE));
-	AppendLine(FString::Printf(TEXT("using %s;"), UNREAL_SHARP_ATTRIBUTES_NAMESPACE));
-	AppendLine(TEXT("using UnrealSharp.Interop;"));
-	AppendLine(TEXT("using System.DoubleNumerics;"));
-	AppendLine(TEXT("using System.Runtime;"));
-	AppendLine(TEXT("using System.Runtime.InteropServices;"));
+	DeclareDirective(UNREAL_SHARP_ENGINE_NAMESPACE);
+	DeclareDirective(UNREAL_SHARP_ATTRIBUTES_NAMESPACE);
+	DeclareDirective(TEXT("UnrealSharp.Interop"));
+	DeclareDirective(TEXT("System.DoubleNumerics"));
+	DeclareDirective(TEXT("System.Runtime"));
+	DeclareDirective(TEXT("System.Runtime.InteropServices"));
+
 	AppendLine();
 	AppendLine(FString::Printf(TEXT("namespace %s;"), *Namespace));
 	AppendLine();
@@ -30,6 +31,13 @@ void FCSScriptBuilder::GenerateScriptSkeleton(const FString& Namespace)
 
 void FCSScriptBuilder::DeclareDirective(const FString& ModuleName)
 {
+	if (Directives.Contains(ModuleName))
+	{
+		return;
+	}
+
+	Directives.Add(ModuleName);
+
 	AppendLine(FString::Printf(TEXT("using %s;"), *ModuleName));
 }
 

--- a/Source/GlueGenerator/CSScriptBuilder.h
+++ b/Source/GlueGenerator/CSScriptBuilder.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "UObject/UnrealType.h"
@@ -37,7 +37,6 @@ public:
 	, IndentCount(0)
 	, IndentMode(InIndentMode)
 	{
-
 	}
 
 	void Indent()
@@ -52,58 +51,68 @@ public:
 
 	void AppendLine()
 	{
-		if (!Report.IsEmpty())
+		if (Report.Len() != 0)
 		{
-			Report += LINE_TERMINATOR;
+			Report.Append(LINE_TERMINATOR);
 		}
 
 		if (IndentMode == IndentType::Spaces)
 		{
 			for (int32 Index = 0; Index < IndentCount; Index++)
 			{
-				Report += TEXT("    ");
+				Report.Append(TEXT("    "));
 			}
 		}
 		else
 		{
 			for (int32 Index = 0; Index < IndentCount; Index++)
 			{
-				Report += TEXT("\t");
+				Report.Append(TEXT("\t"));
 			}
 		}
 	}
 
 	void Append(const FString& String)
 	{
-		Report += String;
+		Report.Append(String);
 	}
 
 	void AppendLine(const FText& Text)
 	{
 		AppendLine();
-		Report += Text.ToString();
+
+		if (const FString* SourceString = FTextInspector::GetSourceString(Text))
+		{
+			Report.Append(*SourceString);
+		}
+		else
+		{
+			Report.Append(Text.ToString());
+		}
 	}
 
 	void AppendLine(const FString& String)
 	{
 		AppendLine();
-		Report += String;
+		Report.Append(String);
 	}
 
-	void AppendLine(const char* String)
+	void AppendLine(const ANSICHAR* Line)
 	{
-		AppendLine(FString(String));
+		AppendLine();
+		Report.Append(Line);
 	}
 
 	void AppendLine(const FName& Name)
 	{
 		AppendLine();
-		Report += Name.ToString();
+		Report.Append(Name.ToString());
 	}
 
 	void AppendLine(const TCHAR* Line)
 	{
-		AppendLine(FString(Line));
+		AppendLine();
+		Report.Append(Line);
 	}
 
 	void OpenBrace()
@@ -155,17 +164,22 @@ public:
 
 	void Clear()
 	{
-		Report.Empty();
+		Report.Reset();
 	}
 
 	FText ToText() const
 	{
-		return FText::FromString(Report);
+		return FText::FromString(ToString());
 	}
 
-	const FString& GetScript() const
+	FString ToString() const
 	{
-		return Report;
+		return Report.ToString();
+	}
+
+	bool IsEmpty() const
+	{
+		return Report.Len() == 0;
 	}
 
 	void GenerateScriptSkeleton(const FString& Namespace);
@@ -174,7 +188,8 @@ public:
 
 private:
 
-	FString Report;
+	TStringBuilder<2048> Report;
+	TArray<FString> Directives;
 	int32 UnsafeBlockCount;
 	int32 IndentCount;
 	IndentType IndentMode;

--- a/Source/GlueGenerator/CSharpGeneratorUtilities.cpp
+++ b/Source/GlueGenerator/CSharpGeneratorUtilities.cpp
@@ -1,4 +1,4 @@
-﻿#include "CSharpGeneratorUtilities.h"
+#include "CSharpGeneratorUtilities.h"
 #include "GlueGeneratorModule.h"
 #include "Misc/Paths.h"
 #include "Misc/FileHelper.h"
@@ -472,6 +472,10 @@ FString GetFieldScriptNameImpl(const UStruct* InField, const FName InMetaDataKey
 	{
 		FieldName = InField->GetName();
 	}
+
+	// Remove '-'s and spaces from the class names.
+	FieldName.ReplaceCharInline(TCHAR('-'), TCHAR(' '));
+	FieldName.RemoveSpacesInline();
 
 	if (InField->IsChildOf<UInterface>())
 	{


### PR DESCRIPTION
Fixing T reuse warnings

If the namespace has a - in it, replace with _

If the field name has a - or a space, remove them.

Improvements to the string concatenation to use string builder.
Fixing how modules are assigned a directory so that game plugins are associated with the game module assembly generation folder.
Fixing a possibility uninitiated variable the compiler warned about. 'uppercaseCount'
Simplified how you lookup a module from a UObject*, all the calls were really FindOrRegisterModule, so that's what they are, and we pass in the Uobject* as directly as possible to not lose valuable context we need to possibly lookup to find the module correctly.