### PR TITLE
Added AddComponentByClass variants to Actor

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Actor.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Actor.cs
@@ -41,4 +41,22 @@ public partial class Actor
             inputComponent.BindAxis(axisName, action, consumeInput, executeWhenPaused);
         }
     }
+
+    private partial ActorComponent AddComponentByClass(SubclassOf<ActorComponent> @class, bool bManualAttachment, Transform relativeTransform, bool bDeferredFinish);
+
+    private partial void FinishAddComponent(ActorComponent component, bool bManualAttachment, Transform relativeTransform);
+
+    public T AddComponentByClass<T>(bool bManualAttachment, Transform relativeTransform) where T : ActorComponent
+        => (AddComponentByClass(new SubclassOf<ActorComponent>(typeof(T)), bManualAttachment, relativeTransform, bDeferredFinish: false) as T)!;
+
+    public T AddComponentByClass<T>(bool bManualAttachment, Transform relativeTransform, Action<T> initializerFunc) where T : ActorComponent
+    {
+        T component = (AddComponentByClass(new SubclassOf<ActorComponent>(typeof(T)), bManualAttachment, relativeTransform, bDeferredFinish: true) as T)!;
+        initializerFunc(component);
+        FinishAddComponent(component, bManualAttachment, relativeTransform);
+        return component;
+    }
+
+    public ActorComponent AddComponentByClass(SubclassOf<ActorComponent> @class, bool bManualAttachment, Transform relativeTransform)
+        => AddComponentByClass(@class, bManualAttachment, relativeTransform, bDeferredFinish: false);
 }

--- a/Source/GlueGenerator/CSGenerator.cpp
+++ b/Source/GlueGenerator/CSGenerator.cpp
@@ -41,8 +41,12 @@ void FCSGenerator::StartGenerator(const FString& OutputDirectory)
 		Whitelist.AddClass(USpringArmComponent::StaticClass()->GetFName());
 		Whitelist.AddClass(UFloatingPawnMovement::StaticClass()->GetFName());
 	}
+
+	Whitelist.AddFunction(AActor::StaticClass()->GetFName(), GET_FUNCTION_NAME_CHECKED(AActor, AddComponentByClass));
 	
 	BlueprintInternalWhitelist.AddFunction(AActor::StaticClass()->GetFName(), GET_FUNCTION_NAME_CHECKED(AActor, UserConstructionScript));
+	BlueprintInternalWhitelist.AddFunction(AActor::StaticClass()->GetFName(), GET_FUNCTION_NAME_CHECKED(AActor, AddComponentByClass));
+	BlueprintInternalWhitelist.AddFunction(AActor::StaticClass()->GetFName(), GET_FUNCTION_NAME_CHECKED(AActor, FinishAddComponent));
 		
 	PropertyTranslators.Reset(new FCSSupportedPropertyTranslators(NameMapper, Blacklist));
 
@@ -294,7 +298,7 @@ void FCSGenerator::ExportEnum(UEnum* Enum, FCSScriptBuilder& Builder)
 
 bool FCSGenerator::CanExportFunction(const UStruct* Struct, const UFunction* Function) const
 {
-	if (Blacklist.HasFunction(Struct, Function) && !Whitelist.HasFunction(Struct, Function) || !ShouldExportFunction(Function))
+	if (Blacklist.HasFunction(Struct, Function) || (!Whitelist.HasFunction(Struct, Function) && !ShouldExportFunction(Function)))
 	{
 		return false;
 	}

--- a/Source/GlueGenerator/PropertyTranslators/PropertyTranslator.cpp
+++ b/Source/GlueGenerator/PropertyTranslators/PropertyTranslator.cpp
@@ -201,7 +201,11 @@ void FPropertyTranslator::FunctionExporter::Initialize(ProtectionMode InProtecti
 	switch (InProtectionMode)
 	{
 	case ProtectionMode::UseUFunctionProtection:
-		if (Function.HasAnyFunctionFlags(FUNC_Public))
+		if (Function.GetBoolMetaData(MD_BlueprintInternalUseOnly) && !Function.HasAnyFunctionFlags(FUNC_BlueprintEvent))
+		{
+			Modifiers = TEXT("private partial ");
+		}
+		else if (Function.HasAnyFunctionFlags(FUNC_Public))
 		{
 			Modifiers = TEXT("public ");
 		}


### PR DESCRIPTION
Currently it's not possible to add components to an actor at runtime. You can get close (via `NewObject` and `AttachToComponent`) but there's no way to call `RegisterComponent` on the component because that is not exposed to BP. Instead, BP gets a custom made node called 'Add Component By Class' so that it could dynamically add pins to support any `ExposeOnSpawn` properties. Internally, this node calls the UFunction `AddComponentByClass` (which is marked blueprint internal) and optionally the UFunction `FinishAddComponent` if there are `ExposeOnSpawn` properties (so that they can be set in between `NewObject` and `RegisterComponent`. There's also a bunch of probably important default object stuff in there I don't understand.

This PR binds the internal `AddComponentByClass` and `FinishAddComponent` UFunctions to C# but privately (which required some slight changes to the glue code) and adds a tidy `AddComponentByClass` API that replicates the behaviour of the BP node.

Example actor using the new APIs:

```CSharp
[UClass]
public class TestAddComponentByClass : Actor
{
    [UProperty(DefaultComponent = true, RootComponent = true)]
    public SceneComponent Root { get; set; }

    [UProperty]
    public StaticMeshComponent? MeshComp1 { get; set; }

    [UProperty]
    public StaticMeshComponent? MeshComp2 { get; set; }

    [UProperty]
    public StaticMeshComponent? MeshComp3 { get; set; }

    [UProperty(PropertyFlags.EditAnywhere)]
    public StaticMesh? Mesh { get; set; }

    protected override void ReceiveBeginPlay()
    {
        base.ReceiveBeginPlay();

        if (Mesh == null) { return; }

        // Generic variant with no initializer
        MeshComp1 = AddComponentByClass<StaticMeshComponent>(false, new Transform(Quaternion.Identity, new(0.0, -100.0, 0.0), Vector3.One));
        MeshComp1.SetStaticMesh(Mesh);

        // Generic variant with initializer to set properties before RegisterComponent is called
        MeshComp2 = AddComponentByClass<StaticMeshComponent>(false, new Transform(Quaternion.Identity, new(0.0, 0.0, 0.0), Vector3.One), newComp =>
        {
            newComp.SetCastShadow(false);
            newComp.SetStaticMesh(Mesh);
        });

        // Non-generic variant
        MeshComp3 = (AddComponentByClass(new SubclassOf<ActorComponent>(typeof(StaticMeshComponent)), false, new Transform(Quaternion.Identity, new(0.0, 100.0, 0.0), Vector3.One)) as StaticMeshComponent)!;
        MeshComp3.SetStaticMesh(Mesh);
    }
}
```

![image](https://github.com/UnrealSharp/UnrealSharp/assets/2463967/9e5840d3-06d1-4c0f-9507-221e91e3a1b8)
