### PR TITLE
Fixed memory leak when using Name.ToString.

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Interop/FStringExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/FStringExporter.cs
@@ -4,4 +4,5 @@ namespace UnrealSharp.Interop;
 public unsafe partial class FStringExporter
 {
     public static delegate* unmanaged<IntPtr, char*, void> MarshalToNativeString;
+    public static delegate* unmanaged<ref UnmanagedArray, void> DisposeString;
 }

--- a/Managed/UnrealSharp/UnrealSharp/Name.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Name.cs
@@ -1,5 +1,5 @@
 ﻿using System.Runtime.InteropServices;
-using System.Text;
+
 using UnrealSharp.Attributes;
 using UnrealSharp.Interop;
 
@@ -36,8 +36,15 @@ public struct Name : IEquatable<Name>, IComparable<Name>
         unsafe
         {
             UnmanagedArray buffer = new UnmanagedArray();
-            FNameExporter.CallNameToString(this, ref buffer);
-            return new string((char*) buffer.Data);
+            try
+            {
+                FNameExporter.CallNameToString(this, ref buffer);
+                return new string((char*)buffer.Data);
+            }
+            finally
+            {
+                FStringExporter.CallDisposeString(ref buffer);
+            }
         }
     }
     

--- a/Source/CSharpForUE/Export/FStringExporter.cpp
+++ b/Source/CSharpForUE/Export/FStringExporter.cpp
@@ -3,6 +3,7 @@
 void UFStringExporter::ExportFunctions(FRegisterExportedFunction RegisterExportedFunction)
 {
 	EXPORT_FUNCTION(MarshalToNativeString);
+	EXPORT_FUNCTION(DisposeString);
 }
 
 void UFStringExporter::MarshalToNativeString(FString* String, TCHAR* ManagedString)
@@ -13,4 +14,14 @@ void UFStringExporter::MarshalToNativeString(FString* String, TCHAR* ManagedStri
 	}
 
 	*String = FString(ManagedString);
+}
+
+void UFStringExporter::DisposeString(FString* String)
+{
+	if (String == nullptr)
+	{
+		return;
+	}
+
+	String->~FString();
 }

--- a/Source/CSharpForUE/Export/FStringExporter.h
+++ b/Source/CSharpForUE/Export/FStringExporter.h
@@ -18,5 +18,6 @@ public:
 private:
 
 	static void MarshalToNativeString(FString* String, TCHAR* ManagedString);
+	static void DisposeString(FString* String);
 	
 };


### PR DESCRIPTION
As far as I can tell this is the only case where a string was being leaked. I haven't changed arrays though and it's possible they need similar treatment.