### PR TITLE
Fixed crash when exporting properties with blittable structs

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
@@ -537,7 +537,7 @@ public static class WeaverHelper
             }
                 
             bool isBlittable = false;
-            var blittableAttrib = FindAttributeField(structAttribute, "IsBlittableStruct");
+            var blittableAttrib = FindAttributeField(structAttribute, "IsBlittable");
                         
             if (blittableAttrib.HasValue)
             {


### PR DESCRIPTION
At some point the `IsBlittableStruct` property probably got renamed to `IsBlittable` and this was forgot to be updated.

Fixes https://github.com/UnrealSharp/UnrealSharp/issues/68 (contains code example for reproduction).