### PR TITLE
fix #178 -fix missing IL code for 'virtual' base method after weaving 

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/FunctionProcessor.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/FunctionProcessor.cs
@@ -46,7 +46,7 @@ public static class FunctionProcessor
                     continue;
                 }
 
-                if (virtualFunction.IsVirtual && virtualFunction.GetBaseMethod() != null)
+                if (virtualFunction.IsVirtual && virtualFunction.GetBaseMethod() != virtualFunction)
                 {
                     continue;
                 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3b20d30f-e7f7-4487-9d30-587a069302dd)

all virtual methods have base methods. change the code to check if the base method is not the current implementation. this base method should always be the root base method as well from the Cecil underlying impl