### PR TITLE
Map single float variants of math structs to System.Numerics

### DIFF
--- a/Source/GlueGenerator/PropertyTranslators/CSSupportedPropertyTranslators.cpp
+++ b/Source/GlueGenerator/PropertyTranslators/CSSupportedPropertyTranslators.cpp
@@ -63,14 +63,19 @@ FCSSupportedPropertyTranslators::FCSSupportedPropertyTranslators(const FCSNameMa
 	AddPropertyTranslator(FArrayProperty::StaticClass(), new FArrayPropertyTranslator(*this));
 
 	AddBlittableCustomStructPropertyTranslator("Vector2D", "System.DoubleNumerics.Vector2", Blacklist);
+	AddBlittableCustomStructPropertyTranslator("Vector2f", "System.Numerics.Vector2", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Vector", "System.DoubleNumerics.Vector3", Blacklist);
+	AddBlittableCustomStructPropertyTranslator("Vector3f", "System.Numerics.Vector3", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Vector_NetQuantize", "System.DoubleNumerics.Vector3", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Vector_NetQuantize10", "System.DoubleNumerics.Vector3", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Vector_NetQuantize100", "System.DoubleNumerics.Vector3", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Vector_NetQuantizeNormal", "System.DoubleNumerics.Vector3", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Vector4", "System.DoubleNumerics.Vector4", Blacklist);
+	AddBlittableCustomStructPropertyTranslator("Vector4f", "System.Numerics.Vector4", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Quat", "System.DoubleNumerics.Quaternion", Blacklist);
+	AddBlittableCustomStructPropertyTranslator("Quat4f", "System.Numerics.Quaternion", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Matrix", "System.DoubleNumerics.Matrix4x4", Blacklist);
+	AddBlittableCustomStructPropertyTranslator("Matrix44f", "System.Numerics.Matrix4x4", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Rotator", UNREAL_SHARP_NAMESPACE ".Rotator", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("Transform", UNREAL_SHARP_NAMESPACE ".Transform", Blacklist);
 	AddBlittableCustomStructPropertyTranslator("RandomStream", UNREAL_SHARP_NAMESPACE ".RandomStream", Blacklist);


### PR DESCRIPTION
There are still some BP APIs that use single precision variants of math structs, like `Vector2f/3f/4f` etc. Currently the glue code generates these structs but it'd be better to use `System.Numerics` where possible (the glue code does already use `System.DoubleNumerics` for the usual double precision variants).

Example code:
```C#
PrintString($"Vector3f: {StringLibrary.Conv_Vector3fToString(new System.Numerics.Vector3(1.0f, 2.0f, 3.0f))}");
```