### PR TITLE
Fixed FHitResult not being populated

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/MulticastDelegateBuilder.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/MulticastDelegateBuilder.cs
@@ -54,7 +54,7 @@ public class MulticastDelegateBuilder : DelegateBuilder
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        catch (Exception ex)");
         stringBuilder.AppendLine("        {");
-        stringBuilder.AppendLine("            Console.WriteLine(ex);");
+        stringBuilder.AppendLine("            System.Console.WriteLine(ex);");
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("    }");
         stringBuilder.AppendLine();
@@ -89,7 +89,7 @@ public class MulticastDelegateBuilder : DelegateBuilder
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        catch (Exception ex)");
         stringBuilder.AppendLine("        {");
-        stringBuilder.AppendLine("            Console.WriteLine(ex);");
+        stringBuilder.AppendLine("            System.Console.WriteLine(ex);");
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        return thisDelegate;");
         stringBuilder.AppendLine("    }");
@@ -125,7 +125,7 @@ public class MulticastDelegateBuilder : DelegateBuilder
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        catch (Exception ex)");
         stringBuilder.AppendLine("        {");
-        stringBuilder.AppendLine("            Console.WriteLine(ex);");
+        stringBuilder.AppendLine("            System.Console.WriteLine(ex);");
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        return thisDelegate;");
         stringBuilder.AppendLine("    }");
@@ -161,7 +161,7 @@ public class MulticastDelegateBuilder : DelegateBuilder
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        catch (Exception ex)");
         stringBuilder.AppendLine("        {");
-        stringBuilder.AppendLine("            Console.WriteLine(ex);");
+        stringBuilder.AppendLine("            System.Console.WriteLine(ex);");
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        return false;");
         stringBuilder.AppendLine("    }");
@@ -198,7 +198,7 @@ public class MulticastDelegateBuilder : DelegateBuilder
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("        catch (Exception ex)");
         stringBuilder.AppendLine("        {");
