### PR TITLE
U# project referencing

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Plugins/Main.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/Main.cs
@@ -15,9 +15,6 @@ public unsafe struct PluginsCallbacks
 public static class Main
 {
     private static readonly Assembly CoreApiAssembly = typeof(UnrealSharpObject).Assembly;
-    private static readonly List<PluginLoadContextWrapper> LoadedPlugins = [];
-    private static readonly List<AssemblyName> SharedAssemblies = [];
-    private static readonly AssemblyLoadContext MainLoadContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ?? AssemblyLoadContext.Default;
     private static DllImportResolver? _dllImportResolver;
     
     // This is for advanced use ony. Any hard references at the wrong time will break unloading.

--- a/Managed/UnrealSharp/UnrealSharp.Plugins/Main.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/Main.cs
@@ -20,39 +20,6 @@ public static class Main
     private static readonly AssemblyLoadContext MainLoadContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ?? AssemblyLoadContext.Default;
     private static DllImportResolver? _dllImportResolver;
     
-    private sealed class PluginLoadContextWrapper
-    {
-        private PluginLoadContext? _pluginLoadContext;
-
-        private PluginLoadContextWrapper(PluginLoadContext pluginLoadContext, Assembly assembly)
-        {
-            _pluginLoadContext = pluginLoadContext;
-            Assembly = new WeakReference<Assembly>(assembly);
-        }
-
-        public string? AssemblyLoadedPath => _pluginLoadContext?.AssemblyLoadedPath;
-        public bool IsCollectible => _pluginLoadContext?.IsCollectible ?? true;
-        public bool IsAlive => _pluginLoadContext != null;
-        
-        // Be careful using this. Any hard reference at the wrong time will prevent the plugin from being unloaded.
-        // Thus breaking hot reloading.
-        public WeakReference<Assembly> Assembly { get; }
-
-        public static (Assembly, PluginLoadContextWrapper) CreateAndLoadFromAssemblyName(AssemblyName assemblyName, string pluginPath, ICollection<string> sharedAssemblies, AssemblyLoadContext mainLoadContext, bool isCollectible)
-        {
-            PluginLoadContext context = new PluginLoadContext(pluginPath, sharedAssemblies, mainLoadContext, isCollectible);
-            Assembly assembly = context.LoadFromAssemblyName(assemblyName);
-            PluginLoadContextWrapper wrapper = new PluginLoadContextWrapper(context, assembly);
-            return (assembly, wrapper);
-        }
-        
-        internal void Unload()
-        {
-            _pluginLoadContext?.Unload();
-            _pluginLoadContext = null;
-        }
-    }
-    
     // This is for advanced use ony. Any hard references at the wrong time will break unloading.
     public static Assembly? LoadPlugin(string assemblyPath, bool isCollectible, bool shouldRemoveExtension = true)
     {
@@ -60,7 +27,7 @@ public static class Main
         {
             string assemblyName = shouldRemoveExtension ? Path.GetFileNameWithoutExtension(assemblyPath) : assemblyPath;
             
-            foreach (var plugin in LoadedPlugins)
+            foreach (var plugin in PluginsInfo.LoadedPlugins)
             {
                 if (plugin.AssemblyLoadedPath != assemblyPath)
                 {
@@ -72,7 +39,7 @@ public static class Main
             }
             
             var sharedAssemblies = new List<string>();
-            foreach (var sharedAssembly in SharedAssemblies)
+            foreach (var sharedAssembly in PluginsInfo.SharedAssemblies)
             {
                 string? sharedAssemblyName = sharedAssembly.Name;
                 if (sharedAssemblyName != null)
@@ -81,14 +48,14 @@ public static class Main
                 }
             }
         
-            var (loadedAssembly, newPlugin) = PluginLoadContextWrapper.CreateAndLoadFromAssemblyName(new AssemblyName(assemblyName), assemblyPath, sharedAssemblies, MainLoadContext, isCollectible);
+            var (loadedAssembly, newPlugin) = PluginLoadContextWrapper.CreateAndLoadFromAssemblyName(new AssemblyName(assemblyName), assemblyPath, sharedAssemblies, isCollectible);
 
             if (!newPlugin.IsAlive)
             {
                 throw new Exception($"Failed to load plugin from: {assemblyPath}");
             }
         
-            LoadedPlugins.Add(newPlugin);
+            PluginsInfo.LoadedPlugins.Add(newPlugin);
             Console.WriteLine($"Successfully loaded plugin: {assemblyName}");
 
             return loadedAssembly;
@@ -103,7 +70,7 @@ public static class Main
     // This is for advanced use ony. Any hard references at the wrong time will break unloading.
     public static bool UnloadPlugin(string assemblyPath)
     {
-        foreach (var plugin in LoadedPlugins)
+        foreach (var plugin in PluginsInfo.LoadedPlugins)
         {
             if (plugin.AssemblyLoadedPath != assemblyPath)
             {
@@ -149,7 +116,7 @@ public static class Main
                     }
                 }
 
-                LoadedPlugins.Remove(plugin);
+                PluginsInfo.LoadedPlugins.Remove(plugin);
                 Console.WriteLine($"{assemblyName} unloaded successfully!");
                 return true;
             }
@@ -215,7 +182,7 @@ public static class Main
     private static void SetupDllImportResolver(IntPtr assemblyPathPtr)
     {
         _dllImportResolver = new UnrealSharpDllImportResolver(assemblyPathPtr).OnResolveDllImport;
-        SharedAssemblies.Add(CoreApiAssembly.GetName());
+        PluginsInfo.SharedAssemblies.Add(CoreApiAssembly.GetName());
         NativeLibrary.SetDllImportResolver(CoreApiAssembly, _dllImportResolver);
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoadContextWrapper.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoadContextWrapper.cs
@@ -1,0 +1,38 @@
+﻿using System.Reflection;
+
+namespace UnrealSharp.Plugins;
+
+internal class PluginLoadContextWrapper
+{
+    private PluginLoadContext? _pluginLoadContext;
+
+    private PluginLoadContextWrapper(PluginLoadContext pluginLoadContext, Assembly assembly)
+    {
+        _pluginLoadContext = pluginLoadContext;
+        AssemblyFullName = assembly.FullName;
+        Assembly = new WeakReference<Assembly>(assembly);
+    }
+
+    public string? AssemblyLoadedPath => _pluginLoadContext?.AssemblyLoadedPath;
+    public bool IsCollectible => _pluginLoadContext?.IsCollectible ?? true;
+    public bool IsAlive => _pluginLoadContext != null;
+    public string? AssemblyFullName { get; private set; }
+        
+    // Be careful using this. Any hard reference at the wrong time will prevent the plugin from being unloaded.
+    // Thus breaking hot reloading.
+    public WeakReference<Assembly> Assembly { get; }
+
+    public static (Assembly, PluginLoadContextWrapper) CreateAndLoadFromAssemblyName(AssemblyName assemblyName, string pluginPath, ICollection<string> sharedAssemblies, bool isCollectible)
+    {
+        PluginLoadContext context = new PluginLoadContext(pluginPath, sharedAssemblies, isCollectible);
+        Assembly assembly = context.LoadFromAssemblyName(assemblyName);
+        PluginLoadContextWrapper wrapper = new PluginLoadContextWrapper(context, assembly);
+        return (assembly, wrapper);
+    }
+        
+    internal void Unload()
+    {
+        _pluginLoadContext?.Unload();
+        _pluginLoadContext = null;
+    }
+}

--- a/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoader.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoader.cs
@@ -3,19 +3,17 @@ using System.Runtime.Loader;
 
 namespace UnrealSharp.Plugins
 {
-    public class PluginLoadContext : AssemblyLoadContext
+    internal class PluginLoadContext : AssemblyLoadContext
     {
         private readonly AssemblyDependencyResolver _resolver;
         private readonly ICollection<string> _sharedAssemblies;
-        private readonly AssemblyLoadContext _mainLoadContext;
 
         public string? AssemblyLoadedPath { get; private set; }
 
-        public PluginLoadContext(string pluginPath, ICollection<string> sharedAssemblies, AssemblyLoadContext mainLoadContext, bool isCollectible) : base(isCollectible)
+        public PluginLoadContext(string pluginPath, ICollection<string> sharedAssemblies, bool isCollectible) : base(isCollectible)
         {
             _resolver = new AssemblyDependencyResolver(pluginPath);
             _sharedAssemblies = sharedAssemblies;
-            _mainLoadContext = mainLoadContext;
             AssemblyLoadedPath = pluginPath;
 
             if (!string.IsNullOrEmpty(AppContext.BaseDirectory))
@@ -49,7 +47,14 @@ namespace UnrealSharp.Plugins
             
             if (_sharedAssemblies.Contains(assemblyName.Name))
             {
-                return _mainLoadContext.LoadFromAssemblyName(assemblyName);
+                return PluginsInfo.MainLoadContext.LoadFromAssemblyName(assemblyName);
+            }
+            
+            //check if assembly already loaded in another plugin
+            var loadedPlugin = PluginsInfo.LoadedPlugins.FirstOrDefault(x => x.AssemblyFullName == assemblyName.FullName);
+            if (loadedPlugin is not null)
+            {
+                return loadedPlugin.Assembly.TryGetTarget(out var pluginAssembly) ? pluginAssembly : null;
             }
 
             string? assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
@@ -75,12 +80,7 @@ namespace UnrealSharp.Plugins
         {
             string? libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
             
-            if (libraryPath != null)
-            {
-                return LoadUnmanagedDllFromPath(libraryPath);
-            }
-            
-            return IntPtr.Zero;
+            return libraryPath != null ? LoadUnmanagedDllFromPath(libraryPath) : IntPtr.Zero;
         }
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp.Plugins/PluginsInfo.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/PluginsInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+using System.Runtime.Loader;
+
+namespace UnrealSharp.Plugins;
+
+internal static class PluginsInfo
+{
+    public static readonly List<PluginLoadContextWrapper> LoadedPlugins = [];
+    public static readonly List<AssemblyName> SharedAssemblies = [];
+    public static readonly AssemblyLoadContext MainLoadContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly()) ?? AssemblyLoadContext.Default;
+}

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/UnrealSharpMetadata.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/UnrealSharpMetadata.cs
@@ -1,0 +1,6 @@
+﻿namespace UnrealSharpWeaver.MetaData;
+
+public class UnrealSharpMetadata
+{
+    public ICollection<string> AssemblyLoadingOrder { get; set; } = [];
+}

--- a/Source/UnrealSharpProcHelper/CSProcHelper.h
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.h
@@ -38,6 +38,11 @@ public:
 	// Path to the directory where we store the user's assembly after it has been processed by the weaver.
 	static FString GetUserAssemblyDirectory();
 
+	// Path to file with UnrealSharp metadata
+	static FString GetUnrealSharpMetadataPath();
+
+	static void GetUserProjectNames(TArray<FString>& UserProjectNames);
+
 	//Path to all use assemblies in the Binaries/managed directory
 	static void GetAllUserAssemblyPaths(TArray<FString>& AssemblyPaths);
 

--- a/Source/UnrealSharpProcHelper/UnrealSharpProcHelper.Build.cs
+++ b/Source/UnrealSharpProcHelper/UnrealSharpProcHelper.Build.cs
@@ -20,7 +20,8 @@ public class UnrealSharpProcHelper : ModuleRules
                 "Engine",
                 "Slate",
                 "SlateCore", 
-                "Projects"
+                "Projects",
+                "Json"
             }
         );
     }


### PR DESCRIPTION
Added support for U# project referencing.
Algorithm:
1. UnrealSharpWeaver order all user assembly by U# dependencies.
2. Create file UnrealSharp.metadata.json with loading order

Example:
```
{"AssemblyLoadingOrder":["SubSubProject","SubProject2","SubProject","Core"]}
```
3. U# plugin read this info and load assembly with their metadata in correct order.

Example:

1. TestController:
![TestControllerCode](https://github.com/user-attachments/assets/d7e9192c-a77e-400f-9857-58b84e6854c8)

3. TestComponent:
![TestComponentCode](https://github.com/user-attachments/assets/cff00cf9-1a60-49f5-a102-2a12d554a256)


Result:
![TestController](https://github.com/user-attachments/assets/bc586243-1a40-4319-ba56-449448e42ada)

![TestComponent](https://github.com/user-attachments/assets/a458ea0d-59ae-4b49-81b8-c94f10c8f1fb)

I'm not sure of the correct implementation, but in my tests everything work fine.