### PR TITLE
Add TransformPosition, TransformVector, and RotateVector to CoreUObject extensions

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Quat.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Quat.cs
@@ -63,6 +63,26 @@ public partial struct Quat
     }
 
     /// <summary>
+    /// Rotates a vector by the Quat.
+    /// </summary>
+    /// <param name="v">The vector to rotate</param>
+    /// <returns>The rotated vector resulting from applying the Quaterinion</returns>
+    public Vector RotateVector(Vector v)
+    {
+        // http://people.csail.mit.edu/bkph/articles/Quaternions.pdf
+        // V' = V + 2w(Q x V) + (2Q x (Q x V))
+        // refactor:
+        // V' = V + w(2(Q x V)) + (Q x (2(Q x V)))
+        // T = 2(Q x V);
+        // V' = V + w*(T) + (Q x T)
+
+        Vector q = new Vector(X, Y, Z);
+        Vector tt = 2f * Vector.Cross(q, v);
+        Vector result = v + W * tt + Vector.Cross(q, tt);
+        return result;
+    }
+
+    /// <summary>
     /// Divides each component of the Quat by the length of the Quat.
     /// </summary>
     /// <param name="value">The source Quat.</param>

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Transform.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Transform.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace UnrealSharp.CoreUObject;
 
 public partial struct Transform
@@ -8,7 +10,31 @@ public partial struct Transform
         Translation = location;
         Scale3D = scale;
     }
-    
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Vector TransformPosition(Vector v)
+    {
+        return Rotation.RotateVector(Scale3D * v) + Translation;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Vector TransformPositionNoScale(Vector v)
+    {
+        return Rotation.RotateVector(v) + Translation;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Vector TransformVector(Vector v)
+    {
+        return Rotation.RotateVector(Scale3D * v);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public Vector TransformVectorNoScale(Vector v)
+    {
+        return Rotation.RotateVector(v);
+    }
+
     public static readonly Transform ZeroTransform = new(Quat.Identity, Vector.Zero, Vector.Zero);
     public static readonly Transform Identity = new(Quat.Identity, Vector.Zero, Vector.One);
     
@@ -31,7 +57,7 @@ public partial struct Transform
     {
         return $"Location: {Translation}, Rotation: {Rotation}, Scale: {Scale3D}";
     }
-    
-    public static bool operator == (Transform left, Transform right) => left.Rotation == right.Rotation && left.Translation == right.Translation && left.Scale3D == right.Scale3D; 
-    public static bool operator != (Transform left, Transform right) => !(left == right);
+
+    public static bool operator ==(Transform left, Transform right) => left.Rotation == right.Rotation && left.Translation == right.Translation && left.Scale3D == right.Scale3D;
+    public static bool operator !=(Transform left, Transform right) => !(left == right);
 }


### PR DESCRIPTION
Ran into a situation where I needed to translate some vectors I was sampling from a spline curve relative to the transform of the component. Added the supporting RotateVector method to Quaternion as well.