-        stringBuilder.AppendLine("            Console.WriteLine(ex);");
+        stringBuilder.AppendLine("            System.Console.WriteLine(ex);");
         stringBuilder.AppendLine("        }");
         stringBuilder.AppendLine("    }");
         stringBuilder.AppendLine();

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Actor.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Actor.cs
@@ -5,15 +5,6 @@ namespace UnrealSharp.Engine;
 
 public partial class Actor
 {
-    public InputComponent? InputComponent
-    {
-        get
-        {
-            IntPtr inputComponent = AActorExporter.CallGetInputComponent(NativeObject);
-            return GcHandleUtilities.GetObjectFromHandlePtr<InputComponent>(inputComponent);
-        }
-    }
-    
     public void BindAction(string actionName, EInputEvent inputEvent, Action action, bool consumeInput = false, bool executeWhenPaused = false)
     {
         InputComponent? inputComponent = InputComponent;

--- a/Managed/UnrealSharp/UnrealSharp/Interop/AActorExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/AActorExporter.cs
@@ -3,5 +3,5 @@
 [NativeCallbacks]
 public static unsafe partial class AActorExporter
 {
-    public static delegate* unmanaged<IntPtr, IntPtr> GetInputComponent;
+    
 }

--- a/Source/CSharpForUE/Export/AActorExporter.cpp
+++ b/Source/CSharpForUE/Export/AActorExporter.cpp
@@ -3,15 +3,5 @@
 
 void UAActorExporter::ExportFunctions(FRegisterExportedFunction RegisterExportedFunction)
 {
-	EXPORT_FUNCTION(GetInputComponent)
-}
-
-void* UAActorExporter::GetInputComponent(const AActor* Actor)
-{
-	if (!IsValid(Actor) || !IsValid(Actor->InputComponent))
-	{
-		return nullptr;
-	}
 	
-	return FCSManager::Get().FindManagedObject(Actor->InputComponent).GetIntPtr();
 }

--- a/Source/CSharpForUE/Export/AActorExporter.h
+++ b/Source/CSharpForUE/Export/AActorExporter.h
@@ -17,6 +17,5 @@ public:
 
 private:
 	
-	static void* GetInputComponent(const AActor* Actor);
 	
 };

--- a/Source/GlueGenerator/CSGenerator.h
+++ b/Source/GlueGenerator/CSGenerator.h
@@ -36,7 +36,7 @@ public:
 	void GetExportedFunctions(TSet<UFunction*>& ExportedFunctions, TSet<UFunction*>& ExportedOverridableFunctions, const UClass* Class);
 	void GetExportedStructs(TSet<UScriptStruct*>& ExportedStructs) const;
 	
-	void ExportMirrorStructMarshalling(FCSScriptBuilder& Builder, const UScriptStruct* Struct, TSet<FProperty*> ExportedProperties) const;
+	void ExportMirrorStructMarshalling(FCSScriptBuilder& Builder, const UScriptStruct* Struct, TSet<FProperty*> ExportedProperties, const TSet<FString>& ReservedNames) const;
 
 	void ExportClass(UClass* Class, FCSScriptBuilder& Builder);
 	void ExportStruct(UScriptStruct* Struct, FCSScriptBuilder& Builder);
@@ -68,18 +68,18 @@ public:
 	
 	// Exporter methods
 	
-	void ExportClassProperties(FCSScriptBuilder& Builder, const UClass* Class, TSet<FProperty*>& ExportedProperties);
-	void ExportStaticConstructor(FCSScriptBuilder& Builder,  const UStruct* Struct,const TSet<FProperty*>& ExportedProperties,  const TSet<UFunction*>& ExportedFunctions, const TSet<UFunction*>& ExportedOverrideableFunctions);
+	void ExportClassProperties(FCSScriptBuilder& Builder, const UClass* Class, TSet<FProperty*>& ExportedProperties, const TSet<FString>& ReservedNames);
+	void ExportStaticConstructor(FCSScriptBuilder& Builder,  const UStruct* Struct,const TSet<FProperty*>& ExportedProperties,  const TSet<UFunction*>& ExportedFunctions, const TSet<UFunction*>& ExportedOverrideableFunctions, const TSet<FString>& ReservedNames);
 	void ExportClassFunctions(FCSScriptBuilder& Builder, const UClass* Class, const TSet<UFunction*>& ExportedFunctions);
 	void ExportInterfaceFunctions(FCSScriptBuilder& Builder, const UClass* Class, const TSet<UFunction*>& ExportedFunctions) const;
-	void ExportPropertiesStaticConstruction(FCSScriptBuilder& Builder, const TSet<FProperty*>& ExportedProperties);
+	void ExportPropertiesStaticConstruction(FCSScriptBuilder& Builder, const TSet<FProperty*>& ExportedProperties, const TSet<FString>& ReservedNames);
 	void ExportClassFunctionsStaticConstruction(FCSScriptBuilder& Builder, const TSet<UFunction*>& ExportedFunctions);
 	void ExportClassOverridableFunctionsStaticConstruction(FCSScriptBuilder& Builder, const TSet<UFunction*>& ExportedOverrideableFunctions) const;
 	void ExportClassFunctionStaticConstruction(FCSScriptBuilder& Builder, const UFunction *Function);
 	void ExportDelegateFunctionStaticConstruction(FCSScriptBuilder& Builder, const UFunction *Function);
 	void ExportClassOverridableFunctions(FCSScriptBuilder& Builder, const TSet<UFunction*>& ExportedOverridableFunctions);
 
-	void ExportStructProperties(FCSScriptBuilder& Builder, const UStruct* Struct, const TSet<FProperty*>& ExportedProperties, bool bSuppressOffsets) const;
+	void ExportStructProperties(FCSScriptBuilder& Builder, const UStruct* Struct, const TSet<FProperty*>& ExportedProperties, bool bSuppressOffsets, const TSet<FString>& ReservedNames) const;
 
 	void RegisterClassToModule(const UObject* Struct);
 

--- a/Source/GlueGenerator/CSharpGeneratorUtilities.h
+++ b/Source/GlueGenerator/CSharpGeneratorUtilities.h
@@ -93,6 +93,8 @@ namespace ScriptGeneratorUtilities
 
 		virtual FString ScriptifyName(const FString& InName, const EScriptNameKind InNameKind) const;
 
+		virtual FString ScriptifyName(const FString& InName, const EScriptNameKind InNameKind, const TSet<FString>& ReservedNames) const;
+
 		/** Get the native module the given field belongs to */
 		FString GetFieldModule(const FField* InField) const;
 
@@ -144,7 +146,7 @@ namespace ScriptGeneratorUtilities
 		TArray<FString> GetDeprecatedScriptConstantScriptNames(const UFunction* InFunc) const;
 
 		/** Get the script name of the given property */
-		FString MapPropertyName(const FProperty* InProp) const;
+		FString MapPropertyName(const FProperty* InProp, const TSet<FString>& ReservedNames) const;
 
 		/** Get the deprecated script names of the given property */
 		TArray<FString> GetDeprecatedPropertyScriptNames(const FProperty* InProp) const;

--- a/Source/GlueGenerator/PropertyTranslators/PropertyTranslator.cpp
+++ b/Source/GlueGenerator/PropertyTranslators/PropertyTranslator.cpp
@@ -50,9 +50,9 @@ FString FPropertyTranslator::GetCSharpFixedSizeArrayType(const FProperty *Proper
 	return FString::Printf(TEXT("%s<%s>"), *ArrayType, *GetManagedType(Property));
 }
 
-void FPropertyTranslator::ExportWrapperProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool IsWhitelisted) const
+void FPropertyTranslator::ExportWrapperProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool IsWhitelisted, const TSet<FString>& ReservedNames) const
 {
-	FString CSharpPropertyName = GetScriptNameMapper().MapPropertyName(Property);
+	FString CSharpPropertyName = GetScriptNameMapper().MapPropertyName(Property, ReservedNames);
 	FString NativePropertyName = GetPropertyName(Property);
 
 	Builder.AppendLine(FString::Printf(TEXT("// %s"), *Property->GetFullName()));
@@ -60,7 +60,7 @@ void FPropertyTranslator::ExportWrapperProperty(FCSScriptBuilder& Builder, const
 
 	if (!IsGreylisted)
 	{
-		BeginWrapperPropertyAccessorBlock(Builder, Property, NativePropertyName);
+		BeginWrapperPropertyAccessorBlock(Builder, Property, CSharpPropertyName);
 		if (Property->ArrayDim == 1)
 		{
             Builder.AppendLine(TEXT("get"));
@@ -121,9 +121,9 @@ void FPropertyTranslator::EndWrapperPropertyAccessorBlock(FCSScriptBuilder& Buil
 	Builder.CloseBrace();
 }
 
-void FPropertyTranslator::ExportMirrorProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool bSuppressOffsets) const
+void FPropertyTranslator::ExportMirrorProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool bSuppressOffsets, const TSet<FString>& ReservedNames) const
 {
-	FString CSharpPropertyName = GetScriptNameMapper().MapPropertyName(Property);
+	FString CSharpPropertyName = GetScriptNameMapper().MapPropertyName(Property, ReservedNames);
 	FString NativePropertyName = Property->GetName();
 
 	Builder.AppendLine(FString::Printf(TEXT("// %s"), *Property->GetFullName()));
@@ -789,7 +789,7 @@ void FPropertyTranslator::ExportOverridableFunction(FCSScriptBuilder& Builder, U
 			Builder,
 			ReturnProperty, 
 			TEXT("null"),
-			GetScriptNameMapper().MapPropertyName(ReturnProperty),
+			GetScriptNameMapper().MapPropertyName(ReturnProperty, {}),
 			TEXT("returnBuffer"),
 			TEXT("0"),
 			TEXT("returnValue"));

--- a/Source/GlueGenerator/PropertyTranslators/PropertyTranslator.h
+++ b/Source/GlueGenerator/PropertyTranslators/PropertyTranslator.h
@@ -42,7 +42,7 @@ public:
 	virtual bool IsBlittable() const { return false; }
 
 	// Exports a C# property which wraps a native FProperty, suitable for use in a reference type backed by a UObject.
-	void ExportWrapperProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool IsWhitelisted) const;
+	void ExportWrapperProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool IsWhitelisted, const TSet<FString>& ReservedNames) const;
 	virtual FString GetPropertyName(const FProperty* Property) const;
 	virtual void ExportPropertyStaticConstruction(FCSScriptBuilder& Builder, const FProperty* Property, const FString& NativePropertyName) const;
 	virtual void ExportParameterStaticConstruction(FCSScriptBuilder& Builder, const FString& NativeMethodName, const FProperty* Parameter) const;
@@ -52,7 +52,7 @@ public:
 	void EndWrapperPropertyAccessorBlock(FCSScriptBuilder& Builder) const;
 
 	// Exports a C# property which mirrors a FProperty, suitable for use in a value type.
-	void ExportMirrorProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool bSuppressOffsets) const;
+	void ExportMirrorProperty(FCSScriptBuilder& Builder, const FProperty* Property, bool IsGreylisted, bool bSuppressOffsets, const TSet<FString>& ReservedNames) const;
 
 	enum class FunctionType : uint8
 	{


### PR DESCRIPTION
This adds glue code generation of public native properties as well as ones exposed to blueprint. This fixes nothing being generated for `FHitResult` (as the members of that struct were not exposed to blueprint, and instead blueprint support was implemented via a native break), and gains a number of other additional bindings.

It did reveal a number of naming conflicts however.
- Fields being named as the same as the enclosing type - fixed by prefixing conflicted members with `K2_`, which was already supposed to be happening but was broken
- Stripping prefixes from properties e.g. types with `bool bOverrideGravity` and `FVector OverrideGravity`, and after stripping the prefix from `bOverrideGravity` this obviously created a conflict with `OverrideGravity`) - fixed by not stripping prefixes if it would cause a conflict

