### PR TITLE
Fixed issue causing C# C4429 warning due to folder names starting with a lowercase 'u' in the directory

### DIFF
--- a/Source/UnrealSharpCore/UnrealSharpCore.Build.cs
+++ b/Source/UnrealSharpCore/UnrealSharpCore.Build.cs
@@ -16,8 +16,8 @@ public class UnrealSharpCore : ModuleRules
 		_managedBinariesPath = Path.Combine(PluginDirectory, "Binaries", "Managed");
 		_engineGluePath = Path.Combine(_managedPath, "UnrealSharp", "UnrealSharp", "Generated");
 		
-		PublicDefinitions.Add("GENERATED_GLUE_PATH=" + _engineGluePath);
-		PublicDefinitions.Add("PLUGIN_PATH=" + PluginDirectory);
+		PublicDefinitions.Add("GENERATED_GLUE_PATH=" + _engineGluePath.Replace("\\","/"));
+		PublicDefinitions.Add("PLUGIN_PATH=" + PluginDirectory.Replace("\\","/"));
 		PublicDefinitions.Add("BUILDING_EDITOR=" + (Target.bBuildEditor ? "1" : "0"));
 		
 		PublicDependencyModuleNames.AddRange(


### PR DESCRIPTION
Fixed issue causing C# C4429 warning due to folder names starting with a lowercase 'u' in the directory