### PR TITLE
Adding more re instancing code for known collection types (map, array or set)

### DIFF
--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
@@ -66,6 +66,39 @@ bool FCSReinstancer::TryUpdatePin(FEdGraphPinType& PinType) const
 			return true;
 		}
 	}
+	else if (PinType.IsMap())
+	{
+		bool bChanged = false;
+		{
+			UScriptStruct* Struct = Cast<UScriptStruct>(PinSubCategoryObject);
+			if (UScriptStruct* const * FoundStruct = StructsToReinstance.Find(Struct))
+			{
+				PinType.PinSubCategoryObject = *FoundStruct;
+				bChanged = true;
+			}
+		}
+		
+		UObject* MapValueType = PinType.PinValueType.TerminalSubCategoryObject.Get();
+		if (UScriptStruct* Struct = Cast<UScriptStruct>(MapValueType))
+		{
+			if (UScriptStruct* const * FoundStruct = StructsToReinstance.Find(Struct))
+			{
+				PinType.PinValueType.TerminalSubCategoryObject = *FoundStruct;
+				bChanged = true;
+			}
+		}
+
+		return bChanged;
+	}
+	else if (PinType.IsSet() || PinType.IsArray() && (PinType.PinCategory != UEdGraphSchema_K2::PC_Wildcard))
+	{
+		UScriptStruct* Struct = Cast<UScriptStruct>(PinSubCategoryObject);
+		if (UScriptStruct* const * FoundStruct = StructsToReinstance.Find(Struct))
+		{
+			PinType.PinSubCategoryObject = *FoundStruct;
+			return  true;
+		}
+	}
 	else if (PinType.PinSubCategory == UEdGraphSchema_K2::PC_Class
 		|| PinType.PinSubCategory == UEdGraphSchema_K2::PC_Object
 		|| PinType.PinSubCategory == UEdGraphSchema_K2::PC_SoftObject

--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
@@ -90,7 +90,7 @@ bool FCSReinstancer::TryUpdatePin(FEdGraphPinType& PinType) const
 
 		return bChanged;
 	}
-	else if (PinType.IsSet() || PinType.IsArray() && (PinType.PinCategory != UEdGraphSchema_K2::PC_Wildcard))
+	else if (PinType.IsSet() || PinType.IsArray())
 	{
 		UScriptStruct* Struct = Cast<UScriptStruct>(PinSubCategoryObject);
 		if (UScriptStruct* const * FoundStruct = StructsToReinstance.Find(Struct))


### PR DESCRIPTION
-additional missing reinstancing code to support hot reload using u# types
-fix map, array, and set types
-fix interface function overloads which work with func refs:
![image](https://github.com/user-attachments/assets/c2a9d1fd-cf69-41bd-90ce-55cd6fcd3c7c)
