### PR TITLE
Fixed includes, TEXT macros, linking and cast issues

### DIFF
--- a/Source/CSharpForUE/CSManager.cpp
+++ b/Source/CSharpForUE/CSManager.cpp
@@ -14,6 +14,7 @@
 #include "Misc/MessageDialog.h"
 #include "Engine/Blueprint.h"
 #include "UnrealSharpProcHelper/CSProcHelper.h"
+#include <vector>
 
 #if WITH_EDITOR
 #include "GlueGenerator/CSGenerator.h"

--- a/Source/CSharpForUE/Export/FGameplayTagExporter.cpp
+++ b/Source/CSharpForUE/Export/FGameplayTagExporter.cpp
@@ -1,5 +1,4 @@
 ﻿#include "FGameplayTagExporter.h"
-#include "GameplayTagContainer.h"
 
 void UFGameplayTagExporter::ExportFunctions(FRegisterExportedFunction RegisterExportedFunction)
 {

--- a/Source/CSharpForUE/Export/FGameplayTagExporter.h
+++ b/Source/CSharpForUE/Export/FGameplayTagExporter.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "FunctionsExporter.h"
+#include "GameplayTagContainer.h"
 #include "FGameplayTagExporter.generated.h"
 
 UCLASS()

--- a/Source/CSharpForUE/Export/UWorldExporter.cpp
+++ b/Source/CSharpForUE/Export/UWorldExporter.cpp
@@ -38,7 +38,7 @@ void UUWorldExporter::SetTimer(UObject* Object, FName FunctionName, float Rate, 
 {
 	FTimerDynamicDelegate Delegate;
 	Delegate.BindUFunction(Object, FunctionName);
-	*TimerHandle = UKismetSystemLibrary::K2_SetTimerDelegate(Delegate, Rate, Loop, InitialDelay);
+	*TimerHandle = UKismetSystemLibrary::K2_SetTimerDelegate(Delegate, Rate, Loop, false, InitialDelay);
 }
 
 void UUWorldExporter::InvalidateTimer(UObject* Object, FTimerHandle* TimerHandle)

--- a/Source/CSharpForUE/Extensions/CSCancellableAsyncAction.cpp
+++ b/Source/CSharpForUE/Extensions/CSCancellableAsyncAction.cpp
@@ -7,7 +7,7 @@ void UCSCancellableAsyncAction::Activate()
 
 void UCSCancellableAsyncAction::Cancel()
 {
-	if (HasAnyFlags(RF_ClassDefaultObject | RF_MirroredGarbage | RF_BeginDestroyed))
+	if (HasAnyFlags(RF_ClassDefaultObject) || !IsValid(this))
 	{
 		return;
 	}

--- a/Source/CSharpForUE/Extensions/CSCancellableAsyncAction.cpp
+++ b/Source/CSharpForUE/Extensions/CSCancellableAsyncAction.cpp
@@ -7,9 +7,10 @@ void UCSCancellableAsyncAction::Activate()
 
 void UCSCancellableAsyncAction::Cancel()
 {
-	if (HasAnyFlags(RF_ClassDefaultObject | RF_PendingKill | RF_BeginDestroyed))
+	if (HasAnyFlags(RF_ClassDefaultObject | RF_MirroredGarbage | RF_BeginDestroyed))
 	{
 		return;
 	}
+
 	ReceiveCancel();
 }

--- a/Source/CSharpForUE/TypeGenerator/CSClass.cpp
+++ b/Source/CSharpForUE/TypeGenerator/CSClass.cpp
@@ -3,6 +3,7 @@
 #include "CSharpForUE/CSDeveloperSettings.h"
 #include "CSharpForUE/CSManager.h"
 #include "Factories/CSPropertyFactory.h"
+#include "Blueprint/BlueprintExceptionInfo.h"
 
 void UCSClass::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL)
 {

--- a/Source/CSharpForUE/TypeGenerator/CSClass.cpp
+++ b/Source/CSharpForUE/TypeGenerator/CSClass.cpp
@@ -3,7 +3,10 @@
 #include "CSharpForUE/CSDeveloperSettings.h"
 #include "CSharpForUE/CSManager.h"
 #include "Factories/CSPropertyFactory.h"
+
+#if ENGINE_MINOR_VERSION >= 4
 #include "Blueprint/BlueprintExceptionInfo.h"
+#endif
 
 void UCSClass::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL)
 {

--- a/Source/CSharpForUE/TypeGenerator/Factories/CSFunctionFactory.cpp
+++ b/Source/CSharpForUE/TypeGenerator/Factories/CSFunctionFactory.cpp
@@ -53,7 +53,7 @@ UCSFunction* FCSFunctionFactory::CreateOverriddenFunction(UClass* Outer, UFuncti
 	TArray<FProperty*> FunctionProperties;
 	for (TFieldIterator<FProperty> PropIt(ParentFunction); PropIt && PropIt->PropertyFlags & CPF_Parm; ++PropIt)
 	{
-		FProperty* ClonedParam = CastField<FProperty>(FField::Duplicate(*PropIt, NewFunction, PropIt->GetFName(), RF_AllFlags, EInternalObjectFlags::AllFlags & ~(EInternalObjectFlags::Native)));
+		FProperty* ClonedParam = CastField<FProperty>(FField::Duplicate(*PropIt, NewFunction, PropIt->GetFName(), RF_AllFlags, EInternalObjectFlags_AllFlags & ~(EInternalObjectFlags::Native)));
 		ClonedParam->PropertyFlags |= CPF_BlueprintVisible | CPF_BlueprintReadOnly;
 		ClonedParam->Next = nullptr;
 		FunctionProperties.Add(ClonedParam);

--- a/Source/CSharpForUE/TypeGenerator/Factories/CSMetaDataFactory.cpp
+++ b/Source/CSharpForUE/TypeGenerator/Factories/CSMetaDataFactory.cpp
@@ -34,8 +34,8 @@ TSharedPtr<FUnrealType> CSMetaDataFactory::Create(const TSharedPtr<FJsonObject>&
 {
 	Initialize();
 	
-	const TSharedPtr<FJsonObject>& PropertyTypeObject = PropertyMetaData->GetObjectField("PropertyDataType");
-	ECSPropertyType PropertyType = static_cast<ECSPropertyType>(PropertyTypeObject->GetIntegerField("PropertyType"));
+	const TSharedPtr<FJsonObject>& PropertyTypeObject = PropertyMetaData->GetObjectField(TEXT("PropertyDataType"));
+	ECSPropertyType PropertyType = static_cast<ECSPropertyType>(PropertyTypeObject->GetIntegerField(TEXT("PropertyType")));
 	
 	TSharedPtr<FUnrealType> MetaData;
 	if (TFunction<TSharedPtr<FUnrealType>()>* FactoryMethod = MetaDataFactoryMap.Find(PropertyType))

--- a/Source/CSharpForUE/TypeGenerator/Factories/CSPropertyFactory.cpp
+++ b/Source/CSharpForUE/TypeGenerator/Factories/CSPropertyFactory.cpp
@@ -67,7 +67,7 @@ FProperty* FCSPropertyFactory::CreateSoftObjectProperty(UField* Outer, const FPr
 
 FProperty* FCSPropertyFactory::CreateObjectPtrProperty(UField* Outer, const FPropertyMetaData& PropertyMetaData, const EPropertyFlags PropertyFlags)
 {
-	return CreateObjectProperty<FObjectPtrProperty>(Outer, PropertyMetaData, PropertyFlags);
+	return CreateObjectProperty<FObjectProperty>(Outer, PropertyMetaData, PropertyFlags);
 }
 
 FProperty* FCSPropertyFactory::CreateSoftClassProperty(UField* Outer, const FPropertyMetaData& PropertyMetaData, const EPropertyFlags PropertyFlags)

--- a/Source/CSharpForUE/TypeGenerator/Register/CSMetaData.cpp
+++ b/Source/CSharpForUE/TypeGenerator/Register/CSMetaData.cpp
@@ -27,8 +27,8 @@ void FUnrealType::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	if (!JsonObject->Values.IsEmpty())
 	{
-		ArrayDim = JsonObject->GetIntegerField("ArrayDim");
-		PropertyType = static_cast<ECSPropertyType>(JsonObject->GetIntegerField("PropertyType"));
+		ArrayDim = JsonObject->GetIntegerField(TEXT("ArrayDim"));
+		PropertyType = static_cast<ECSPropertyType>(JsonObject->GetIntegerField(TEXT("PropertyType")));
 	}
 }
 
@@ -92,16 +92,16 @@ void CSharpMetaDataUtils::SerializeProperty(const TSharedPtr<FJsonObject>& Prope
 
 void FTypeReferenceMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
-	Name = JsonObject->GetStringField("Name");
-	Namespace = JsonObject->GetStringField("Namespace");
-	AssemblyName = JsonObject->GetStringField("AssemblyName");
+	Name = JsonObject->GetStringField(TEXT("Name"));
+	Namespace = JsonObject->GetStringField(TEXT("Namespace"));
+	AssemblyName = JsonObject->GetStringField(TEXT("AssemblyName"));
 
 	FMetaDataHelper::SerializeFromJson(JsonObject, MetaData);
 }
 
 void FMemberMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
-	Name = *JsonObject->GetStringField("Name");
+	Name = *JsonObject->GetStringField(TEXT("Name"));
 	FMetaDataHelper::SerializeFromJson(JsonObject, MetaData);
 }
 
@@ -142,28 +142,28 @@ void FClassMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject
 
 	ClassFlags = CSharpMetaDataUtils::GetFlags<EClassFlags>(JsonObject,"ClassFlags");
 	
-	ParentClass.SerializeFromJson(JsonObject->GetObjectField("ParentClass"));
+	ParentClass.SerializeFromJson(JsonObject->GetObjectField(TEXT("ParentClass")));
 
-	JsonObject->TryGetStringField("ConfigCategory", ClassConfigName);
-	JsonObject->TryGetStringArrayField("Interfaces", Interfaces);
+	JsonObject->TryGetStringField(TEXT("ConfigCategory"), ClassConfigName);
+	JsonObject->TryGetStringArrayField(TEXT("Interfaces"), Interfaces);
 
 	const TArray<TSharedPtr<FJsonValue>>* FoundFunctions;
-	if (JsonObject->TryGetArrayField("Functions", FoundFunctions))
+	if (JsonObject->TryGetArrayField(TEXT("Functions"), FoundFunctions))
 	{
 		CSharpMetaDataUtils::SerializeFunctions(*FoundFunctions, Functions);
 	}
 	
 	const TArray<TSharedPtr<FJsonValue>>* FoundVirtualFunctions;
-	if (JsonObject->TryGetArrayField("VirtualFunctions", FoundVirtualFunctions))
+	if (JsonObject->TryGetArrayField(TEXT("VirtualFunctions"), FoundVirtualFunctions))
 	{
 		for (const TSharedPtr<FJsonValue>& VirtualFunction : *FoundVirtualFunctions)
 		{
-			VirtualFunctions.Add(VirtualFunction->AsObject()->GetStringField("Name"));
+			VirtualFunctions.Add(VirtualFunction->AsObject()->GetStringField(TEXT("Name")));
 		}
 	}
 
 	const TArray<TSharedPtr<FJsonValue>>* FoundProperties;
-	if (JsonObject->TryGetArrayField("Properties", FoundProperties))
+		if (JsonObject->TryGetArrayField(TEXT("Properties"), FoundProperties))
 	{
 		CSharpMetaDataUtils::SerializeProperties(*FoundProperties, Properties);
 	}
@@ -172,19 +172,19 @@ void FClassMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject
 void FClassPropertyMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FUnrealType::SerializeFromJson(JsonObject);
-	TypeRef.SerializeFromJson(JsonObject->GetObjectField("InnerType"));
+	TypeRef.SerializeFromJson(JsonObject->GetObjectField(TEXT("InnerType")));
 }
 
 void FStructPropertyMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FUnrealType::SerializeFromJson(JsonObject);
-	TypeRef.SerializeFromJson(JsonObject->GetObjectField("InnerType"));
+	TypeRef.SerializeFromJson(JsonObject->GetObjectField(TEXT("InnerType")));
 }
 
 void FObjectMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FUnrealType::SerializeFromJson(JsonObject);
-	InnerType.SerializeFromJson(JsonObject->GetObjectField("InnerType"));
+	InnerType.SerializeFromJson(JsonObject->GetObjectField(TEXT("InnerType")));
 }
 
 //END ----------------------FClassMetaData----------------------------------------
@@ -201,8 +201,8 @@ void FObjectMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObjec
 void FStructMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FTypeReferenceMetaData::SerializeFromJson(JsonObject);
-	CSharpMetaDataUtils::SerializeProperties(JsonObject->GetArrayField("Fields"), Properties);
-	bIsDataTableStruct = JsonObject->GetBoolField("IsDataTableStruct");
+	CSharpMetaDataUtils::SerializeProperties(JsonObject->GetArrayField(TEXT("Fields")), Properties);
+	bIsDataTableStruct = JsonObject->GetBoolField(TEXT("IsDataTableStruct"));
 }
 
 //END ----------------------FStructMetaData----------------------------------------
@@ -218,7 +218,7 @@ void FStructMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObjec
 void FEnumPropertyMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FUnrealType::SerializeFromJson(JsonObject);
-	InnerProperty.SerializeFromJson(JsonObject->GetObjectField("InnerProperty"));
+	InnerProperty.SerializeFromJson(JsonObject->GetObjectField(TEXT("InnerProperty")));
 }
 
 void FEnumMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
@@ -226,7 +226,7 @@ void FEnumMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 	FTypeReferenceMetaData::SerializeFromJson(JsonObject);
 
 	const TArray<TSharedPtr<FJsonValue>>* OutArray;
-	JsonObject->TryGetArrayField("Items", OutArray);
+	JsonObject->TryGetArrayField(TEXT("Items"), OutArray);
 	
 	for (const TSharedPtr<FJsonValue>& Item : *OutArray)
 	{
@@ -248,13 +248,13 @@ void FFunctionMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObj
 	FMemberMetaData::SerializeFromJson(JsonObject);
 
 	const TArray<TSharedPtr<FJsonValue>>* ParametersArrayField;
-	if (JsonObject->TryGetArrayField("Parameters", ParametersArrayField))
+	if (JsonObject->TryGetArrayField(TEXT("Parameters"), ParametersArrayField))
 	{
 		CSharpMetaDataUtils::SerializeProperties(*ParametersArrayField, Parameters);
 	}
 
 	const TSharedPtr<FJsonObject>* ReturnValueObject;
-	if (JsonObject->TryGetObjectField("ReturnValue", ReturnValueObject))
+	if (JsonObject->TryGetObjectField(TEXT("ReturnValue"), ReturnValueObject))
 	{
 		CSharpMetaDataUtils::SerializeProperty(*ReturnValueObject, ReturnValue);
 		
@@ -262,7 +262,7 @@ void FFunctionMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObj
 		ReturnValue.Name = "ReturnValue";
 	}
 
-	JsonObject->TryGetBoolField("IsVirtual", IsVirtual);
+	JsonObject->TryGetBoolField(TEXT("IsVirtual"), IsVirtual);
 	FunctionFlags = CSharpMetaDataUtils::GetFlags<EFunctionFlags>(JsonObject,"FunctionFlags");
 }
 
@@ -281,9 +281,9 @@ void FPropertyMetaData:: SerializeFromJson(const TSharedPtr<FJsonObject>& JsonOb
 	PropertyFlags = CSharpMetaDataUtils::GetFlags<EPropertyFlags>(JsonObject,"PropertyFlags");
 	LifetimeCondition = CSharpMetaDataUtils::GetFlags<ELifetimeCondition>(JsonObject,"LifetimeCondition");
 
-	JsonObject->TryGetStringField("BlueprintGetter", BlueprintGetter);
-	JsonObject->TryGetStringField("BlueprintSetter", BlueprintSetter);
-	JsonObject->TryGetStringField("RepNotifyFunctionName", RepNotifyFunctionName);
+	JsonObject->TryGetStringField(TEXT("BlueprintGetter"), BlueprintGetter);
+	JsonObject->TryGetStringField(TEXT("BlueprintSetter"), BlueprintSetter);
+	JsonObject->TryGetStringField(TEXT("RepNotifyFunctionName"), RepNotifyFunctionName);
 }
 
 //END ----------------------FPropertyMetaData----------------------------------------
@@ -296,7 +296,7 @@ void FPropertyMetaData:: SerializeFromJson(const TSharedPtr<FJsonObject>& JsonOb
 void FArrayPropertyMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FUnrealType::SerializeFromJson(JsonObject);
-	CSharpMetaDataUtils::SerializeProperty(JsonObject->GetObjectField("InnerProperty"), InnerProperty);
+	CSharpMetaDataUtils::SerializeProperty(JsonObject->GetObjectField(TEXT("InnerProperty")), InnerProperty);
 }
 //END ----------------------FArrayMetaData----------------------------------------
 
@@ -312,9 +312,9 @@ void FArrayPropertyMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& Js
 void FDefaultComponentMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FObjectMetaData::SerializeFromJson(JsonObject);
-	JsonObject->TryGetBoolField("IsRootComponent", IsRootComponent);
-	JsonObject->TryGetStringField("AttachmentComponent", AttachmentComponent);
-	JsonObject->TryGetStringField("AttachmentSocket", AttachmentSocket);
+	JsonObject->TryGetBoolField(TEXT("IsRootComponent"), IsRootComponent);
+	JsonObject->TryGetStringField(TEXT("AttachmentComponent"), AttachmentComponent);
+	JsonObject->TryGetStringField(TEXT("AttachmentSocket"), AttachmentSocket);
 }
 
 void FDefaultComponentMetaData::OnPropertyCreated(FProperty* Property)
