### PR TITLE
Fixed cooking calling into Initialize

### DIFF
--- a/Source/CSharpForUE/CSharpForUE.cpp
+++ b/Source/CSharpForUE/CSharpForUE.cpp
@@ -18,6 +18,9 @@ DEFINE_LOG_CATEGORY(LogUnrealSharp);
 
 void FCSharpForUEModule::StartupModule()
 {
+	// Cooking starts up a new instance of unreal causing this to run, we don't want this
+	if (IsRunningCookCommandlet()) return;
+
 	FCSManager::Get().InitializeUnrealSharp();
 }
 

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -1,4 +1,4 @@
-﻿#include "UnrealSharpEditor.h"
+#include "UnrealSharpEditor.h"
 #include "AssetToolsModule.h"
 #include "CSCommands.h"
 #include "DirectoryWatcherModule.h"
@@ -26,6 +26,9 @@ FUnrealSharpEditorModule& FUnrealSharpEditorModule::Get()
 
 void FUnrealSharpEditorModule::StartupModule()
 {
+	// Cooking starts up a new instance of unreal causing this to run, we don't want this
+	if (IsRunningCookCommandlet()) return;
+
 	FCSManager& Manager = FCSManager::Get();
 	if (!Manager.IsInitialized())
 	{


### PR DESCRIPTION
Right now when packaging cooking creates a new instance of unreal causing it to call into InitializeUnrealSharp(), this PR fixes this.