### PR TITLE
Added setting to disable automatic HotReload

### DIFF
--- a/Source/CSharpForUE/CSDeveloperSettings.h
+++ b/Source/CSharpForUE/CSDeveloperSettings.h
@@ -4,6 +4,17 @@
 #include "Engine/DeveloperSettings.h"
 #include "CSDeveloperSettings.generated.h"
 
+UENUM()
+enum EHotReloadMethod : uint8
+{
+	// Automatically Hot Reloads when script changes are saved
+	OnScriptSave,
+	// Wait for the Editor to gain focus before Hot Reloading
+	OnEditorFocus,
+	// Will not Hot Reload automatically
+	Off,
+};
+
 UCLASS(config = EditorPerProjectUserSettings, meta = (DisplayName = "UnrealSharp Settings"))
 class CSHARPFORUE_API UCSDeveloperSettings : public UDeveloperSettings
 {
@@ -15,8 +26,7 @@ public:
 	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Debugging")
 	bool bCrashOnException = true;
 	
-	// Whether Hot Reload should wait for the Editor to gain focus
+	// Whether Hot Reload should automatically start on script save, gaining Editor focus, or not at all.
 	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Hot Reload")
-	bool bRequireFocusForHotReload = false;
-	
+	TEnumAsByte<EHotReloadMethod> AutomaticHotReloading = OnScriptSave;
 };

--- a/Source/CSharpForUE/CSDeveloperSettings.h
+++ b/Source/CSharpForUE/CSDeveloperSettings.h
@@ -5,7 +5,7 @@
 #include "CSDeveloperSettings.generated.h"
 
 UENUM()
-enum EHotReloadMethod : uint8
+enum EAutomaticHotReloadMethod : uint8
 {
 	// Automatically Hot Reloads when script changes are saved
 	OnScriptSave,
@@ -28,5 +28,5 @@ public:
 	
 	// Whether Hot Reload should automatically start on script save, gaining Editor focus, or not at all.
 	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Hot Reload")
-	TEnumAsByte<EHotReloadMethod> AutomaticHotReloading = OnScriptSave;
+	TEnumAsByte<EAutomaticHotReloadMethod> AutomaticHotReloading = OnScriptSave;
 };

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -15,6 +15,11 @@
 
 #define LOCTEXT_NAMESPACE "FUnrealSharpEditorModule"
 
+FUnrealSharpEditorModule& FUnrealSharpEditorModule::Get()
+{
+	return FModuleManager::LoadModuleChecked<FUnrealSharpEditorModule>("UnrealSharpEditor");
+}
+
 void FUnrealSharpEditorModule::StartupModule()
 {
 	FCSManager& Manager = FCSManager::Get();
@@ -42,7 +47,7 @@ void FUnrealSharpEditorModule::ShutdownModule()
 
 void FUnrealSharpEditorModule::OnCSharpCodeModified(const TArray<FFileChangeData>& ChangedFiles)
 {
-	if (bIsReloading)
+	if (IsHotReloading())
 	{
 		return;
 	}
@@ -65,16 +70,15 @@ void FUnrealSharpEditorModule::OnCSharpCodeModified(const TArray<FFileChangeData
 		}
 		
 		// Return on the first .cs file we encounter so we can reload.
-		bIsReloading = true;
-
-		// Return early and let TickDelegate handle Reload
-		if (Settings->bRequireFocusForHotReload)
+		if (Settings->AutomaticHotReloading != OnScriptSave)
 		{
-			return;
+			HotReloadStatus = PendingReload;
+		}
+		else
+		{
+			StartHotReload();
 		}
 		
-		StartHotReload();
-		bIsReloading = false;
 		return;
 	}
 }
@@ -89,12 +93,15 @@ void FUnrealSharpEditorModule::StartHotReload()
 		SuggestProjectSetup();
 		return;
 	}
+
+	HotReloadStatus = Active;
 	
 	FScopedSlowTask Progress(2, LOCTEXT("HotReload", "Hot Reloading C#..."));
 	Progress.MakeDialog();
 
 	if (!FCSProcHelper::InvokeUnrealSharpBuildTool(BuildWeave))
 	{
+		HotReloadStatus = Inactive;
 		return;
 	}
 	
@@ -107,6 +114,7 @@ void FUnrealSharpEditorModule::StartHotReload()
 		FString ProjectName = FPaths::GetBaseFilename(ProjectPath);
 		if (!CSharpManager.UnloadAssembly(ProjectName))
 		{
+			HotReloadStatus = Inactive;
 			return;
 		}
 	}
@@ -116,11 +124,14 @@ void FUnrealSharpEditorModule::StartHotReload()
 	// TODO: Same here, only load the assembly that was modified.
 	if (!CSharpManager.LoadUserAssembly())
 	{
+		HotReloadStatus = Inactive;
 		return;
 	}
 
 	Progress.EnterProgressFrame(1, LOCTEXT("HotReload", "Reinstancing..."));
 	FCSReinstancer::Get().StartReinstancing();
+
+	HotReloadStatus = Inactive;
 }
 
 void FUnrealSharpEditorModule::OnUnrealSharpInitialized()
