### PR TITLE
Fix singlecast delegate issues

### DIFF
--- a/Source/GlueGenerator/CSGenerator.cpp
+++ b/Source/GlueGenerator/CSGenerator.cpp
@@ -734,7 +734,7 @@ void FCSGenerator::ExportClass(UClass* Class, FCSScriptBuilder& Builder)
 	}
 
 	TSet<const FCSModule*> Dependencies;
-	GatherDependencies(Class, Dependencies);
+	GatherModuleDependencies(Class, Dependencies);
 
 	for (const FCSModule* DependencyModule : Dependencies)
 	{
@@ -1270,7 +1270,7 @@ bool FCSGenerator::CanExportReturnValue(const FProperty* Property) const
 	return bCanExport;
 }
 
-void FCSGenerator::GatherDependencies(const FProperty* Property, TSet<const FCSModule*>& DependencySet)
+void FCSGenerator::GatherModuleDependencies(const FProperty* Property, TSet<const FCSModule*>& DependencySet)
 {
 	TSet<UFunction*> DelegateSignatures;
 	PropertyTranslatorManager->Find(Property).AddDelegateReferences(Property, DelegateSignatures);
@@ -1278,27 +1278,32 @@ void FCSGenerator::GatherDependencies(const FProperty* Property, TSet<const FCSM
 	for (UFunction* DelegateSignature : DelegateSignatures)
 	{
 		const FCSModule& DelegateModule = FCSGenerator::Get().FindOrRegisterModule(DelegateSignature->GetOutermost());
+
 		DependencySet.Add(&DelegateModule);
 	}
 }
 
-void FCSGenerator::GatherDependencies(const UClass* Class, TSet<const FCSModule*>& DependencySet)
+void FCSGenerator::GatherModuleDependencies(const UClass* Class, TSet<const FCSModule*>& DependencySet)
 {
+	// Gather the modules for all interfaces that the class implements
 	for (const FImplementedInterface& ImplementedInterface : Class->Interfaces)
 	{
 		UClass* InterfaceClass = ImplementedInterface.Class;
 		const FCSModule& InterfaceModule = FindOrRegisterModule(InterfaceClass);
 
-		bool WasAlreadyInSet;
-		DependencySet.Add(&InterfaceModule, &WasAlreadyInSet);
-
-		if (WasAlreadyInSet)
-		{
-			continue;
-		}
-
-		GatherDependencies(InterfaceClass, DependencySet);
+		DependencySet.Add(&InterfaceModule);
 	}
+
+	// Gather the module for the base class of the class
+	const UClass* SuperClass = Class->GetSuperClass();
+	if (SuperClass)
+	{
+		const FCSModule& SuperClassModule = FindOrRegisterModule(SuperClass);
+
+		DependencySet.Add(&SuperClassModule);
+	}
+
+	// Gather the modules for the types of all properties that the class contains
 	for (TFieldIterator<FProperty> PropertyIt(Class, EFieldIteratorFlags::ExcludeSuper); PropertyIt; ++PropertyIt)
 	{
 		FProperty* Property = *PropertyIt;
@@ -1308,6 +1313,29 @@ void FCSGenerator::GatherDependencies(const UClass* Class, TSet<const FCSModule*
 			continue;
 		}
 
-		GatherDependencies(Property, DependencySet);
+		GatherModuleDependencies(Property, DependencySet);
+	}
+
+	// Gather the modules for the return and parameter types of all functions that the class contains
+	for (TFieldIterator<UFunction> FunctionIt(Class, EFieldIteratorFlags::ExcludeSuper); FunctionIt; ++FunctionIt)
+	{
+		UFunction* Function = *FunctionIt;
+
+		if (!CanExportFunction(Class, Function))
+		{
+			continue;
+		}
+
+		FProperty* ReturnProperty = Function->GetReturnProperty();
+		if (ReturnProperty)
+		{
+			GatherModuleDependencies(ReturnProperty, DependencySet);
+		}
+
+		for (TFieldIterator<FProperty> ParamIt(Function); ParamIt; ++ParamIt)
+		{
+			FProperty* Parameter = *ParamIt;
+			GatherModuleDependencies(Parameter, DependencySet);
+		}
 	}
 }

--- a/Source/GlueGenerator/CSGenerator.h
+++ b/Source/GlueGenerator/CSGenerator.h
@@ -93,6 +93,10 @@ public:
 
 	const FString& GetNamespace(const UObject* Object);
 
+	void GatherDependencies(const FProperty* Property, TSet<const FCSModule*>& DependencySet);
+
+	void GatherDependencies(const UClass* Class, TSet<const FCSModule*>& DependencySet);
+
 	FCSModule& FindOrRegisterModule(const UObject* Object);
 
 protected:

--- a/Source/GlueGenerator/CSGenerator.h
+++ b/Source/GlueGenerator/CSGenerator.h
@@ -93,9 +93,9 @@ public:
 
 	const FString& GetNamespace(const UObject* Object);
 
-	void GatherDependencies(const FProperty* Property, TSet<const FCSModule*>& DependencySet);
+	void GatherModuleDependencies(const FProperty* Property, TSet<const FCSModule*>& DependencySet);
 
-	void GatherDependencies(const UClass* Class, TSet<const FCSModule*>& DependencySet);
+	void GatherModuleDependencies(const UClass* Class, TSet<const FCSModule*>& DependencySet);
 
 	FCSModule& FindOrRegisterModule(const UObject* Object);
 

--- a/Source/GlueGenerator/PropertyTranslators/DelegateBasePropertyTranslator.cpp
+++ b/Source/GlueGenerator/PropertyTranslators/DelegateBasePropertyTranslator.cpp
@@ -10,6 +10,6 @@ void FDelegateBasePropertyTranslator::ExportPropertyStaticConstruction(FCSScript
 FString FDelegateBasePropertyTranslator::GetDelegateName(const UFunction* SignatureFunction)
 {
 	FString DelegateSignatureName = SignatureFunction->GetName();
-	int32 DelegateSignatureIndex = DelegateSignatureName.Find("DelegateSignature");
-	return DelegateSignatureName.Left(DelegateSignatureIndex - 2);
+	int32 DelegateSignatureIndex = DelegateSignatureName.Find("__DelegateSignature");
+	return DelegateSignatureName.Left(DelegateSignatureIndex);
 }

--- a/Source/GlueGenerator/PropertyTranslators/SinglecastDelegatePropertyTranslator.cpp
+++ b/Source/GlueGenerator/PropertyTranslators/SinglecastDelegatePropertyTranslator.cpp
@@ -53,7 +53,7 @@ void FSinglecastDelegatePropertyTranslator::ExportCleanupMarshallingBuffer(FCSSc
 void FSinglecastDelegatePropertyTranslator::ExportMarshalFromNativeBuffer(FCSScriptBuilder& Builder, const FProperty* Property, const FString& Owner, const FString& PropertyName, const FString& AssignmentOrReturn, const FString& SourceBuffer, const FString& Offset, bool bCleanupSourceBuffer, bool reuseRefMarshallers) const
 {
 	FString DelegateName = GetDelegateName(CastFieldChecked<FDelegateProperty>(Property));
-	Builder.AppendLine(FString::Printf(TEXT("DelegateMarshaller<%s>.FromNative(IntPtr.Add(%s, %s), 0, %s, %s);"), *DelegateName, *SourceBuffer, *Offset, *Owner));
+	Builder.AppendLine(FString::Printf(TEXT("%s DelegateMarshaller<%s>.FromNative(IntPtr.Add(%s, %s), IntPtr.Zero, 0, %s);"), *AssignmentOrReturn, *DelegateName, *SourceBuffer, *Offset, *Owner));
 }
 
 FString FSinglecastDelegatePropertyTranslator::GetNullReturnCSharpValue(const FProperty* ReturnProperty) const


### PR DESCRIPTION
This fixes a few singlecast delegate related issues.

- If the delegate was declared in a different module A, it wasn't getting a using to that module being added to the glue code for a class in module B
- This also goes for if the delegate is declared and used in an interface, both in a different module A, then the interface method using the delegate is overridden in a class in module B
- The marshal from native buffer code was implemented incorrectly. As far as I can tell this code path only happens when implementing an interface, e.g.

```C++
DECLARE_DYNAMIC_DELEGATE(FTestSinglecastWithoutParamsDelegate);

UINTERFACE(MinimalAPI, Blueprintable)
class UTestDelegatesInterface : public UInterface
{
	GENERATED_BODY()
};

class ITestDelegatesInterface
{
	GENERATED_BODY()

public:
	

	UFUNCTION(BlueprintCallable, BlueprintNativeEvent)
	void TestCallbackWithoutParams(const FTestSinglecastWithoutParamsDelegate& Delegate);
	virtual void TestCallbackWithoutParams_Implementation(const FTestSinglecastWithoutParamsDelegate& Delegate)
	{
		
	}

};

UCLASS(BlueprintType)
class UNREALSHARPTEST_API UTestDelegatesInheritedObject : public UObject, public ITestDelegatesInterface
{
	GENERATED_BODY()

public:

	virtual void TestCallbackWithoutParams_Implementation(const FTestSinglecastWithoutParamsDelegate& Delegate) override
	{
		Delegate.Execute();
	}

};
```

The namespace issues are solved by the addition of a `GatherModuleDependencies` method that, for a given class, finds all `FCSModule` instances that need to have usings generated in the glue code for that class. This includes the base class, any interfaces and any delegates referenced by any property or function in the class.