### PR TITLE
-fix #238 #250 reinstancing is not performed on method (UK2Node_CallFunction or UK2Node_CSAsyncAction) nodes.

### DIFF
--- a/Source/UnrealSharpBlueprint/K2Node_CSAsyncAction.h
+++ b/Source/UnrealSharpBlueprint/K2Node_CSAsyncAction.h
@@ -21,14 +21,14 @@ public:
 
 	UK2Node_CSAsyncAction();
 
-	static void SetNodeFunc(UEdGraphNode * NewNode, bool, TWeakObjectPtr<UFunction> FunctionPtr);
+	static void SetNodeFunc(UEdGraphNode* NewNode, bool, TWeakObjectPtr<UFunction> FunctionPtr);
 
-	TObjectPtr<UClass> const & GetProxyClass() const
+	const TObjectPtr<UClass> & GetProxyClass() const
 	{
 		return ProxyClass;
 	};
 
-	FName const & GetFactoryFunctionName() const
+	const FName & GetFactoryFunctionName() const
 	{
 		return ProxyFactoryFunctionName;
 	}

--- a/Source/UnrealSharpBlueprint/K2Node_CSAsyncAction.h
+++ b/Source/UnrealSharpBlueprint/K2Node_CSAsyncAction.h
@@ -13,14 +13,26 @@ class FBlueprintActionDatabaseRegistrar;
 class UObject;
 
 UCLASS()
-class UK2Node_CSAsyncAction : public UK2Node_BaseAsyncTask
+class UNREALSHARPBLUEPRINT_API UK2Node_CSAsyncAction : public UK2Node_BaseAsyncTask
 {
 	GENERATED_BODY()
 
 public:
 
 	UK2Node_CSAsyncAction();
-	
+
+	static void SetNodeFunc(UEdGraphNode * NewNode, bool, TWeakObjectPtr<UFunction> FunctionPtr);
+
+	TObjectPtr<UClass> const & GetProxyClass() const
+	{
+		return ProxyClass;
+	};
+
+	FName const & GetFactoryFunctionName() const
+	{
+		return ProxyFactoryFunctionName;
+	}
+
 	// UK2Node interface
 	virtual void GetMenuActions(FBlueprintActionDatabaseRegistrar& ActionRegistrar) const override;
 	// End of UK2Node interface

--- a/Source/UnrealSharpBlueprint/K2Node_CSCancellableAsyncAction.h
+++ b/Source/UnrealSharpBlueprint/K2Node_CSCancellableAsyncAction.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "K2Node_BaseAsyncTask.h"
+#include "K2Node_CSAsyncAction.h"
 #include "UObject/ObjectMacros.h"
 #include "UObject/UObjectGlobals.h"
 
@@ -13,7 +13,7 @@ class FBlueprintActionDatabaseRegistrar;
 class UObject;
 
 UCLASS()
-class UK2Node_CSCancellableAsyncAction : public UK2Node_BaseAsyncTask
+class UK2Node_CSCancellableAsyncAction : public UK2Node_CSAsyncAction
 {
 	GENERATED_BODY()
 

--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
@@ -1,5 +1,8 @@
 ﻿#pragma once
 
+class UK2Node_BaseAsyncTask;
+class UK2Node_CSAsyncAction;
+class UK2Node_CallFunction;
 class FCSReload;
 class UClass;
 
@@ -28,14 +31,17 @@ public:
 
 	void UpdateBlueprints();
 	
-	bool TryUpdatePin(FEdGraphPinType& PinType);
+	bool TryUpdatePin(FEdGraphPinType& PinType) const;
 
 	static void GetTablesDependentOnStruct(UScriptStruct* Struct, TArray<UDataTable*>& DataTables);
 
 	friend FCSReload;
 
 private:
-	
+	UFunction * FindMatchingMember(FMemberReference const & functionReference) const;
+	bool UpdateMemberCall(UK2Node_CallFunction * node) const;
+	bool UpdateMemberCall(UK2Node_CSAsyncAction * node) const;
+
 	// Pending classes/interfaces to reinstance
 	TMap<UClass*, UClass*> ClassesToReinstance;
 

--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
@@ -1,6 +1,5 @@
 ﻿#pragma once
 
-class UK2Node_BaseAsyncTask;
 class UK2Node_CSAsyncAction;
 class UK2Node_CallFunction;
 class FCSReload;
@@ -38,9 +37,9 @@ public:
 	friend FCSReload;
 
 private:
-	UFunction * FindMatchingMember(FMemberReference const & functionReference) const;
-	bool UpdateMemberCall(UK2Node_CallFunction * node) const;
-	bool UpdateMemberCall(UK2Node_CSAsyncAction * node) const;
+	UFunction* FindMatchingMember(const FMemberReference& FunctionReference) const;
+	bool UpdateMemberCall(UK2Node_CallFunction* Node) const;
+	bool UpdateMemberCall(UK2Node_CSAsyncAction* Node) const;
 
 	// Pending classes/interfaces to reinstance
 	TMap<UClass*, UClass*> ClassesToReinstance;

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.Build.cs
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.Build.cs
@@ -32,7 +32,8 @@ public class UnrealSharpEditor : ModuleRules
                 "EditorStyle", 
                 "Projects",
                 "GameplayTags",
-                "DeveloperSettings"
+                "DeveloperSettings",
+                "UnrealSharpBlueprint"
             }
         );
     }


### PR DESCRIPTION
-properly reconstruct methods and async methods on c# recompile reload. this will also now pick up any changes to signatures and prevent blueprints from breaking since they reference their old types.

![image](https://github.com/user-attachments/assets/3c92521e-76d5-44c8-8040-d91d35836036)

![image](https://github.com/user-attachments/assets/269ba712-f851-4818-8284-58d2442d007a)

will fix #238 and #250