### PR TITLE
Add a setting to require editor focus for Hot Reload

### DIFF
--- a/Source/CSharpForUE/CSDeveloperSettings.h
+++ b/Source/CSharpForUE/CSDeveloperSettings.h
@@ -29,4 +29,7 @@ public:
 	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Build Configuration")
 	TEnumAsByte<EDotNetBuildConfiguration> UserBuildConfiguration = EDotNetBuildConfiguration::Debug;
 	
+	// Whether Hot Reload should wait for the Editor to gain focus
+	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Hot Reload")
+	bool bRequireFocusForHotReload = false;
 };

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.h
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
+#include "Containers/Ticker.h"
 
 class FUnrealSharpEditorModule : public IModuleInterface
 {
@@ -14,6 +15,11 @@ public:
     
     void OnCSharpCodeModified(const TArray<struct FFileChangeData>& ChangedFiles);
     void Reload();
+
+    FTickerDelegate TickDelegate;
+    FTSTicker::FDelegateHandle TickDelegateHandle;
+
+    bool Tick(float DeltaTime);
 
     bool bIsReloading = false;
 };


### PR DESCRIPTION
I tend to hit CTRL + S very frequently when I'm typing code, so I added a small toggle to hold off on Hot Reloading until Unreal Engine regains focus