### PR TITLE
Fixed self-referencing interfaces causing stack overflow

### DIFF
--- a/Source/GlueGenerator/CSGenerator.cpp
+++ b/Source/GlueGenerator/CSGenerator.cpp
@@ -608,6 +608,13 @@ FCSModule& FCSGenerator::FindOrRegisterModule(const UObject* Struct)
 
 void FCSGenerator::ExportInterface(UClass* Interface, FCSScriptBuilder& Builder)
 {
+	if (!ensure(!ExportedTypes.Contains(Interface)))
+	{
+		return;
+	}
+
+	ExportedTypes.Add(Interface);
+
 	FString InterfaceName = NameMapper.GetScriptClassName(Interface);
 	const FCSModule& BindingsModule = FindOrRegisterModule(Interface);
 	


### PR DESCRIPTION
Interfaces with methods that have parameters referencing the interface were causing an infinite loop and stack overflow in the glue generator.

Code to reproduce:

```C++
UINTERFACE(BlueprintType)
class UTestCrash : public UInterface
{
    GENERATED_BODY()
};

/**
 *
 */
class ITestCrash : public IInterface
{
    GENERATED_BODY()
public:

    UFUNCTION(BlueprintCallable, BlueprintNativeEvent)
    void TestCrashFunction(const TScriptInterface<ITestCrash>& Test);
};
```