### PR TITLE
Add functionality to reload modules only & Add shortcuts

### DIFF
--- a/Source/UnrealSharpCore/CSDeveloperSettings.h
+++ b/Source/UnrealSharpCore/CSDeveloperSettings.h
@@ -9,6 +9,8 @@ enum EAutomaticHotReloadMethod : uint8
 {
 	// Automatically Hot Reloads when script changes are saved
 	OnScriptSave,
+	// Automatically Hot Reloads when the built .NET modules changed (build the C# project in your IDE and UnrealSharp will automatically reload)
+	OnModuleChange,
 	// Wait for the Editor to gain focus before Hot Reloading
 	OnEditorFocus,
 	// Will not Hot Reload automatically

--- a/Source/UnrealSharpEditor/CSCommands.cpp
+++ b/Source/UnrealSharpEditor/CSCommands.cpp
@@ -15,19 +15,9 @@ FCSCommands::FCSCommands() : TCommands<FCSCommands>(
 
 void FCSCommands::RegisterCommands()
 {
-	FInputChord ReloadModulesChord;
-	ReloadModulesChord.Key = EKeys::F10;
-	ReloadModulesChord.bAlt = true;
-	ReloadModulesChord.bCtrl = true;
-
-	FInputChord CompileModulesChord;
-	CompileModulesChord.Key = EKeys::F9;
-	CompileModulesChord.bAlt = true;
-	CompileModulesChord.bCtrl = true;
-	
 	UI_COMMAND(CreateNewProject, "New C# Project", "Create a new C# project with all necessary dependencies and initial setup", EUserInterfaceActionType::Button, FInputChord());
-	UI_COMMAND(CompileManagedCode, "Compile C#", "Trigger a hot reload to recompile the project's C# code", EUserInterfaceActionType::Button, CompileModulesChord);
-	UI_COMMAND(ReloadManagedCode, "Reload modules", "Reloads the built modules in case they were built externally (for example from your IDE)", EUserInterfaceActionType::Button, ReloadModulesChord);
+	UI_COMMAND(CompileManagedCode, "Compile C#", "Trigger a hot reload to recompile the project's C# code", EUserInterfaceActionType::Button, FInputChord(EKeys::F10, EModifierKey::Control | EModifierKey::Alt));
+	UI_COMMAND(ReloadManagedCode, "Reload modules", "Reloads the built modules in case they were built externally (for example from your IDE)", EUserInterfaceActionType::Button, FInputChord(EKeys::F9, EModifierKey::Control | EModifierKey::Alt));
 	UI_COMMAND(RegenerateSolution, "Regenerate Solution", "Rebuild the C# solution file to reflect the latest project changes", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(OpenSolution, "Open C# Solution", "Launch the project's C# solution file in the default IDE", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(PackageProject, "Package Project", "Package the C# project to the archived directory", EUserInterfaceActionType::Button, FInputChord());

--- a/Source/UnrealSharpEditor/CSCommands.cpp
+++ b/Source/UnrealSharpEditor/CSCommands.cpp
@@ -15,8 +15,19 @@ FCSCommands::FCSCommands() : TCommands<FCSCommands>(
 
 void FCSCommands::RegisterCommands()
 {
+	FInputChord ReloadModulesChord;
+	ReloadModulesChord.Key = EKeys::F10;
+	ReloadModulesChord.bAlt = true;
+	ReloadModulesChord.bCtrl = true;
+
+	FInputChord CompileModulesChord;
+	CompileModulesChord.Key = EKeys::F9;
+	CompileModulesChord.bAlt = true;
+	CompileModulesChord.bCtrl = true;
+	
 	UI_COMMAND(CreateNewProject, "New C# Project", "Create a new C# project with all necessary dependencies and initial setup", EUserInterfaceActionType::Button, FInputChord());
-	UI_COMMAND(CompileManagedCode, "Compile C#", "Trigger a hot reload to recompile the project's C# code", EUserInterfaceActionType::Button, FInputChord());
+	UI_COMMAND(CompileManagedCode, "Compile C#", "Trigger a hot reload to recompile the project's C# code", EUserInterfaceActionType::Button, CompileModulesChord);
+	UI_COMMAND(ReloadManagedCode, "Reload modules", "Reloads the built modules in case they were built externally (for example from your IDE)", EUserInterfaceActionType::Button, ReloadModulesChord);
 	UI_COMMAND(RegenerateSolution, "Regenerate Solution", "Rebuild the C# solution file to reflect the latest project changes", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(OpenSolution, "Open C# Solution", "Launch the project's C# solution file in the default IDE", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(PackageProject, "Package Project", "Package the C# project to the archived directory", EUserInterfaceActionType::Button, FInputChord());

--- a/Source/UnrealSharpEditor/CSCommands.h
+++ b/Source/UnrealSharpEditor/CSCommands.h
@@ -1,23 +1,18 @@
 ﻿#pragma once
-#include "EditorStyleSet.h"
 
 class CSCommands
 {
-public:
-	
 };
 
 class FCSCommands : public TCommands<FCSCommands>
 {
 public:
-
 	FCSCommands();
 
 	// TCommands<> interface
 	virtual void RegisterCommands() override;
 	// End
 
-public:
 	TSharedPtr<FUICommandInfo> CreateNewProject;
 	TSharedPtr<FUICommandInfo> CompileManagedCode;
 	TSharedPtr<FUICommandInfo> ReloadManagedCode;

--- a/Source/UnrealSharpEditor/CSCommands.h
+++ b/Source/UnrealSharpEditor/CSCommands.h
@@ -20,6 +20,7 @@ public:
 public:
 	TSharedPtr<FUICommandInfo> CreateNewProject;
 	TSharedPtr<FUICommandInfo> CompileManagedCode;
+	TSharedPtr<FUICommandInfo> ReloadManagedCode;
 	TSharedPtr<FUICommandInfo> RegenerateSolution;
 	TSharedPtr<FUICommandInfo> OpenSolution;
 	TSharedPtr<FUICommandInfo> PackageProject;

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -9,6 +9,7 @@
 #include "GameplayTagsSettings.h"
 #include "IDirectoryWatcher.h"
 #include "ISettingsModule.h"
+#include "LevelEditor.h"
 #include "SourceCodeNavigation.h"
 #include "Engine/AssetManager.h"
 #include "Engine/AssetManagerSettings.h"
@@ -448,6 +449,10 @@ void FUnrealSharpEditorModule::RegisterCommands()
 	UnrealSharpCommands->MapAction(FCSCommands::Get().OpenSettings, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnOpenSettings));
 	UnrealSharpCommands->MapAction(FCSCommands::Get().OpenDocumentation, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnOpenDocumentation));
 	UnrealSharpCommands->MapAction(FCSCommands::Get().ReportBug, FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnReportBug));
+
+	const FLevelEditorModule& LevelEditorModule = FModuleManager::GetModuleChecked<FLevelEditorModule>("LevelEditor");
+	const TSharedRef<FUICommandList> Commands = LevelEditorModule.GetGlobalLevelEditorActions();
+	Commands->Append(UnrealSharpCommands.ToSharedRef());
 }
 
 void FUnrealSharpEditorModule::RegisterMenu()

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -101,21 +101,31 @@ void FUnrealSharpEditorModule::OnCSharpCodeModified(const TArray<FFileChangeData
 
 	for (const FFileChangeData& ChangedFile : ChangedFiles)
 	{
+		FString NormalizedFileName = ChangedFile.Filename;
+		FPaths::NormalizeFilename(NormalizedFileName);
+		
 		// Skip ProjectGlue files
-		if (ChangedFile.Filename.Contains(TEXT("ProjectGlue")))
+		if (NormalizedFileName.Contains(TEXT("ProjectGlue")))
 		{
 			continue;
 		}
 		
 		// Skip generated files in bin and obj folders
-		if (ChangedFile.Filename.Contains(TEXT("\\bin\\")) || ChangedFile.Filename.Contains(TEXT("\\obj\\")))
+		if (NormalizedFileName.Contains(TEXT("/obj/")))
 		{
 			continue;
 		}
 
-		// Check if the file is a .cs file
-		FString Extension = FPaths::GetExtension(ChangedFile.Filename);
-		if (Extension != "cs")
+		if (Settings->AutomaticHotReloading == OnModuleChange && NormalizedFileName.EndsWith(".dll") && NormalizedFileName.Contains(TEXT("/bin/")))
+		{
+			// A module changed, initiate the reload and return
+			StartHotReload();
+			return;
+		}
+		
+		// Check if the file is a .cs file and not in the bin directory
+		FString Extension = FPaths::GetExtension(NormalizedFileName);
+		if (Extension != "cs" || NormalizedFileName.Contains(TEXT("/bin/")))
 		{
 			continue;
 		}

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -119,7 +119,7 @@ void FUnrealSharpEditorModule::OnCSharpCodeModified(const TArray<FFileChangeData
 		if (Settings->AutomaticHotReloading == OnModuleChange && NormalizedFileName.EndsWith(".dll") && NormalizedFileName.Contains(TEXT("/bin/")))
 		{
 			// A module changed, initiate the reload and return
-			StartHotReload();
+			StartHotReload(false);
 			return;
 		}
 		

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.h
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.h
@@ -29,7 +29,7 @@ public:
     // End
     
     void OnCSharpCodeModified(const TArray<struct FFileChangeData>& ChangedFiles);
-    void StartHotReload();
+    void StartHotReload(bool bRebuild = true);
 
     bool IsHotReloading() const { return HotReloadStatus == Active; }
     bool HasPendingHotReloadChanges() const { return HotReloadStatus == PendingReload; }
@@ -44,6 +44,7 @@ private:
 
     static void OnCreateNewProject();
     static void OnCompileManagedCode();
+    static void OnReloadManagedCode();
     static void OnRegenerateSolution();
     static void OnOpenSolution();
     static void OnPackageProject();


### PR DESCRIPTION
I added a quick functionality that let's users build the modules in their IDEs and then let UnrealSharp only weave and reload the modules instead of building them. This allows me to handle any errors of my code inside my IDE and let UnrealSharp only do the reload work when it's actually needed.

I also added two shortcuts so compiling & reloading can be accessed quickly.

If that change is ok I would also go ahead and implement automatic reloading if the module files changed to complete this additional workflow.