### PR TITLE
Fix UFunctions not applying the metadata defined in C# and Fix some PropertyFlags mismatch with how they work C++

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Attributes/UFunctionAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/UFunctionAttribute.cs
@@ -42,7 +42,7 @@ public enum FunctionFlags
 
 [AttributeUsage(AttributeTargets.Method)]
 [FunctionFlagsMap(NativeFunctionFlags.Native)] 
-public sealed class UFunctionAttribute(FunctionFlags flags = FunctionFlags.None) : Attribute
+public sealed class UFunctionAttribute(FunctionFlags flags = FunctionFlags.None) : BaseUAttribute
 {
     public FunctionFlags Flags { get; private set; } = flags;
 }

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/UPropertyAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/UPropertyAttribute.cs
@@ -56,7 +56,7 @@ public enum PropertyFlags : ulong
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 [PropertyFlagsMap]
-public sealed class UPropertyAttribute(PropertyFlags flags = PropertyFlags.None) : Attribute
+public sealed class UPropertyAttribute(PropertyFlags flags = PropertyFlags.None) : BaseUAttribute
 {
     public PropertyFlags Flags
     {

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/UPropertyAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/UPropertyAttribute.cs
@@ -32,8 +32,8 @@ public enum PropertyFlags : ulong
     [PropertyFlagsMap(NativePropertyFlags.BlueprintReadOnly)]
     BlueprintReadOnly = NativePropertyFlags.BlueprintReadOnly | NativePropertyFlags.BlueprintVisible,
     
-    [PropertyFlagsMap(NativePropertyFlags.Edit)]
-    BlueprintReadWrite = NativePropertyFlags.Edit | NativePropertyFlags.BlueprintVisible,
+    [PropertyFlagsMap(NativePropertyFlags.BlueprintReadWrite)]
+    BlueprintReadWrite = NativePropertyFlags.BlueprintReadWrite,
     
     [PropertyFlagsMap(NativePropertyFlags.Net)]
     Replicated = NativePropertyFlags.Net,

--- a/Managed/UnrealSharp/UnrealSharp/NativePropertyFlags.cs
+++ b/Managed/UnrealSharp/UnrealSharp/NativePropertyFlags.cs
@@ -74,9 +74,11 @@ public enum NativePropertyFlags : ulong
     /** all the properties that should never be loaded or saved */
     ComputedFlags = IsPlainOldData | NoDestructor | ZeroConstructor | HasGetValueTypeHash,
 
-    EditDefaultsOnly = Edit | BlueprintVisible | DisableEditOnInstance,
-    EditInstanceOnly = Edit | BlueprintVisible,
-    EditAnywhere = Edit | BlueprintVisible | BlueprintReadOnly,
+    EditDefaultsOnly = Edit | DisableEditOnInstance,
+    EditInstanceOnly = Edit | DisableEditOnTemplate,
+    EditAnywhere = Edit,
+    
+    BlueprintReadWrite = BlueprintVisible,
 
     AllFlags = 0xFFFFFFFFFFFFFFFF
 }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/BaseMetaData.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/BaseMetaData.cs
@@ -150,6 +150,23 @@ public class BaseMetaData
             }
         }
     }
+
+    public void AddBaseAttributes(CustomAttribute? baseAttribute)
+    {
+        CustomAttributeArgument? displayNameArgument = WeaverHelper.FindAttributeField(baseAttribute, "DisplayName");
+
+        if (displayNameArgument.HasValue)
+        {
+            MetaData.Add("DisplayName", (string) displayNameArgument.Value.Value);
+        }
+
+        CustomAttributeArgument? categoryArgument = WeaverHelper.FindAttributeField(baseAttribute, "Category");
+
+        if (categoryArgument.HasValue)
+        {
+            MetaData.Add("Category", (string) categoryArgument.Value.Value);
+        }
+    }
     
     protected static bool GetBoolMetadata(Dictionary<string, string> dictionary, string key)
     {

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/FunctionMetaData.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/FunctionMetaData.cs
@@ -124,6 +124,13 @@ public class FunctionMetaData : BaseMetaData
                 throw new InvalidUnrealFunctionException(method, "Unknown access level");
         }
 
+        CustomAttribute? ufunctionAttribute = FindAttribute(method.CustomAttributes, "UFunctionAttribute");
+
+        if (ufunctionAttribute != null)
+        {
+            AddBaseAttributes(ufunctionAttribute);
+        }
+
         if (method.IsStatic)
         {
             flags |= FunctionFlags.Static;

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/PropertyMetaData.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/PropertyMetaData.cs
@@ -131,6 +131,9 @@ public class PropertyMetaData : BaseMetaData
         }
         
         CustomAttribute? upropertyAttribute = FindAttribute(property.CustomAttributes, "UPropertyAttribute");
+
+        AddBaseAttributes(upropertyAttribute);
+
         CustomAttributeArgument? blueprintSetterArgument = WeaverHelper.FindAttributeField(upropertyAttribute, "BlueprintSetter");
         
         if (blueprintSetterArgument.HasValue)

--- a/Source/CSharpForUE/TypeGenerator/Factories/CSFunctionFactory.cpp
+++ b/Source/CSharpForUE/TypeGenerator/Factories/CSFunctionFactory.cpp
@@ -4,7 +4,7 @@
 #include "CSharpForUE/TypeGenerator/Register/CSGeneratedClassBuilder.h"
 #include "CSharpForUE/TypeGenerator/Register/CSMetaData.h"
 
