### PR TITLE
Recursive dependency copying

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -266,26 +266,49 @@ public static class Program
         }
     }
 
+    private static void RecursiveFileCopy(DirectoryInfo sourceDirectory, DirectoryInfo destinationDirectory)
+    {
+        // Early out of our search if the last updated timestamps match
+        if (sourceDirectory.LastWriteTimeUtc == destinationDirectory.LastWriteTimeUtc) return;
+
+        if (!destinationDirectory.Exists)
+        {
+            destinationDirectory.Create();
+        }
+
+        foreach (FileInfo sourceFile in sourceDirectory.GetFiles())
+        {
+            string destinationFilePath = Path.Combine(destinationDirectory.FullName, sourceFile.Name);
+            FileInfo destinationFile = new FileInfo(destinationFilePath);
+
+            if (!destinationFile.Exists || sourceFile.LastWriteTimeUtc > destinationFile.LastWriteTimeUtc)
+            {
+                sourceFile.CopyTo(destinationFilePath, true);
+            }
+        }
+
+        // Update our write time to match source for faster copying
+        destinationDirectory.LastWriteTimeUtc = sourceDirectory.LastWriteTimeUtc;
+
+        foreach (DirectoryInfo subSourceDirectory in sourceDirectory.GetDirectories())
+        {
+            string subDestinationDirectoryPath = Path.Combine(destinationDirectory.FullName, subSourceDirectory.Name);
+            DirectoryInfo subDestinationDirectory = new DirectoryInfo(subDestinationDirectoryPath);
+
+            RecursiveFileCopy(subSourceDirectory, subDestinationDirectory);
+        }
+    }
+
     private static void CopyAssemblyDependencies(string destinationPath, string sourcePath)
     {
         var directoryName = Path.GetDirectoryName(destinationPath) ?? throw new InvalidOperationException("Assembly path does not have a valid directory.");
 
-        if (!Directory.Exists(directoryName)) 
-        {
-            Directory.CreateDirectory(directoryName);
-        }
-
         try
         {
-            string[] dependencies = Directory.GetFiles(sourcePath, "*.*");
-            foreach (var dependency in dependencies) 
-            {
-                var destPath = Path.Combine(directoryName, Path.GetFileName(dependency));
-                if (!File.Exists(destPath) || new FileInfo(dependency).LastWriteTimeUtc > new FileInfo(destPath).LastWriteTimeUtc)
-                {
-                    File.Copy(dependency, destPath, true);
-                }
-            }
+            var destinationDirectory = new DirectoryInfo(directoryName);
+            var sourceDirectory = new DirectoryInfo(sourcePath);
+
+            RecursiveFileCopy(sourceDirectory, destinationDirectory);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Right now if there are native runtimes or any other files in sub directories in project bin folders they are ignored, this fixes that by copying files over recursively.