### PR TITLE
Generate ManagedProject.csproj at compile time

### DIFF
--- a/Source/CSharpForUE/CSManager.cpp
+++ b/Source/CSharpForUE/CSManager.cpp
@@ -66,7 +66,7 @@ void FCSManager::InitializeUnrealSharp()
 	{
 		if (!FApp::IsUnattended())
 		{
-			if (!FCSProcHelper::GenerateProject())
+			if (!FCSProcHelper::InvokeUnrealSharpBuildTool(Build) || !FCSProcHelper::InvokeUnrealSharpBuildTool(Weave))
 			{
 				InitializeUnrealSharp();
 				return;

--- a/Source/UnrealSharpScriptGenerator/Program.cs
+++ b/Source/UnrealSharpScriptGenerator/Program.cs
@@ -63,6 +63,31 @@ public static class Program
 	            Console.WriteLine("Detected modified engine glue. Starting the build process...");
 	            DotNetUtilities.BuildSolution(Path.Combine(ManagedPath, "UnrealSharp"));
 	        }
+
+			string? projectName = Path.GetFileNameWithoutExtension(factory.Session.ProjectFile);
+	        if (projectName != null && !File.Exists($"{factory.Session.ProjectDirectory}/Script/Managed{projectName}.csproj"))
+	        {
+		        string dotNetExe = DotNetUtilities.FindDotNetExecutable();
+
+		        string args = string.Empty;
+		        args += $"\"{PluginDirectory}/Binaries/Managed/UnrealSharpBuildTool.dll\"";
+		        args += " --Action GenerateProject";
+		        args += $" --EngineDirectory \"{factory.Session.EngineDirectory}/\"";
+		        args += $" --ProjectDirectory \"{factory.Session.ProjectDirectory}/\"";
+		        args += $" --ProjectName {projectName}";
+		        args += $" --PluginDirectory \"{PluginDirectory}\"";
+		        args += $" --DotNetPath \"{dotNetExe}\"";
+
+		        Process process = new Process();
+		        ProcessStartInfo startInfo = new ProcessStartInfo
+		        {
+			        WindowStyle = ProcessWindowStyle.Hidden,
+			        FileName = DotNetUtilities.FindDotNetExecutable(),
+			        Arguments = args
+		        };
+		        process.StartInfo = startInfo;
+		        process.Start();
+	        }
 	    }
 	    catch (Exception ex)
 	    {

--- a/Source/UnrealSharpScriptGenerator/Program.cs
+++ b/Source/UnrealSharpScriptGenerator/Program.cs
@@ -63,31 +63,8 @@ public static class Program
 	            Console.WriteLine("Detected modified engine glue. Starting the build process...");
 	            DotNetUtilities.BuildSolution(Path.Combine(ManagedPath, "UnrealSharp"));
 	        }
-
-			string? projectName = Path.GetFileNameWithoutExtension(factory.Session.ProjectFile);
-	        if (projectName != null && !File.Exists($"{factory.Session.ProjectDirectory}/Script/Managed{projectName}.csproj"))
-	        {
-		        string dotNetExe = DotNetUtilities.FindDotNetExecutable();
-
-		        string args = string.Empty;
-		        args += $"\"{PluginDirectory}/Binaries/Managed/UnrealSharpBuildTool.dll\"";
-		        args += " --Action GenerateProject";
-		        args += $" --EngineDirectory \"{factory.Session.EngineDirectory}/\"";
-		        args += $" --ProjectDirectory \"{factory.Session.ProjectDirectory}/\"";
-		        args += $" --ProjectName {projectName}";
-		        args += $" --PluginDirectory \"{PluginDirectory}\"";
-		        args += $" --DotNetPath \"{dotNetExe}\"";
-
-		        Process process = new Process();
-		        ProcessStartInfo startInfo = new ProcessStartInfo
-		        {
-			        WindowStyle = ProcessWindowStyle.Hidden,
-			        FileName = DotNetUtilities.FindDotNetExecutable(),
-			        Arguments = args
-		        };
-		        process.StartInfo = startInfo;
-		        process.Start();
-	        }
+	        
+	        TryGenerateProject();
 	    }
 	    catch (Exception ex)
 	    {
@@ -98,6 +75,38 @@ public static class Program
 	        Console.WriteLine(ex.StackTrace);
 	        Console.ResetColor();
 	    }
+	}
+
+	static void TryGenerateProject()
+	{
+		string? projectName = Path.GetFileNameWithoutExtension(Factory.Session.ProjectFile);
+		string projectPath = $"{Factory.Session.ProjectDirectory}/Script/Managed{projectName}.csproj";
+
+		if (projectName == null || File.Exists(projectPath))
+		{
+			return;
+		}
+		
+		string dotNetExe = DotNetUtilities.FindDotNetExecutable();
+
+		string args = string.Empty;
+		args += $"\"{PluginDirectory}/Binaries/Managed/UnrealSharpBuildTool.dll\"";
+		args += " --Action GenerateProject";
+		args += $" --EngineDirectory \"{Factory.Session.EngineDirectory}/\"";
+		args += $" --ProjectDirectory \"{Factory.Session.ProjectDirectory}/\"";
+		args += $" --ProjectName {projectName}";
+		args += $" --PluginDirectory \"{PluginDirectory}\"";
+		args += $" --DotNetPath \"{dotNetExe}\"";
+
+		Process process = new Process();
+		ProcessStartInfo startInfo = new ProcessStartInfo
+		{
+			WindowStyle = ProcessWindowStyle.Hidden,
+			FileName = dotNetExe,
+			Arguments = args
+		};
+		process.StartInfo = startInfo;
+		process.Start();
 	}
 	
 	static void InitializeStatics()


### PR DESCRIPTION
I noticed that the ManagedProject.csproj file doesn't get generated until you boot up Unreal Engine. This change should generate it at compile time.