### PR TITLE
Add name constructor to PrimaryAssetType

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/PrimaryAssetType.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/PrimaryAssetType.cs
@@ -1,0 +1,9 @@
+namespace UnrealSharp.CoreUObject;
+
+public partial struct PrimaryAssetType
+{
+    public PrimaryAssetType(Name name)
+    {
+        Name = name;
+    }
+}


### PR DESCRIPTION
Adds a constructor for PrimaryAssetType that lets you pass an FName to set the Name property, matching the C++ constructor

Without
```
        PrimaryAssetType ExperienceList = new()
        {
            Name = nameof(LyraUserFacingExperienceDefinition)
        };
```

With
```
PrimaryAssetType ExperienceList = new(nameof(LyraUserFacingExperienceDefinition));
```