### PR TITLE
[BUG, DEADLOCK] fix build tool may deadlock on reading weaver output and error streams in sequence

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/BuildToolProcess.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/BuildToolProcess.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Text;
 
 namespace UnrealSharpBuildTool;
 
@@ -34,8 +35,19 @@ public class BuildToolProcess : Process
                 throw new Exception("Failed to start process");
             }
             WriteOutProcess();
-            
-            string output = StandardOutput.ReadToEnd();
+
+            https://learn.microsoft.com/de-de/dotnet/api/system.diagnostics.process.standardoutput?view=net-8.0
+            StringBuilder output = new();
+            this.OutputDataReceived += (sender, args) =>
+            {
+                if (args.Data != null)
+                {
+                    output.AppendLine(args.Data);
+                }
+            };
+            // To avoid deadlocks, use an asynchronous read operation on at least one of the streams.
+            BeginOutputReadLine();
+
             string error = StandardError.ReadToEnd();
             
             WaitForExit();

--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -41,6 +41,7 @@ bool FCSProcHelper::InvokeCommand(const FString& ProgramPath, const FString& Arg
 	while (FPlatformProcess::IsProcRunning(ProcHandle))
 	{
 		Output += FPlatformProcess::ReadPipe(ReadPipe);
+		FPlatformProcess::Sleep(0.1f);
 	}
 
 	FPlatformProcess::GetProcReturnCode(ProcHandle, &OutReturnCode);


### PR DESCRIPTION
this is when the weaver will run into errors. this is then deadlocking unreal during c# compilation.
also give UE thread a little rest time while waiting for recompilation process output

