### PR TITLE
Changed Delegates glue exposure

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AnalyzerStatics.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AnalyzerStatics.cs
@@ -10,7 +10,9 @@ public static class AnalyzerStatics
     public const string UEnumAttribute = "UEnumAttribute";
     public const string UClassAttribute = "UClassAttribute";
     public const string UInterfaceAttribute = "UInterfaceAttribute";
-    
+    public const string UMultiDelegateAttribute = "UMultiDelegateAttribute";
+    public const string USingleDelegateAttribute = "USingleDelegateAttribute";
+
     public const string GeneratedTypeAttribute = "GeneratedTypeAttribute";
     
     public const string UPropertyAttribute = "UPropertyAttribute";

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/DelegateWrapperGenerator.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/DelegateWrapperGenerator.cs
@@ -102,17 +102,21 @@ public class DelegateWrapperGenerator : ISourceGenerator
             
             string baseType;
             DelegateType delegateType;
-            if (AnalyzerStatics.HasAttribute(delegateSymbol, "USingleDelegateAttribute"))
+            if (AnalyzerStatics.HasAttribute(delegateSymbol, AnalyzerStatics.USingleDelegateAttribute))
             {
                 baseType = "Delegate";
                 delegateType = DelegateType.Single;
             }
-            else
+            else if (AnalyzerStatics.HasAttribute(delegateSymbol, AnalyzerStatics.UMultiDelegateAttribute))
             {
                 baseType = "MulticastDelegate";
                 delegateType = DelegateType.Multicast;
             }
-            
+            else
+            {
+                continue;
+            }
+
             stringBuilder.AppendLine($"public partial class {delegateName} : {baseType}<{delegateSymbol}>");
             stringBuilder.AppendLine("{");
             

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/UMultiDelegateAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/UMultiDelegateAttribute.cs
@@ -1,0 +1,4 @@
+﻿namespace UnrealSharp.Attributes;
+
+[AttributeUsage(AttributeTargets.Delegate)]
+public class UMultiDelegateAttribute : Attribute;

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -255,8 +255,8 @@ public static class Program
             UnrealEnumProcessor.ProcessEnums(enums, metadata);
             UnrealInterfaceProcessor.ProcessInterfaces(interfaces, metadata);
             UnrealStructProcessor.ProcessStructs(structs, metadata, userAssembly);
-            UnrealDelegateProcessor.ProcessMulticastDelegates(multicastDelegates);
-            UnrealDelegateProcessor.ProcessSingleDelegates(delegates);
+            UnrealDelegateProcessor.ProcessMulticastDelegates(multicastDelegates, userAssembly);
+            UnrealDelegateProcessor.ProcessSingleDelegates(delegates, userAssembly);
             UnrealClassProcessor.ProcessClasses(classes, metadata);
         }
         catch (Exception ex)

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -235,11 +235,11 @@ public static class Program
                         {
                             RegisterType(interfaces, type);
                         }
-                        else if (type.BaseType != null && type.BaseType.FullName.Contains("UnrealSharp.MulticastDelegate"))
+                        else if (WeaverHelper.IsUMultiDelegate(type))
                         {
                             RegisterType(multicastDelegates, type);
                         }
-                        else if (type.BaseType != null && type.BaseType.FullName.Contains("UnrealSharp.Delegate"))
+                        else if (WeaverHelper.IsUSingleDelegate(type))
                         {
                             RegisterType(delegates, type);
                         }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -93,6 +93,7 @@ public static class Program
             {
                 string weaverOutputPath = Path.Combine(outputDirInfo.FullName, Path.GetFileName(userAssemblyPath));
                 StartWeavingAssembly(userAssembly, weaverOutputPath);
+                continue;
             }
             catch (WeaverProcessError error)
             {
@@ -103,8 +104,9 @@ public static class Program
                 Console.Error.WriteLine($"Exception processing {userAssemblyPath}: {ex.Message}");
                 Console.Error.WriteLine(ex.StackTrace);
             }
+            return false;
         }
-
+        
         return true;
     }
     

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -235,11 +235,11 @@ public static class Program
                         {
                             RegisterType(interfaces, type);
                         }