Example code:
```C#
[UClass]
public class TestTraceActor : Actor
{
    [UProperty(DefaultComponent = true, RootComponent = true)]
    private SceneComponent Root { get; set; }

    [UProperty(DefaultComponent = true)]
    private ArrowComponent Arrow { get; set; }

    public override void ReceiveTick(float deltaSeconds)
    {
        base.ReceiveTick(deltaSeconds);

        Vector3 start = GetActorLocation();
        Vector3 end = start + GetActorForwardVector() * 1000.0;

        if (SystemLibrary.LineTraceSingle(this, start, end, ETraceTypeQuery.TraceTypeQuery1, false, new List<Actor>(), EDrawDebugTrace.ForOneFrame, out var hit, true))
        {
            PrintString($"Hit! Component = {hit.Component} Time = {hit.Time}, Normal = {hit.Normal}, Location = {hit.Location}");
        }
    }
}
```

![image](https://github.com/UnrealSharp/UnrealSharp/assets/2463967/ca56039d-dbf8-4a00-8cb4-d3482c25bb48)

I don't really like the naming collision prevention code, I think it needs a larger overall refactor to decide the managed names of all exported members top-level, i.e. before exporting them, rather than letting each individual export decide it's own name and have to pass awkward name sets everywhere, but I didn't want to do that in an already fairly wide scoped PR so that could be a future improvement.