### PR TITLE
fix #250: BP skeleton updates where not performed on BP's using u# types (i.e. as function parameters or variables)

### DIFF
--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
@@ -1,6 +1,8 @@
 ﻿#include "CSReinstancer.h"
 #include "BlueprintActionDatabase.h"
+#include "BlueprintCompilationManager.h"
 #include "K2Node_CallFunction.h"
+#include "K2Node_DynamicCast.h"
 #include "K2Node_StructOperation.h"
 #include "AssetRegistry/AssetRegistryModule.h"
 #include "UnrealSharpCore/TypeGenerator/Register/CSTypeRegistry.h"
@@ -100,6 +102,9 @@ void FCSReinstancer::StartReinstancing()
 	NotifyChanges(InterfacesToReinstance);
 	NotifyChanges(StructsToReinstance);
 	NotifyChanges(ClassesToReinstance);
+
+	FBlueprintCompilationManager::ReparentHierarchies(InterfacesToReinstance);
+	FBlueprintCompilationManager::ReparentHierarchies(ClassesToReinstance);
 
 	// Before we reinstance, we want the BP to know about the new types
 	UpdateBlueprints();
@@ -310,6 +315,14 @@ void FCSReinstancer::UpdateBlueprints()
 				if (UScriptStruct* const * FoundNewStructType = StructsToReinstance.Find(StructOperation->StructType))
 				{
 					StructOperation->StructType = *FoundNewStructType;
+					bNeedsNodeReconstruction = true;
+				}
+			}
+			else if (UK2Node_DynamicCast* Node_DynamicCast = Cast<UK2Node_DynamicCast>(Node))
+			{
+				if (UClass* const * FoundNewStructType = ClassesToReinstance.Find(Node_DynamicCast->TargetType))
+				{
+					Node_DynamicCast->TargetType = *FoundNewStructType;	
 					bNeedsNodeReconstruction = true;
 				}
 			}

--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
@@ -40,6 +40,8 @@ private:
 	UFunction* FindMatchingMember(const FMemberReference& FunctionReference) const;
 	bool UpdateMemberCall(UK2Node_CallFunction* Node) const;
 	bool UpdateMemberCall(UK2Node_CSAsyncAction* Node) const;
+	void UpdateInheritance(UBlueprint* Blueprint, bool& RefNeedsNodeReconstruction) const;
+	void UpdateNodePinTypes(UEdGraphNode* Node, bool& RefNeedsNodeReconstruction) const;
 
 	// Pending classes/interfaces to reinstance
 	TMap<UClass*, UClass*> ClassesToReinstance;

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.Build.cs
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.Build.cs
@@ -33,7 +33,8 @@ public class UnrealSharpEditor : ModuleRules
                 "Projects",
                 "GameplayTags",
                 "DeveloperSettings",
-                "UnrealSharpBlueprint"
+                "UnrealSharpBlueprint",
+                "Kismet"
             }
         );
     }


### PR DESCRIPTION
-replace more remaining data in BPS to update for reinstancing. also unreals api is used to trigger skeleton updates and changed events so recompilation will trigger like it would with c++  class changes.

![FunctionOnBpTest](https://github.com/user-attachments/assets/66b55d13-f5a3-44fe-b390-60ebc47f6eb3)
This is solving the case shown above. Using a BP class not inheriting from c# with a function using a struct from c# in its parameters and the BP will use a variable of type of the c# struct too,  