-                        else if (WeaverHelper.IsUMultiDelegate(type))
+                        else if (type.BaseType != null && type.BaseType.FullName.Contains("UnrealSharp.MulticastDelegate"))
                         {
                             RegisterType(multicastDelegates, type);
                         }
-                        else if (WeaverHelper.IsUSingleDelegate(type))
+                        else if (type.BaseType != null && type.BaseType.FullName.Contains("UnrealSharp.Delegate"))
                         {
                             RegisterType(delegates, type);
                         }
@@ -255,7 +255,7 @@ public static class Program
             UnrealEnumProcessor.ProcessEnums(enums, metadata);
             UnrealInterfaceProcessor.ProcessInterfaces(interfaces, metadata);
             UnrealStructProcessor.ProcessStructs(structs, metadata, userAssembly);
-            UnrealDelegateProcessor.ProcessMulticastDelegates(multicastDelegates, userAssembly);
+            UnrealDelegateProcessor.ProcessMulticastDelegates(multicastDelegates);
             UnrealDelegateProcessor.ProcessSingleDelegates(delegates, userAssembly);
             UnrealClassProcessor.ProcessClasses(classes, metadata);
         }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
@@ -34,8 +34,8 @@ public static class WeaverHelper
     public static readonly string UFunctionAttribute = "UFunctionAttribute";
     public static readonly string UClassAttribute = "UClassAttribute";
     public static readonly string UInterfaceAttribute = "UInterfaceAttribute";
-    public static readonly string UMultiDelegateAttribute = "UMultiDelegate";
-    public static readonly string USingleDelegateAttribute = "USingleDelegate";
+    public static readonly string UMultiDelegateAttribute = "UMultiDelegateAttribute";
+    public static readonly string USingleDelegateAttribute = "USingleDelegateAttribute";
 
     public static readonly string GeneratedTypeAttribute = "GeneratedTypeAttribute";
     public static readonly string BlittableTypeAttribute = "BlittableTypeAttribute";

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
@@ -34,7 +34,9 @@ public static class WeaverHelper
     public static readonly string UFunctionAttribute = "UFunctionAttribute";
     public static readonly string UClassAttribute = "UClassAttribute";
     public static readonly string UInterfaceAttribute = "UInterfaceAttribute";
-    
+    public static readonly string UMultiDelegateAttribute = "UMultiDelegate";
+    public static readonly string USingleDelegateAttribute = "USingleDelegate";
+
     public static readonly string GeneratedTypeAttribute = "GeneratedTypeAttribute";
     public static readonly string BlittableTypeAttribute = "BlittableTypeAttribute";
     
@@ -945,7 +947,17 @@ public static class WeaverHelper
     {
         return FindAttribute(type.CustomAttributes, UInterfaceAttribute);
     }
-        
+
+    public static CustomAttribute? GetUMultiDelegateInterface(TypeDefinition type)
+    {
+        return FindAttribute(type.CustomAttributes, UMultiDelegateAttribute);
+    }
+
+    public static CustomAttribute? GetUSingleDelegateInterface(TypeDefinition type)
+    {
+        return FindAttribute(type.CustomAttributes, USingleDelegateAttribute);
+    }
+
     public static bool IsUProperty(IMemberDefinition property)
     {
         return GetUProperty(property) != null;
@@ -960,7 +972,17 @@ public static class WeaverHelper
     {
         return GetUClass(typeDefinition) != null;
     }
-    
+
+    public static bool IsUMultiDelegate(TypeDefinition typeDefinition)
+    {
+        return GetUMultiDelegateInterface(typeDefinition) != null;
+    }
+
+    public static bool IsUSingleDelegate(TypeDefinition typeDefinition)
+    {
+        return GetUSingleDelegateInterface(typeDefinition) != null;
+    }
+
     public static bool IsGenerated(TypeDefinition typeDefinition)
     {
         return FindAttribute(typeDefinition.CustomAttributes, GeneratedTypeAttribute) != null;


### PR DESCRIPTION
Any delegates in a project the weaver will attempt to glue even if the user doesn't want to expose a delegate to USharp, this changes that and requires all delegates that the user wants to be glued requires an attribute.

```c#
// Multicast delegates.
[UMultiDelegate]
public delegate void MyShowcaseMulticastDelegate(int a);

// Single delegates.
[USingleDelegate]
public delegate void MyShowcaseDelegate(int a);
``` 