### PR TITLE
Guard against C# null strings on [UProperty]

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
@@ -85,6 +85,7 @@ public static class StringMarshaller
     {
         unsafe
         {
+            if (obj == null) obj = string.Empty; //Guard against C# null strings (use string.Empty instead)
             IntPtr ustring = nativeBuffer + arrayIndex * sizeof(UnmanagedArray);
             fixed (char* stringPtr = obj)
             {


### PR DESCRIPTION
Add a guard to the StringMarshaller to guard against C# null strings (treat as string.Empty instead)

Otherwise:

 [UProperty(PropertyFlags.BlueprintReadOnly)]
 public string TestString { get; set; }

Will crash with an Unhandled Exception: EXCEPTION_ACCESS_VIOLATION reading address 0x0000000000000000