### PR TITLE
Code Generator fixes

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AsyncWrapperGenerator.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AsyncWrapperGenerator.cs
@@ -60,6 +60,11 @@ public class AsyncWrapperGenerator : ISourceGenerator
                     continue;
                 }
 
+                if (typeSymbol is INamedTypeSymbol nts && nts.IsGenericType)
+                {
+                    namespaces.UnionWith(nts.TypeArguments.Select(t => t.ContainingNamespace.ToDisplayString()));
+                }
+
                 namespaces.Add(typeSymbol.ContainingNamespace.ToDisplayString());
             }
 

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/DelegateBuilder.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/DelegateBuilder.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Text;
 using Microsoft.CodeAnalysis;
 
@@ -31,7 +32,7 @@ public abstract class DelegateBuilder
         else
         {
             stringBuilder.Append($"    protected void Invoker(");
-            stringBuilder.Append(string.Join(", ", delegateSymbol.DelegateInvokeMethod.Parameters.Select(x => $"{x.Type} {x.Name}")));
+            stringBuilder.Append(string.Join(", ", delegateSymbol.DelegateInvokeMethod.Parameters.Select(x => $"{DelegateWrapperGenerator.GetRefKindKeyword(x)}{x.Type} {x.Name}")));
             stringBuilder.Append(")");
             stringBuilder.AppendLine();
         }

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/DelegateWrapperGenerator.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/DelegateGenerator/DelegateWrapperGenerator.cs
@@ -139,20 +139,20 @@ public class DelegateWrapperGenerator : ISourceGenerator
             context.AddSource($"{namespaceName}.{delegateName}.generated.cs", SourceText.From(stringBuilder.ToString(), Encoding.UTF8));
         }
     }
-    
+
     public static void GenerateDelegateExtensionsClass(StringBuilder stringBuilder, INamedTypeSymbol delegateSymbol, string delegateName, DelegateType delegateType)
     {
         stringBuilder.AppendLine($"public static class {delegateName}Extensions");
         stringBuilder.AppendLine("{");
             
         var parametersList = delegateSymbol.DelegateInvokeMethod!.Parameters.ToList();
-            
+
         string args = parametersList.Any()
-            ? string.Join(", ", parametersList.Select(x => $"{(x.RefKind == RefKind.Ref ? "ref " : x.RefKind == RefKind.Out ? "out " : string.Empty)}{x.Type} {x.Name}"))
+            ? string.Join(", ", parametersList.Select(x => $"{GetRefKindKeyword(x)}{x.Type} {x.Name}"))
             : string.Empty;
             
         string parameters = parametersList.Any()
-            ? string.Join(", ", parametersList.Select(x => $"{(x.RefKind == RefKind.Ref ? "ref " : x.RefKind == RefKind.Out ? "out " : string.Empty)}{x.Name}"))
+            ? string.Join(", ", parametersList.Select(x => $"{GetRefKindKeyword(x)}{x.Name}"))
             : string.Empty;
         
         string delegateTypeString = delegateType == DelegateType.Multicast ? "TMulticastDelegate" : "TDelegate";
@@ -162,5 +162,17 @@ public class DelegateWrapperGenerator : ISourceGenerator
         stringBuilder.AppendLine($"         @delegate.InnerDelegate.Invoke({parameters});");
         stringBuilder.AppendLine("     }");
         stringBuilder.AppendLine("}");
+    }
+
+    public static string GetRefKindKeyword(IParameterSymbol x)
+    {
+        return x.RefKind switch
+               {
+                   RefKind.RefReadOnlyParameter => "in ",
+                   RefKind.In => "in ",
+                   RefKind.Ref => "ref ",
+                   RefKind.Out => "out ",
+                   _ => string.Empty
+               };
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/NativeCallbacksWrapperGenerator.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/NativeCallbacksWrapperGenerator.cs
@@ -31,7 +31,7 @@ public class NativeCallbacksWrapperGenerator : ISourceGenerator
             var model = compilation.GetSemanticModel(classInfo.ClassDeclaration.SyntaxTree);
             var sourceBuilder = new StringBuilder();
 
-            List<INamespaceSymbol> namespaces = [];
+            HashSet<string> namespaces = [];
             foreach (var delegateInfo in classInfo.Delegates)
             {
                 foreach (var parameter in delegateInfo.Parameters)
@@ -43,19 +43,19 @@ public class NativeCallbacksWrapperGenerator : ISourceGenerator
                     {
                         continue;
                     }
-                    
-                    if (namespaces.Contains(typeSymbol.ContainingNamespace))
+
+                    if (typeSymbol is INamedTypeSymbol nts && nts.IsGenericType)
                     {
-                        continue;
+                        namespaces.UnionWith(nts.TypeArguments.Select(t => t.ContainingNamespace.ToDisplayString()));
                     }
-                    
-                    namespaces.Add(typeSymbol.ContainingNamespace);
+
+                    namespaces.Add(typeSymbol.ContainingNamespace.ToDisplayString());
                 }
             }
             
             foreach(var ns in namespaces)
             {
-                sourceBuilder.AppendLine($"using {ns.ToDisplayString()};");
+                sourceBuilder.AppendLine($"using {ns};");
             }
             
             sourceBuilder.AppendLine();


### PR DESCRIPTION
-Fix AsyncWrapperGenerator and NativeCallbacksWrapperGenerator do not pick up generic type argument namespaces which will lead to failing compilation of generated code

-Fix delegate parameter could not be passed by ref or in or out when used with TDelegate.
![image](https://github.com/user-attachments/assets/bd97b832-128b-4a63-aeb1-1f4fb6175b97)

