### PR TITLE
Move developer settings to Editor preferences

### DIFF
--- a/Source/CSharpForUE/CSDeveloperSettings.h
+++ b/Source/CSharpForUE/CSDeveloperSettings.h
@@ -4,7 +4,7 @@
 #include "Engine/DeveloperSettings.h"
 #include "CSDeveloperSettings.generated.h"
 
-UCLASS(config = UnrealSharp, meta = (DisplayName = "UnrealSharp Settings"))
+UCLASS(config = EditorPerProjectUserSettings, meta = (DisplayName = "UnrealSharp Settings"))
 class CSHARPFORUE_API UCSDeveloperSettings : public UDeveloperSettings
 {
 	GENERATED_BODY()


### PR DESCRIPTION
UCSDeveloperSettings now uses EditorPerProjectUserSettings so it shows up within Editor Preferences instead of the Project Settings, since the settings are editor specific.

Prior to this change the settings also did not save locally for me, after moving it over to this config they get saved and persist between editor launches.