### PR TITLE
Fixed 5.5 error requiring TObjectPtr

### DIFF
--- a/Source/UnrealSharpCore/CSManager.h
+++ b/Source/UnrealSharpCore/CSManager.h
@@ -62,10 +62,10 @@ private:
 	static UCSManager* Instance;
 
 	UPROPERTY()
-	UPackage* UnrealSharpPackage;
+	TObjectPtr<UPackage> UnrealSharpPackage;
 
 	UPROPERTY()
-	UObject* CurrentWorldContext;
+	TObjectPtr<UObject> CurrentWorldContext;
 
 	TMap<const UObjectBase*, FGCHandle> UnmanagedToManagedMap;
 	TMap<FName, TSharedPtr<FCSAssembly>> LoadedPlugins;


### PR DESCRIPTION
Was getting an error within CSManager stating the raw pointers needed to be converted to TObjectPtr<>