@@ -330,12 +330,12 @@ void FDefaultComponentMetaData::OnPropertyCreated(FProperty* Property)
 void FDelegateMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FUnrealType::SerializeFromJson(JsonObject);
-	SignatureFunction.SerializeFromJson(JsonObject->GetObjectField("Signature"));
+	SignatureFunction.SerializeFromJson(JsonObject->GetObjectField(TEXT("Signature")));
 	SignatureFunction.Name = "";
 }
 
 void FInterfaceMetaData::SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject)
 {
 	FTypeReferenceMetaData::SerializeFromJson(JsonObject);
-	CSharpMetaDataUtils::SerializeFunctions(JsonObject->GetArrayField("Functions"), Functions);
+	CSharpMetaDataUtils::SerializeFunctions(JsonObject->GetArrayField(TEXT("Functions")), Functions);
 }

--- a/Source/CSharpForUE/TypeGenerator/Register/CSMetaData.h
+++ b/Source/CSharpForUE/TypeGenerator/Register/CSMetaData.h
@@ -82,19 +82,21 @@ struct FMetaDataHelper
 
 struct FTypeReferenceMetaData
 {
+	virtual ~FTypeReferenceMetaData() = default;
+
 	FString Name;
 	FString Namespace;
 	FString AssemblyName;
 
 	TMap<FString, FString> MetaData;
 	
-	virtual ~FTypeReferenceMetaData() = default;
-	
 	virtual void SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject);
 };
 
 struct FMemberMetaData
 {
+	virtual ~FMemberMetaData() = default;
+
 	FName Name;
 	TMap<FString, FString> MetaData;
 	
@@ -103,6 +105,8 @@ struct FMemberMetaData
 
 struct FUnrealType
 {
+	virtual ~FUnrealType() = default;
+
 	FName UnrealPropertyClass;
 	ECSPropertyType PropertyType = ECSPropertyType::Unknown;
 	int32 ArrayDim;
@@ -113,6 +117,8 @@ struct FUnrealType
 
 struct FClassMetaData : FTypeReferenceMetaData
 {
+	virtual ~FClassMetaData() = default;
+
 	FTypeReferenceMetaData ParentClass;
 	
 	TArray<FPropertyMetaData> Properties;
@@ -136,6 +142,8 @@ struct FClassMetaData : FTypeReferenceMetaData
 
 struct FClassPropertyMetaData : FUnrealType
 {
+	virtual ~FClassPropertyMetaData() = default;
+
 	FTypeReferenceMetaData TypeRef;
 
 	//FTypeMetaData interface implementation
@@ -145,6 +153,8 @@ struct FClassPropertyMetaData : FUnrealType
 
 struct FStructMetaData : FTypeReferenceMetaData
 {
+	virtual ~FStructMetaData() = default;
+
 	TArray<FPropertyMetaData> Properties;
 	bool bIsDataTableStruct = false;
 
@@ -155,6 +165,8 @@ struct FStructMetaData : FTypeReferenceMetaData
 
 struct FStructPropertyMetaData : FUnrealType
 {
+	virtual ~FStructPropertyMetaData() = default;
+
 	FTypeReferenceMetaData TypeRef;
 
 	// FUnrealType interface implementation
@@ -164,6 +176,8 @@ struct FStructPropertyMetaData : FUnrealType
 
 struct FEnumPropertyMetaData : FUnrealType
 {
+	virtual ~FEnumPropertyMetaData() = default;
+
 	FTypeReferenceMetaData InnerProperty;
 
 	// FUnrealType interface implementation
@@ -173,6 +187,8 @@ struct FEnumPropertyMetaData : FUnrealType
 
 struct FEnumMetaData : FTypeReferenceMetaData
 {
+	virtual ~FEnumMetaData() = default;
+
 	TArray<FString> Items;
 
 	//FTypeMetaData interface implementation
@@ -182,6 +198,8 @@ struct FEnumMetaData : FTypeReferenceMetaData
 
 struct FPropertyMetaData : FMemberMetaData
 {
+	virtual ~FPropertyMetaData() = default;
+
 	TSharedPtr<FUnrealType> Type;
 	FString RepNotifyFunctionName;
 	int32 ArrayDim = 0;
@@ -204,6 +222,8 @@ struct FPropertyMetaData : FMemberMetaData
 
 struct FArrayPropertyMetaData : FUnrealType
 {
+	virtual ~FArrayPropertyMetaData() = default;
+
 	FPropertyMetaData InnerProperty;
 
 	//FTypeMetaData interface implementation
@@ -213,6 +233,8 @@ struct FArrayPropertyMetaData : FUnrealType
 
 struct FObjectMetaData : FUnrealType
 {
+	virtual ~FObjectMetaData() = default;
+
 	FTypeReferenceMetaData InnerType;
 
 	//FTypeMetaData interface implementation
@@ -222,6 +244,8 @@ struct FObjectMetaData : FUnrealType
 
 struct FDefaultComponentMetaData : FObjectMetaData
 {
+	virtual ~FDefaultComponentMetaData() = default;
+
 	bool IsRootComponent = false;
 	FString AttachmentComponent;
 	FString AttachmentSocket;
@@ -234,6 +258,8 @@ struct FDefaultComponentMetaData : FObjectMetaData
 
 struct FFunctionMetaData : FMemberMetaData
 {
+	virtual ~FFunctionMetaData() = default;
+
 	TArray<FPropertyMetaData> Parameters;
 	FPropertyMetaData ReturnValue;
 	bool IsVirtual = false;
@@ -246,6 +272,8 @@ struct FFunctionMetaData : FMemberMetaData
 
 struct FDelegateMetaData : FUnrealType
 {
+	virtual ~FDelegateMetaData() = default;
+
 	FFunctionMetaData SignatureFunction;
 
 	//FTypeMetaData interface implementation
@@ -255,6 +283,8 @@ struct FDelegateMetaData : FUnrealType
 
 struct FInterfaceMetaData : FTypeReferenceMetaData
 {
+	virtual ~FInterfaceMetaData() = default;
+
 	TArray<FFunctionMetaData> Functions;
 	
 	//FTypeMetaData interface implementation

--- a/Source/CSharpForUE/TypeGenerator/Register/CSTypeRegistry.cpp
+++ b/Source/CSharpForUE/TypeGenerator/Register/CSTypeRegistry.cpp
@@ -48,10 +48,10 @@ bool FCSTypeRegistry::ProcessMetaData(const FString& FilePath)
 		return false;
 	}
 
-	DeserializeMetaDataObjects(JsonObject->GetArrayField("ClassMetaData"), ManagedClasses);
-	DeserializeMetaDataObjects(JsonObject->GetArrayField("StructMetaData"), ManagedStructs);
-	DeserializeMetaDataObjects(JsonObject->GetArrayField("EnumMetaData"), ManagedEnums);
-	DeserializeMetaDataObjects(JsonObject->GetArrayField("InterfacesMetaData"), ManagedInterfaces);
+	DeserializeMetaDataObjects(JsonObject->GetArrayField(TEXT("ClassMetaData")), ManagedClasses);
+	DeserializeMetaDataObjects(JsonObject->GetArrayField(TEXT("StructMetaData")), ManagedStructs);
+	DeserializeMetaDataObjects(JsonObject->GetArrayField(TEXT("EnumMetaData")), ManagedEnums);
+	DeserializeMetaDataObjects(JsonObject->GetArrayField(TEXT("InterfacesMetaData")), ManagedInterfaces);
 
 	InitializeBuilders(ManagedClasses);
 	InitializeBuilders(ManagedStructs);
@@ -90,7 +90,7 @@ UClass* FCSTypeRegistry::GetClassFromName(FName Name)
 	}
 	else
 	{
-		FoundType = FindObject<UClass>(ANY_PACKAGE, *Name.ToString());
+		FoundType = FindFirstObjectSafe<UClass>(*Name.ToString());
 	}
 	
 	return FoundType;
@@ -105,7 +105,7 @@ UScriptStruct* FCSTypeRegistry::GetStructFromName(FName Name)
 	}
 	else
 	{
-		FoundType = FindObject<UScriptStruct>(ANY_PACKAGE, *Name.ToString());
+		FoundType = FindFirstObjectSafe<UScriptStruct>(*Name.ToString());
 	}
 	
 	return FoundType;
@@ -120,7 +120,7 @@ UEnum* FCSTypeRegistry::GetEnumFromName(FName Name)
 	}
 	else
 	{
-		FoundType = FindObject<UEnum>(ANY_PACKAGE, *Name.ToString());
+		FoundType = FindFirstObjectSafe<UEnum>(*Name.ToString());
 	}
 	
 	return FoundType;
@@ -135,7 +135,7 @@ UClass* FCSTypeRegistry::GetInterfaceFromName(FName Name)
 	}
 	else
 	{
-		FoundType = FindObject<UClass>(ANY_PACKAGE, *Name.ToString());
+		FoundType = FindFirstObjectSafe<UClass>(*Name.ToString());
 	}
 	
 	return FoundType;

--- a/Source/CSharpForUE/TypeGenerator/Register/TypeInfo/CSEnumInfo.h
+++ b/Source/CSharpForUE/TypeGenerator/Register/TypeInfo/CSEnumInfo.h
@@ -4,6 +4,8 @@
 #include "CSharpForUE/TypeGenerator/Register/CSGeneratedEnumBuilder.h"
 #include "CSharpForUE/TypeGenerator/Register/CSMetaData.h"
 
+class FCSGeneratedEnumBuilder;
+
 struct CSHARPFORUE_API FCSharpEnumInfo : TCSharpTypeInfo<FEnumMetaData, UEnum, FCSGeneratedEnumBuilder>
 {
 	FCSharpEnumInfo(const TSharedPtr<FJsonValue>& MetaData) : TCSharpTypeInfo(MetaData) {}

--- a/Source/CSharpForUE/TypeGenerator/Register/TypeInfo/CSInterfaceInfo.h
+++ b/Source/CSharpForUE/TypeGenerator/Register/TypeInfo/CSInterfaceInfo.h
@@ -1,8 +1,10 @@
 ﻿#pragma once
 
-#include "CSTypeInfo.h"
+#include "CSharpForUE/TypeGenerator/Register/TypeInfo/CSTypeInfo.h"
 #include "CSharpForUE/TypeGenerator/Register/CSGeneratedInterfaceBuilder.h"
 #include "CSharpForUE/TypeGenerator/Register/CSMetaData.h"
+
+class FCSGeneratedInterfaceBuilder;
 
 struct CSHARPFORUE_API FCSharpInterfaceInfo : TCSharpTypeInfo<FInterfaceMetaData, UClass, FCSGeneratedInterfaceBuilder>
 {

--- a/Source/CSharpForUE/TypeGenerator/Register/TypeInfo/CSStructInfo.h
+++ b/Source/CSharpForUE/TypeGenerator/Register/TypeInfo/CSStructInfo.h
@@ -4,6 +4,8 @@
 #include "CSharpForUE/TypeGenerator/Register/CSGeneratedStructBuilder.h"
 #include "CSharpForUE/TypeGenerator/Register/CSMetaData.h"
 
+class FCSGeneratedStructBuilder;
+
 struct CSHARPFORUE_API FCSharpStructInfo : TCSharpTypeInfo<FStructMetaData, UScriptStruct, FCSGeneratedStructBuilder>
 {
 	FCSharpStructInfo(const TSharedPtr<FJsonValue>& MetaData) : TCSharpTypeInfo(MetaData) {}

--- a/Source/GlueGenerator/CSGenerator.h
+++ b/Source/GlueGenerator/CSGenerator.h
@@ -18,8 +18,6 @@ struct ExtensionMethod
 static const FName MD_WorldContext = "WorldContext";
 static const FName MD_WorldContextObject = "WorldContextObject";
 
-#define GLUE_GENERATOR_VERSION 2
-
 class GLUEGENERATOR_API FCSGenerator
 {
 public:

--- a/Source/GlueGenerator/CSharpGeneratorUtilities.cpp
+++ b/Source/GlueGenerator/CSharpGeneratorUtilities.cpp
@@ -147,7 +147,7 @@ namespace ScriptGeneratorUtilities
 
 	bool IsBlueprintExposedField(const FField* InField)
 	{
-		if (const FProperty* Prop = Cast<const FProperty>(InField))
+		if (const FProperty* Prop = CastField<const FProperty>(InField))
 		{
 			return IsBlueprintExposedProperty(Prop);
 		}

--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -135,7 +135,7 @@ FString FCSProcHelper::GetLatestHostFxrPath()
 
 	if (HighestVersion < DOTNET_MAJOR_VERSION)
 	{
-		UE_LOG(LogUnrealSharpProcHelper, Fatal, TEXT("Hostfxr version %s is less than the required version %s"), *HighestVersion, DOTNET_MAJOR_VERSION);
+		UE_LOG(LogUnrealSharpProcHelper, Fatal, TEXT("Hostfxr version %s is less than the required version %s"), *HighestVersion, TEXT(DOTNET_MAJOR_VERSION));
 		return "";
 	}
 	


### PR DESCRIPTION
I tried this plugin using Windows 11 and Unreal Engine 5.4. Got a lot of compiling issues. Mostly it was missing includes and forgotten TEXT macros.

I also switch from using `Cast` to `CastField` inside (Source/GlueGenerator/CSharpGeneratorUtilities.cpp:150)

I also changed 'RF_PendingKill' to 'RF_MirroredGarbage' inside (Source/CSharpForUE/Extensions/CSCancellableAsyncAction.cpp:10)

Committed by Robin Johannesson.