-UCSFunction* FCSFunctionFactory::CreateFunction(UClass* Outer, const FName& Name, EFunctionFlags FunctionFlags, UStruct* ParentFunction, void* ManagedMethod)
+UCSFunction* FCSFunctionFactory::CreateFunction(UClass* Outer, const FName& Name, const FFunctionMetaData& FunctionMetaData, EFunctionFlags FunctionFlags, UStruct* ParentFunction, void* ManagedMethod)
 {
 	UCSFunction* NewFunction = NewObject<UCSFunction>(Outer, UCSFunction::StaticClass(), Name, RF_Public);
 	NewFunction->FunctionFlags = FunctionFlags;
@@ -18,13 +18,15 @@ UCSFunction* FCSFunctionFactory::CreateFunction(UClass* Outer, const FName& Name
 	NewFunction->SetManagedMethod(ManagedMethod);
 	
 	FinalizeFunctionSetup(Outer, NewFunction);
+
+	FMetaDataHelper::ApplyMetaData(FunctionMetaData.MetaData, NewFunction);
 	
 	return NewFunction;
 }
 
 UCSFunction* FCSFunctionFactory::CreateFunctionFromMetaData(UClass* Outer, const FFunctionMetaData& FunctionMetaData)
 {
-	UCSFunction* NewFunction = CreateFunction(Outer, FunctionMetaData.Name, FunctionMetaData.FunctionFlags);
+	UCSFunction* NewFunction = CreateFunction(Outer, FunctionMetaData.Name, FunctionMetaData, FunctionMetaData.FunctionFlags);
 
 	// Check if this function has a return value or is just void, otherwise skip.
 	if (FunctionMetaData.ReturnValue.Type->UnrealPropertyClass != "None")
@@ -46,7 +48,7 @@ UCSFunction* FCSFunctionFactory::CreateFunctionFromMetaData(UClass* Outer, const
 UCSFunction* FCSFunctionFactory::CreateOverriddenFunction(UClass* Outer, UFunction* ParentFunction)
 {
 	const EFunctionFlags FunctionFlags = ParentFunction->FunctionFlags & (FUNC_FuncInherit | FUNC_Public | FUNC_Protected | FUNC_Private | FUNC_BlueprintPure);
-	UCSFunction* NewFunction = CreateFunction(Outer, ParentFunction->GetFName(), FunctionFlags, ParentFunction);
+	UCSFunction* NewFunction = CreateFunction(Outer, ParentFunction->GetFName(), FFunctionMetaData(), FunctionFlags, ParentFunction);
 	
 	TArray<FProperty*> FunctionProperties;
 	for (TFieldIterator<FProperty> PropIt(ParentFunction); PropIt && PropIt->PropertyFlags & CPF_Parm; ++PropIt)

--- a/Source/CSharpForUE/TypeGenerator/Factories/CSFunctionFactory.h
+++ b/Source/CSharpForUE/TypeGenerator/Factories/CSFunctionFactory.h
@@ -21,6 +21,7 @@ public:
 	static UCSFunction* CreateFunction(
 		UClass* Outer,
 		const FName& Name,
+		const FFunctionMetaData& FunctionMetaData,
 		EFunctionFlags FunctionFlags = FUNC_None,
 		UStruct* ParentFunction = nullptr,
 		void* ManagedMethod = nullptr);


### PR DESCRIPTION
First commit fixes an issue where metadatas weren't being applied when used in UFunctions: 
```csharp
// This works correctly
[UProperty(PropertyFlags.EditAnywhere | PropertyFlags.BlueprintReadWrite), UMetaData("DisplayName","MyInteger"), UMetaData("Category","Inner|TestCat")]
public int TestInt { get; set; }
    
// Both UMetaData weren't being applied
[UFunction(FunctionFlags.BlueprintCallable), UMetaData("DisplayName", "MyTestFunction"), UMetaData("Category","Inner|TestCat")]
public void TestFunction()
{
}
```

Second commit makes some PropertyFlags work closer to how they work in C++ (I haven't tried every combination, but so far, I haven't encountered an issue). Also fixes the following issue where a combination of BlueprintReadWrite and EditAnywhere was causing the property to be ReadOnly in BP:

```csharp
// This combination caused TestInt to be readonly in BP
[UProperty(PropertyFlags.BlueprintReadWrite | PropertyFlags.EditAnywhere)]
public int TestInt { get; set; }
```

Sorry I'm not too familiar with github PRs, a third commit was auto-added to this PR. This one is about supporting the `DisplayName` and `Category` metadata directly in the UProperty and UFunction attributes:

```csharp
// So we can do this
[UProperty(PropertyFlags.BlueprintReadWrite | PropertyFlags.EditAnywhere, DisplayName = "MyNewName", Category = "Inner|TestCat")]
public string TestString { get; set; }

// Instead of this (which is still supported)
[UProperty(PropertyFlags.BlueprintReadWrite | PropertyFlags.EditAnywhere), UMetaData("DisplayName", "MyNewName"), UMetaData("Category","Inner|TestCat")]
public string TestString { get; set; }
```