### PR TITLE
Fixed invoke managed method alignment issue

### DIFF
--- a/Source/CSharpForUE/TypeGenerator/CSClass.cpp
+++ b/Source/CSharpForUE/TypeGenerator/CSClass.cpp
@@ -7,7 +7,6 @@
 void UCSClass::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL)
 {
 	const UCSFunction* Function = CastChecked<UCSFunction>(Stack.CurrentNativeFunction);
-	TArray<uint8> ArgumentData;
 	FString ExceptionMessage;
 	bool Success;
 
@@ -19,7 +18,7 @@ void UCSClass::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RES
 			++Stack.Code;
 		}
 		
-		Success = InvokeManagedEvent(ObjectToInvokeOn, Function, ArgumentData, ExceptionMessage, RESULT_PARAM);
+		Success = InvokeManagedEvent(ObjectToInvokeOn, Function, TArrayView<const uint8>(), ExceptionMessage, RESULT_PARAM);
 		if (!Success)
 		{
 			const FBlueprintExceptionInfo ExceptionInfo(EBlueprintExceptionType::FatalError, FText::FromString(ExceptionMessage));
@@ -28,11 +27,14 @@ void UCSClass::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RES
 		return;
 	}
 	
-    void* LocalStruct = FMemory_Alloca(FMath::Max<int32>(1, Function->GetStructureSize()));
+	int LocalStructSize = Function->GetStructureSize();
+    void* LocalStruct = FMemory_Alloca(FMath::Max<int32>(1, LocalStructSize));
     Function->InitializeStruct(LocalStruct);
 	
     FOutParmRec* OutParameters = nullptr;
     FOutParmRec** LastOut = &OutParameters;
+
+	TArrayView<uint8> ArgumentData((uint8*)FMemory_Alloca(FMath::Max<int32>(1, LocalStructSize)), LocalStructSize);
 	
 	for (TFieldIterator<FProperty> ParamIt(Function, EFieldIteratorFlags::ExcludeSuper); ParamIt; ++ParamIt)
     {
@@ -78,8 +80,13 @@ void UCSClass::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RES
                 *LastOut = Out;
             }
         }
-		
-        ArgumentData.Append(ValueAddress, FunctionParameter->GetSize());
+
+		// When C# marshals the parameter to it's own format, it will call GetOffset_ForInternal to determine the offset into ArgumentData to read the parameter from
+		// Let's check that the offset matches where we're currently writing into ArgumentData - if it doesn't, C# will be reading from the wrong place and we have ourselves a nasty alignment error!
+		int InternalOffset = FunctionParameter->GetOffset_ForInternal();
+		int InternalSize = FunctionParameter->GetSize();
+		check((InternalOffset + InternalSize) <= ArgumentData.Num());
+		FMemory::Memcpy(ArgumentData.GetData() + InternalOffset, ValueAddress, InternalSize);
     }
 	
 	if (Stack.Code)
@@ -98,24 +105,24 @@ void UCSClass::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RES
 		FBlueprintCoreDelegates::ThrowScriptException(ObjectToInvokeOn, Stack, ExceptionInfo);
 	}
 	
-	ProcessOutParameters(OutParameters, ArgumentData.GetData());
+	ProcessOutParameters(OutParameters, ArgumentData);
 	
 	// Free up memory
 	Function->DestroyStruct(LocalStruct);
 }
 
-void UCSClass::ProcessOutParameters(FOutParmRec* OutParameters, uint8* ArgumentData)
+void UCSClass::ProcessOutParameters(FOutParmRec* OutParameters, TArrayView<const uint8> ArgumentData)
 {
 	for (FOutParmRec* OutParameter = OutParameters; OutParameter != nullptr; OutParameter = OutParameter->NextOutParm)
 	{
-		uint8* ValueAddress = ArgumentData + OutParameter->Property->GetOffset_ForUFunction();
+		const uint8* ValueAddress = ArgumentData.GetData() + OutParameter->Property->GetOffset_ForUFunction();
 		OutParameter->Property->CopyCompleteValue(OutParameter->PropAddr, ValueAddress);
 	}
 }
 
-bool UCSClass::InvokeManagedEvent(UObject* ObjectToInvokeOn, const UCSFunction* Function, TArray<uint8>& ArgumentData, FString& ExceptionMessage, RESULT_DECL)
+bool UCSClass::InvokeManagedEvent(UObject* ObjectToInvokeOn, const UCSFunction* Function, TArrayView<const uint8> ArgumentData, FString& ExceptionMessage, RESULT_DECL)
 {
 	const FGCHandle ManagedObjectHandle = FCSManager::Get().FindManagedObject(ObjectToInvokeOn);
-	int ResultCode = FCSManagedCallbacks::ManagedCallbacks.InvokeManagedMethod(ManagedObjectHandle.GetHandle(), Function->GetManagedMethod(), ArgumentData.GetData(), RESULT_PARAM, &ExceptionMessage);
+	int ResultCode = FCSManagedCallbacks::ManagedCallbacks.InvokeManagedMethod(ManagedObjectHandle.GetHandle(), Function->GetManagedMethod(), (void*)ArgumentData.GetData(), RESULT_PARAM, &ExceptionMessage);
 	return ResultCode == 0;
 }

--- a/Source/CSharpForUE/TypeGenerator/CSClass.h
+++ b/Source/CSharpForUE/TypeGenerator/CSClass.h
@@ -15,8 +15,8 @@ class CSHARPFORUE_API UCSClass : public UBlueprintGeneratedClass
 public:
 
 	static void InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL);
-	static void ProcessOutParameters(FOutParmRec* OutParameters, uint8* ArgumentData);
-	static bool InvokeManagedEvent(UObject* ObjectToInvokeOn, const UCSFunction* Function, TArray<uint8>& ArgumentData, FString& ExceptionMessage, RESULT_DECL);
+	static void ProcessOutParameters(FOutParmRec* OutParameters, TArrayView<const uint8> ArgumentData);
+	static bool InvokeManagedEvent(UObject* ObjectToInvokeOn, const UCSFunction* Function, TArrayView<const uint8> ArgumentData, FString& ExceptionMessage, RESULT_DECL);
 
 	bool bCanTick = true;
 };


### PR DESCRIPTION
The managed invoke code works by allocating a buffer called `ArgumentData` and copying parameters from the execution stack to the buffer. This buffer is then passed along to C#, which marshals the parameters out of the buffer into it's own format. C# uses `FProperty::GetOffset_ForInternal` to determine where in the `ArgumentData` buffer to read from. However, the managed invoker was not considering the property offset at all when preparing the buffer and instead was simply appending to the buffer - making the false assumption that the offset of property 2 would be equal to the offset of property 1 + the size of property 1. This meant that if the properties were ever padded for some reason (most likely to keep things like pointers aligned in memory), the offsets didn't line up and C# ended up reading the wrong data.

This can be reproduced with the following code:
```CSharp
[UFunction(FunctionFlags.BlueprintCallable)]
public void TestAlignmentError(int num, string str)
{
    PrintString($"The number is '{num}' and the string is '{str}'");
}
```

The above will crash with an access violation inside the string marshaller when invoked, because the offset for the string is actually 8 (probably to keep the pointer to the string aligned) but the invoker will incorrectly place it at 4 inside `ArgumentData` because it's simply appending it after the 32-bit int.

This PR fixes the invoker to always use the offset given by unreal to keep things aligned. It also scraps the usage of `TArray` in favour of `FMemory_Alloca` to save potential heap allocations, since the buffer size is known ahead of time - this is unrelated to a fix and is a small optimisation.