### PR TITLE
Fixed issue with manually exported types

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/TimerHandle.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/TimerHandle.cs
@@ -3,7 +3,7 @@ using UnrealSharp.Attributes;
 
 namespace UnrealSharp.Engine;
 
-[UStruct, BlittableType, StructLayout(LayoutKind.Sequential)]
+[StructLayout(LayoutKind.Sequential)]
 public partial struct FTimerHandle
 {
     private const uint IndexBits = 24;

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/EnhancedInput/InputActionValue.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/EnhancedInput/InputActionValue.cs
@@ -4,7 +4,7 @@ using UnrealSharp.CoreUObject;
 
 namespace UnrealSharp.EnhancedInput;
 
-[UStruct, BlittableType, StructLayout(LayoutKind.Sequential)]
+[StructLayout(LayoutKind.Sequential)]
 public partial struct FInputActionValue
 {
     private FVector AxisValue;

--- a/Source/UnrealSharpScriptGenerator/Exporters/ClassExporter.cs
+++ b/Source/UnrealSharpScriptGenerator/Exporters/ClassExporter.cs
@@ -9,7 +9,7 @@ namespace UnrealSharpScriptGenerator.Exporters;
 
 public static class ClassExporter
 {
-    public static void ExportClass(UhtClass classObj)
+    public static void ExportClass(UhtClass classObj, bool isManualExport)
     {
         GeneratorStringBuilder stringBuilder = new();
 
@@ -53,14 +53,18 @@ public static class ClassExporter
         
         stringBuilder.DeclareType(classObj, "class", classObj.GetStructName(), superClassName, true, interfaces);
         
-        StaticConstructorUtilities.ExportStaticConstructor(stringBuilder, classObj, exportedProperties, exportedFunctions, exportedOverrides);
+        // For manual exports we just want to generate attributes
+        if (!isManualExport)
+        { 
+            StaticConstructorUtilities.ExportStaticConstructor(stringBuilder, classObj, exportedProperties, exportedFunctions, exportedOverrides);
         
-        ExportClassProperties(stringBuilder, exportedProperties);
+            ExportClassProperties(stringBuilder, exportedProperties);
         
-        ExportClassFunctions(classObj, stringBuilder, exportedFunctions);
-        ExportOverrides(stringBuilder, exportedOverrides);
-        
-        stringBuilder.AppendLine();
+            ExportClassFunctions(classObj, stringBuilder, exportedFunctions);
+            ExportOverrides(stringBuilder, exportedOverrides);
+            stringBuilder.AppendLine();
+        }
+
         stringBuilder.CloseBrace();
         
         FileExporter.SaveGlueToDisk(classObj, stringBuilder);

--- a/Source/UnrealSharpScriptGenerator/Exporters/StructExporter.cs
+++ b/Source/UnrealSharpScriptGenerator/Exporters/StructExporter.cs
@@ -9,7 +9,7 @@ namespace UnrealSharpScriptGenerator.Exporters;
 
 public static class StructExporter
 {
-    public static void ExportStruct(UhtScriptStruct structObj)
+    public static void ExportStruct(UhtScriptStruct structObj, bool isManualExport)
     {
         GeneratorStringBuilder stringBuilder = new();
         List<UhtProperty> exportedProperties = new();
@@ -53,12 +53,16 @@ public static class StructExporter
         stringBuilder.AppendLine(attributeBuilder.ToString());
         
         stringBuilder.DeclareType(structObj, "struct", structObj.GetStructName());
-        
-        List<string> reservedNames = GetReservedNames(exportedProperties);
-        
-        ExportStructProperties(stringBuilder, exportedProperties, isBlittable, reservedNames);
 
-        if (!isBlittable)
+        // For manual exports we just want to generate attributes
+        if (!isManualExport)
+        {
+            List<string> reservedNames = GetReservedNames(exportedProperties);
+
+            ExportStructProperties(stringBuilder, exportedProperties, isBlittable, reservedNames);
+        }
+
+        if (!isBlittable && !isManualExport)
         {
             stringBuilder.AppendLine();
             StaticConstructorUtilities.ExportStaticConstructor(stringBuilder, structObj, exportedProperties, new List<UhtFunction>(), new List<UhtFunction>());
@@ -68,7 +72,7 @@ public static class StructExporter
         
         stringBuilder.CloseBrace();
         
-        if (!isBlittable)
+        if (!isBlittable && !isManualExport)
         {
             ExportStructMarshaller(stringBuilder, structObj);
         }


### PR DESCRIPTION
This PR fixes an issue currently with manually exported types not having the GeneratedType attribute applied to them causing them to become FallBack structs when doing object lookups by name C++ side.