### PR TITLE
Fixes user assembly resolving managed dlls

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildSolution.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildSolution.cs
@@ -29,7 +29,7 @@ public class BuildSolution() : BuildToolAction
             buildSolutionProcess.StartInfo.ArgumentList.Add("build");
         }
         
-        buildSolutionProcess.StartInfo.ArgumentList.Add($"\"{slnPath}\"");
+        buildSolutionProcess.StartInfo.ArgumentList.Add($"{slnPath}");
         
         buildSolutionProcess.StartInfo.ArgumentList.Add("--configuration");
         buildSolutionProcess.StartInfo.ArgumentList.Add(Program.GetBuildConfiguration(buildConfig));

--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/WeaveProject.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/WeaveProject.cs
@@ -21,11 +21,11 @@ public class WeaveProject : BuildToolAction
         weaveProcess.StartInfo.ArgumentList.Add(weaverPath);
         
         weaveProcess.StartInfo.ArgumentList.Add("-p");
-        weaveProcess.StartInfo.ArgumentList.Add($"\"{Program.FixPath(scriptFolderBinaries)}\"");
+        weaveProcess.StartInfo.ArgumentList.Add($"{Program.FixPath(scriptFolderBinaries)}");
 
         // Add path to the output folder for the weaver.
         weaveProcess.StartInfo.ArgumentList.Add("-o");
-        weaveProcess.StartInfo.ArgumentList.Add($"\"{Program.FixPath(outputPath)}\"");
+        weaveProcess.StartInfo.ArgumentList.Add($"{Program.FixPath(outputPath)}");
 
         // Add the project name.
         weaveProcess.StartInfo.ArgumentList.Add("-n");

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Mono.Cecil;
 using Mono.Cecil.Pdb;
 using UnrealSharpWeaver.MetaData;
@@ -73,11 +73,22 @@ public static class Program
             }
 
             string weaverOutputPath = Path.Combine(outputDirectory, Path.GetFileName(userAssemblyPath));
-            
+
+            DefaultAssemblyResolver resolver = new DefaultAssemblyResolver();
+
+            foreach (var assemblyPath in WeaverOptions.AssemblyPaths)
+            {
+                if (Directory.Exists(assemblyPath))
+                {
+                    resolver.AddSearchDirectory(assemblyPath);
+                }
+            }
+
             var readerParams = new ReaderParameters
             {
                 ReadSymbols = true,
                 SymbolReaderProvider = new PdbReaderProvider(),
+                AssemblyResolver = resolver
             };
 
             AssemblyDefinition userAssembly = AssemblyDefinition.ReadAssembly(userAssemblyPath, readerParams);


### PR DESCRIPTION
Currently if you use any kind of type in a ufunction or uproperty of such from another project it'll cause a weaver file lock. This fixes that by applying the same resolver the managed UnrealSharp project does before hand.

Let me know if you'd like me to also fix unmanaged dlls in this pr and will also work on that.