### PR TITLE
Fixed obj/bin folders not being ignored in Script subfolders

### DIFF
--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -52,7 +52,7 @@ void FUnrealSharpEditorModule::OnCSharpCodeModified(const TArray<FFileChangeData
 	for (const FFileChangeData& ChangedFile : ChangedFiles)
 	{
 		// Skip generated files in bin and obj folders
-		if (ChangedFile.Filename.Contains("Script/bin") || ChangedFile.Filename.Contains("Script/obj"))
+		if (ChangedFile.Filename.Contains("\\bin\\") || ChangedFile.Filename.Contains("\\obj\\"))
 		{
 			continue;
 		}


### PR DESCRIPTION
Someone was running into a problem where their other obj/bin folders weren't being ignored with the directory watcher, so now its checks for the folders without the Script prefix to account for subfolders