### PR TITLE
fix #176 -user breakpoints will not hit for user code for unreal event implementations

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -127,7 +127,7 @@ public static class Program
         {
             assembly.Write(assemblyOutputPath, new WriterParameters
             {
-                WriteSymbols = true,
+                WriteSymbols = false,
                 SymbolWriterProvider = new PdbWriterProvider(),
             });
         }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -127,7 +127,6 @@ public static class Program
         {
             assembly.Write(assemblyOutputPath, new WriterParameters
             {
-                WriteSymbols = false,
                 SymbolWriterProvider = new PdbWriterProvider(),
             });
         }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
@@ -237,7 +237,12 @@ public static class WeaverHelper
         return parameter;
     }
 
-    public static MethodDefinition CopyMethod(string name, MethodDefinition method, bool addMethod = true)
+    /// <param name="name">name the method copy will have</param>
+    /// <param name="method">original method</param>
+    /// <param name="addMethod">Add the method copy to the declaring type. this allows to use the original sources to be matched to the copy.</param>
+    /// <param name="copyMetadataToken"></param>
+    /// <returns>new instance of as copy of the original</returns>
+    public static MethodDefinition CopyMethod(string name, MethodDefinition method, bool addMethod = true, bool copyMetadataToken = true)
     {
         MethodDefinition newMethod = new MethodDefinition(name, method.Attributes, method.ReturnType)
         {
@@ -246,6 +251,11 @@ public static class WeaverHelper
             CallingConvention = method.CallingConvention,
             Body = method.Body
         };
+
+        if (copyMetadataToken)
+        {
+            newMethod.MetadataToken = method.MetadataToken;
+        }
 
         foreach (ParameterDefinition parameter in method.Parameters)
         {


### PR DESCRIPTION
- fix user breakponits not hitting by copying over the metadata tokens of the original method.
- disabling pdb generation since it does not make sense will rewrite all debugging metadata wich prevents from matching code  IL code to user code manually (like with metadata tokens)

this will lead to matching debug symbols for IL method copies and breakpoints will hit like desired for user code.

i made more extensive tests with 
- calling event functions from blueprints
- implementing delegates and callbacks to regular ufunctions and event functions
- general [UFunction(FunctionFlags.BlueprintEvent | FunctionFlags.BlueprintCallable)] decorations