@@ -172,6 +183,11 @@ void FUnrealSharpEditorModule::OnCreateNewProject()
 	OpenNewProjectDialog();
 }
 
+void FUnrealSharpEditorModule::OnCompileManagedCode()
+{
+	Get().StartHotReload();
+}
+
 void FUnrealSharpEditorModule::OnRegenerateSolution()
 {
 	if (!FCSProcHelper::InvokeUnrealSharpBuildTool(GenerateSolution))
@@ -179,6 +195,11 @@ void FUnrealSharpEditorModule::OnRegenerateSolution()
 		return;
 	}
 
+	OpenSolution();
+}
+
+void FUnrealSharpEditorModule::OnOpenSolution()
+{
 	OpenSolution();
 }
 
@@ -255,13 +276,11 @@ void FUnrealSharpEditorModule::SuggestProjectSetup()
 bool FUnrealSharpEditorModule::Tick(float DeltaTime)
 {
 	const UCSDeveloperSettings* Settings = GetDefault<UCSDeveloperSettings>();
-	if (!Settings->bRequireFocusForHotReload || !bIsReloading || !FApp::HasFocus())
+	if (Settings->AutomaticHotReloading == OnEditorFocus && !IsHotReloading() && HasPendingHotReloadChanges() && FApp::HasFocus())
 	{
-		return true;
+		StartHotReload();
 	}
 
-	StartHotReload();
-	bIsReloading = false;
 	return true;
 }
 
@@ -270,9 +289,9 @@ void FUnrealSharpEditorModule::RegisterCommands()
 	FCSCommands::Register();
 	UnrealSharpCommands = MakeShareable(new FUICommandList);
 	UnrealSharpCommands->MapAction(FCSCommands::Get().CreateNewProject, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnCreateNewProject));
-	UnrealSharpCommands->MapAction(FCSCommands::Get().CompileManagedCode, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::StartHotReload));
+	UnrealSharpCommands->MapAction(FCSCommands::Get().CompileManagedCode, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnCompileManagedCode));
 	UnrealSharpCommands->MapAction(FCSCommands::Get().RegenerateSolution, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnRegenerateSolution));
-	UnrealSharpCommands->MapAction(FCSCommands::Get().OpenSolution, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OpenSolution));
+	UnrealSharpCommands->MapAction(FCSCommands::Get().OpenSolution, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnOpenSolution));
 }
 
 void FUnrealSharpEditorModule::RegisterMenu()

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.h
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.h
@@ -4,19 +4,31 @@
 #include "Modules/ModuleManager.h"
 #include "Containers/Ticker.h"
 
+enum HotReloadStatus
+{
+    // Not Hot Reloading
+    Inactive,
+    // When the DirectoryWatcher picks up on new code changes that haven't been Hot Reloaded yet
+    PendingReload,
+    // Actively Hot Reloading
+    Active
+};
+
 class FUnrealSharpEditorModule : public IModuleInterface
 {
 public:
-
+    static FUnrealSharpEditorModule& Get();
+    
     // IModuleInterface interface begin
     virtual void StartupModule() override;
     virtual void ShutdownModule() override;
     // End
     
     void OnCSharpCodeModified(const TArray<struct FFileChangeData>& ChangedFiles);
-    static void StartHotReload();
+    void StartHotReload();
 
-    bool IsReloading() const { return bIsReloading; }
+    bool IsHotReloading() const { return HotReloadStatus == Active; }
+    bool HasPendingHotReloadChanges() const { return HotReloadStatus == PendingReload; }
     
     static void OpenSolution();
 
@@ -25,7 +37,9 @@ private:
     void OnUnrealSharpInitialized();
 
     static void OnCreateNewProject();
+    static void OnCompileManagedCode();
     static void OnRegenerateSolution();
+    static void OnOpenSolution();
 
     TSharedRef<SWidget> GenerateUnrealSharpMenu();
     
@@ -37,9 +51,10 @@ private:
     
     void RegisterCommands();
     void RegisterMenu();
-
+    
+    HotReloadStatus HotReloadStatus = Inactive;
+    
     FTickerDelegate TickDelegate;
     FTSTicker::FDelegateHandle TickDelegateHandle;
-    bool bIsReloading = false;
     TSharedPtr<FUICommandList> UnrealSharpCommands;
 };


### PR DESCRIPTION
- Moved to using an enum for the automatic reload developer setting for multiple states (`OnScriptSave`, `OnEditorFocus`, `Off`).
- Moved to using an enum for `bIsReloading` in `UnrealSharpEditor` for multiple states (`Inactive`, `PendingReload`, `Active`).
  - `PendingReload` is a new state that gets set to true when the DirectoryWatcher finds script changes, but the automatic setting is set to only Hot Reload on Focus or Manual.
- `HotReloadStatus` is now set to active and inactive within `StartHotReload()`, so it does not need to be manually set to true and false when calling the function.
  - `StartHotReload()` is no longer static so the `HotReloadStatus` can be set within the function.
- There's now static `OnCompileManagedCode()` and `OnOpenSolution()` functions that the commands register to, to match the other `On` prefixed static command functions.