### PR TITLE
fix #298 -fix UCSWorldSubsystem crash when it was not initialized but…

### DIFF
--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.h
@@ -19,8 +19,11 @@ class UCSWorldSubsystem : public UTickableWorldSubsystem
   
 	virtual void Deinitialize() override
 	{
-		Super::Deinitialize();
-		K2_Deinitialize();
+		if (IsInitialized())
+		{
+			Super::Deinitialize();
+			K2_Deinitialize();
+		}
 	}
   
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override


### PR DESCRIPTION
… scheduled for deinitialize after a hot reload is performed. this crash will then happen on a level change or other actions.

fix #298 