### PR TITLE
Added proper handling of exceptions thrown by managed events

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Interop/FStringExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/FStringExporter.cs
@@ -1,0 +1,7 @@
+namespace UnrealSharp.Interop;
+
+[NativeCallbacks]
+public unsafe partial class FStringExporter
+{
+    public static delegate* unmanaged<IntPtr, char*, void> MarshalToNativeString;
+}

--- a/Managed/UnrealSharp/UnrealSharp/Interop/ManagedCallbacks.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/ManagedCallbacks.cs
@@ -6,7 +6,7 @@ namespace UnrealSharp.Interop;
 public unsafe struct ManagedCallbacks
 {
     public delegate* unmanaged<IntPtr, IntPtr, IntPtr> ScriptManagerBridge_CreateManagedObject;
-    public delegate* unmanaged<IntPtr, IntPtr, IntPtr, IntPtr, void> ScriptManagerBridge_InvokeManagedMethod;
+    public delegate* unmanaged<IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, int> ScriptManagerBridge_InvokeManagedMethod;
     public delegate* unmanaged<IntPtr, char*, IntPtr> ScriptManagerBridge_LookupManagedMethod;
     public delegate* unmanaged<IntPtr, char*, char*, IntPtr> ScriptManagedBridge_LookupManagedType;
     public delegate* unmanaged<IntPtr, void> ScriptManagedBridge_Dispose;

--- a/Managed/UnrealSharp/UnrealSharp/Interop/UnmanagedCallbacks.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/UnmanagedCallbacks.cs
@@ -136,14 +136,8 @@ public static class UnmanagedCallbacks
                 throw new Exception("managedObject is null");
             }
 
-            object[] arguments = { argumentsBuffer, returnValueBuffer };
+            object[] arguments = [argumentsBuffer, returnValueBuffer];
             methodToInvoke.Invoke(managedObject, arguments);
-        }
-        catch (TargetInvocationException ex)
-        {
-            StringMarshaller.ToNative(exceptionTextBuffer, 0, null, (ex.InnerException ?? ex).ToString());
-            Console.WriteLine($"Exception during InvokeManagedMethod: {ex}");
-            return 1;
         }
         catch (Exception ex)
         {

--- a/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
@@ -85,7 +85,7 @@ public static class ObjectMarshaller<T> where T : UnrealSharpObject
 
 public static class StringMarshaller
 {
-    public static void ToNative(IntPtr nativeBuffer, int arrayIndex, UnrealSharpObject owner, string obj)
+    public static void ToNative(IntPtr nativeBuffer, int arrayIndex, UnrealSharpObject? owner, string obj)
     {
         unsafe
         {

--- a/Source/CSharpForUE/CSDeveloperSettings.h
+++ b/Source/CSharpForUE/CSDeveloperSettings.h
@@ -28,6 +28,10 @@ public:
 	// The build configuration to use when building the user's assembly.
 	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Build Configuration")
 	TEnumAsByte<EDotNetBuildConfiguration> UserBuildConfiguration = EDotNetBuildConfiguration::Debug;
+
+	// Should we exit PIE when an exception is thrown in C#?
+	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Debugging")
+	bool bCrashOnException = true;
 	
 	// Whether Hot Reload should wait for the Editor to gain focus
 	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Hot Reload")

--- a/Source/CSharpForUE/CSManagedCallbacksCache.h
+++ b/Source/CSharpForUE/CSManagedCallbacksCache.h
@@ -11,7 +11,7 @@ class CSHARPFORUE_API FCSManagedCallbacks
 	struct FManagedCallbacks
 	{
 		using ManagedCallbacks_CreateNewManagedObject = GCHandleIntPtr(__stdcall*)(void*, void*);
-		using ManagedCallbacks_InvokeManagedEvent = void(__stdcall*)(GCHandleIntPtr, void*, void*, void*);
+		using ManagedCallbacks_InvokeManagedEvent = int(__stdcall*)(GCHandleIntPtr, void*, void*, void*, void*);
 		using ManagedCallbacks_LookupMethod = void*(__stdcall*)(void*, const TCHAR*);
 		using ManagedCallbacks_LookupType = uint8*(__stdcall*)(GCHandleIntPtr, const TCHAR*, const TCHAR*);
 		using ManagedCallbacks_Dispose = void(__stdcall*)(GCHandleIntPtr);

--- a/Source/CSharpForUE/Export/FStringExporter.cpp
+++ b/Source/CSharpForUE/Export/FStringExporter.cpp
@@ -1,0 +1,16 @@
+﻿#include "FStringExporter.h"
+
+void UFStringExporter::ExportFunctions(FRegisterExportedFunction RegisterExportedFunction)
+{
+	EXPORT_FUNCTION(MarshalToNativeString);
+}
+
+void UFStringExporter::MarshalToNativeString(FString* String, TCHAR* ManagedString)
+{
+	if (String == nullptr)
+	{
+		return;
+	}
+
+	*String = FString(ManagedString);
+}

--- a/Source/CSharpForUE/Export/FStringExporter.h
+++ b/Source/CSharpForUE/Export/FStringExporter.h
@@ -1,0 +1,22 @@
+﻿#pragma once
+
+#include "CoreMinimal.h"
+#include "FunctionsExporter.h"
+#include "FStringExporter.generated.h"
+
+UCLASS()
+class CSHARPFORUE_API UFStringExporter : public UFunctionsExporter
+{
+	GENERATED_BODY()
+
+public:
+	
+	// UFunctionsExporter interface
+	virtual void ExportFunctions(FRegisterExportedFunction RegisterExportedFunction) override;
+	// End of UFunctionsExporter interface
+
+private:
+
+	static void MarshalToNativeString(FString* String, TCHAR* ManagedString);
+	
+};

--- a/Source/CSharpForUE/TypeGenerator/CSClass.h
+++ b/Source/CSharpForUE/TypeGenerator/CSClass.h
@@ -16,7 +16,7 @@ public:
 
 	static void InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL);
 	static void ProcessOutParameters(FOutParmRec* OutParameters, uint8* ArgumentData);
-	static void InvokeManagedEvent(UObject* ObjectToInvokeOn, const UCSFunction* Function, TArray<uint8>& ArgumentData, RESULT_DECL);
+	static bool InvokeManagedEvent(UObject* ObjectToInvokeOn, const UCSFunction* Function, TArray<uint8>& ArgumentData, FString& ExceptionMessage, RESULT_DECL);
 
 	bool bCanTick = true;
 };


### PR DESCRIPTION
Currently exceptions thrown in a C# UFunction are swallowed up and logged to somewhere unuseful. This PR changes the managed method invoke mechanism to allow exceptions to be passed back to C++ and injected into the stack frame, allowing the BP error handler to take over. Most importantly this shows the exception in the output log as it occurs, which makes debugging considerably easier.

Example code:
```C#
[UFunction(FunctionFlags.BlueprintCallable)]
public void TestException()
{
    throw new Exception("Test exception!");
}
```

![image](https://github.com/UnrealSharp/UnrealSharp/assets/2463967/c77e7cb9-f045-42e1-9245-f4b03c5d175d)

The errors are marked as fatal which seems to end the PIE session immediately - I'm not sure if that's too severe and maybe they should only be warnings instead? Then again exceptions are pretty bad and the user can always wrap their own code in try/catch so maybe this is ok.