### PR TITLE
Fix EngineDir not being set when compiling UnrealSharpScriptGenerator

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateProject.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateProject.cs
@@ -158,7 +158,7 @@ public class GenerateProject : BuildToolAction
         }
         
         AddProperty("CopyLocalLockFileAssembliesName", "true", doc, propertyGroup);
-        AddProperty("AllowUnsafeBlocksName", "true", doc, propertyGroup);
+        AddProperty("AllowUnsafeBlocks", "true", doc, propertyGroup);
         AddProperty("EnableDynamicLoading", "true", doc, propertyGroup);
     }
 

--- a/Source/UnrealSharpScriptGenerator/UnrealSharpScriptGenerator.ubtplugin.csproj
+++ b/Source/UnrealSharpScriptGenerator/UnrealSharpScriptGenerator.ubtplugin.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     
+    <Import Project="UnrealSharpScriptGenerator.ubtplugin.csproj.props" Condition="Exists('UnrealSharpScriptGenerator.ubtplugin.csproj.props')" />
     <Import Project="$(EngineDir)\Source\Programs\Shared\UnrealEngine.csproj.props" />
 
     <PropertyGroup>


### PR DESCRIPTION
This should fix the error `The imported project "C:\Source\Programs\Shared\UnrealEngine.csproj.props" was not found.`