### PR TITLE
Removed now unnecessary array fix

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/PropertyMetaData.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/PropertyMetaData.cs
@@ -14,8 +14,6 @@ public class PropertyMetaData : BaseMetaData
     public string BlueprintSetter { get; set; }
     public string BlueprintGetter { get; set; }
 
-    public bool IsArray => PropertyDataType is NativeDataArrayType || PropertyDataType is NativeDataNativeArrayType;
-
     // Non-serialized for JSON
     public FieldDefinition PropertyOffsetField;
     public FieldDefinition? NativePropertyField;

--- a/Source/UnrealSharpCore/TypeGenerator/Factories/CSPropertyFactory.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Factories/CSPropertyFactory.cpp
@@ -292,11 +292,6 @@ FProperty* FCSPropertyFactory::CreateProperty(UField* Outer, const FCSPropertyMe
 				NewProperty->SetPropertyFlags(CPF_Net | CPF_RepNotify);
 			}
 		}
-
-		if (PropertyMetaData.IsArray)
-		{
-			NewProperty->SetPropertyFlags(NewProperty->PropertyFlags | CPF_ReferenceParm | CPF_OutParm);
-		}
 		
 		FCSMetaDataUtils::ApplyMetaData(PropertyMetaData.MetaData, NewProperty);
 		

--- a/Source/UnrealSharpCore/TypeGenerator/Register/MetaData/CSPropertyMetaData.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Register/MetaData/CSPropertyMetaData.cpp
@@ -10,7 +10,6 @@ void FCSPropertyMetaData:: SerializeFromJson(const TSharedPtr<FJsonObject>& Json
 	
 	JsonObject->TryGetStringField(TEXT("BlueprintGetter"), BlueprintGetter);
 	JsonObject->TryGetStringField(TEXT("BlueprintSetter"), BlueprintSetter);
-	JsonObject->TryGetBoolField(TEXT("IsArray"), IsArray);
 
 	FString RepNotifyFunctionNameStr;
 	if (JsonObject->TryGetStringField(TEXT("RepNotifyFunctionName"), RepNotifyFunctionNameStr))

--- a/Source/UnrealSharpCore/TypeGenerator/Register/MetaData/CSPropertyMetaData.h
+++ b/Source/UnrealSharpCore/TypeGenerator/Register/MetaData/CSPropertyMetaData.h
@@ -15,8 +15,6 @@ struct FCSPropertyMetaData : FCSMemberMetaData
 	FString BlueprintSetter;
 	FString BlueprintGetter;
 
-	bool IsArray = false;
-
 	//FTypeMetaData interface implementation
 	virtual void SerializeFromJson(const TSharedPtr<FJsonObject>& JsonObject) override;
 	//End of implementation


### PR DESCRIPTION
Removed some changes from #147 that are no longer neccessary and gets rid of a warning that Unreal spams in console when using RPCs with arrays.