### PR TITLE
Check for missing launchSettings.json in C# project files during UE startup and add it if absent.

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildWeave.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildWeave.cs
@@ -1,6 +1,4 @@
-﻿using Newtonsoft.Json;
-
-namespace UnrealSharpBuildTool.Actions;
+﻿namespace UnrealSharpBuildTool.Actions;
 
 public class BuildWeave : BuildToolAction
 {
@@ -12,12 +10,8 @@ public class BuildWeave : BuildToolAction
     } 
     bool AddLaunchSettings()
     {
-        DirectoryInfo scriptFolder = new DirectoryInfo(Program.GetScriptFolder());
-        FileInfo[] csprojFiles = scriptFolder.GetFiles("*.csproj", SearchOption.AllDirectories);
-        FileInfo[] fsprojFiles = scriptFolder.GetFiles("*.fsproj", SearchOption.AllDirectories);
-        List<FileInfo> allProjectFiles = new List<FileInfo>(csprojFiles.Length + fsprojFiles.Length);
-        allProjectFiles.AddRange(csprojFiles);
-        allProjectFiles.AddRange(fsprojFiles);
+        List<FileInfo> allProjectFiles = Program.GetAllProjectFiles(new DirectoryInfo(Program.GetScriptFolder()));
+
         foreach (FileInfo projectFile in allProjectFiles)
         {
             if (projectFile.Directory.Name == "ProjectGlue")
@@ -27,53 +21,17 @@ public class BuildWeave : BuildToolAction
             string csProjectPath = Path.Combine(Program.GetScriptFolder(), projectFile.Directory.Name);
             string propertiesDirectoryPath = Path.Combine(csProjectPath, "Properties");
             string launchSettingsPath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");
-
             if (!Directory.Exists(propertiesDirectoryPath))
             {
                 Directory.CreateDirectory(propertiesDirectoryPath);
             }
-        
             if (File.Exists(launchSettingsPath))
             {
                 return true;
             }
-        
-            CreateOrUpdateLaunchSettings(launchSettingsPath);
+            Program.CreateOrUpdateLaunchSettings(launchSettingsPath);
         }
         return true;
     }
     
-    void CreateOrUpdateLaunchSettings(string launchSettingsPath)
-    {
-        Root root = new Root();
-
-        string executablePath = string.Empty;
-        if (OperatingSystem.IsWindows())
-        {
-            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Win64", "UnrealEditor.exe");
-        }
-        else if (OperatingSystem.IsMacOS())
-        {
-            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Mac", "UnrealEditor");
-        }
-        string commandLineArgs = Program.FixPath(Program.GetUProjectFilePath());
-        
-        // Create a new profile if it doesn't exist
-        if (root.Profiles == null)
-        {
-            root.Profiles = new Profiles();
-        }
-            
-        root.Profiles.ProfileName = new Profile
-        {
-            CommandName = "Executable",
-            ExecutablePath = executablePath,
-            CommandLineArgs = $"\"{commandLineArgs}\"",
-        };
-        
-        string newJsonString = JsonConvert.SerializeObject(root, Newtonsoft.Json.Formatting.Indented);
-        StreamWriter writer = File.CreateText(launchSettingsPath);
-        writer.Write(newJsonString);
-        writer.Close();
-    }
 }

--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildWeave.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildWeave.cs
@@ -1,4 +1,6 @@
-﻿namespace UnrealSharpBuildTool.Actions;
+﻿using Newtonsoft.Json;
+
+namespace UnrealSharpBuildTool.Actions;
 
 public class BuildWeave : BuildToolAction
 {
@@ -6,6 +8,72 @@ public class BuildWeave : BuildToolAction
     {
         BuildSolution buildSolution = new BuildUserSolution();
         WeaveProject weaveProject = new WeaveProject();
-        return buildSolution.RunAction() && weaveProject.RunAction();
+        return buildSolution.RunAction() && weaveProject.RunAction() && AddLaunchSettings();
+    } 
+    bool AddLaunchSettings()
+    {
+        DirectoryInfo scriptFolder = new DirectoryInfo(Program.GetScriptFolder());
+        FileInfo[] csprojFiles = scriptFolder.GetFiles("*.csproj", SearchOption.AllDirectories);
+        FileInfo[] fsprojFiles = scriptFolder.GetFiles("*.fsproj", SearchOption.AllDirectories);
+        List<FileInfo> allProjectFiles = new List<FileInfo>(csprojFiles.Length + fsprojFiles.Length);
+        allProjectFiles.AddRange(csprojFiles);
+        allProjectFiles.AddRange(fsprojFiles);
+        foreach (FileInfo projectFile in allProjectFiles)
+        {
+            if (projectFile.Directory.Name == "ProjectGlue")
+            {
+                continue;
+            }
+            string csProjectPath = Path.Combine(Program.GetScriptFolder(), projectFile.Directory.Name);
+            string propertiesDirectoryPath = Path.Combine(csProjectPath, "Properties");
+            string launchSettingsPath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");
+
+            if (!Directory.Exists(propertiesDirectoryPath))
+            {
+                Directory.CreateDirectory(propertiesDirectoryPath);
+            }
+        
+            if (File.Exists(launchSettingsPath))
+            {
+                return true;
+            }
+        
+            CreateOrUpdateLaunchSettings(launchSettingsPath);
+        }
+        return true;
+    }
+    
+    void CreateOrUpdateLaunchSettings(string launchSettingsPath)
+    {
+        Root root = new Root();
+
+        string executablePath = string.Empty;
+        if (OperatingSystem.IsWindows())
+        {
+            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Win64", "UnrealEditor.exe");
+        }
+        else if (OperatingSystem.IsMacOS())
+        {
+            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Mac", "UnrealEditor");
+        }
+        string commandLineArgs = Program.FixPath(Program.GetUProjectFilePath());
+        
+        // Create a new profile if it doesn't exist
+        if (root.Profiles == null)
+        {
+            root.Profiles = new Profiles();
+        }
+            
+        root.Profiles.ProfileName = new Profile
+        {
+            CommandName = "Executable",
+            ExecutablePath = executablePath,
+            CommandLineArgs = $"\"{commandLineArgs}\"",
+        };
+        
+        string newJsonString = JsonConvert.SerializeObject(root, Newtonsoft.Json.Formatting.Indented);
+        StreamWriter writer = File.CreateText(launchSettingsPath);
+        writer.Write(newJsonString);
+        writer.Close();
     }
 }

--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateProject.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateProject.cs
@@ -239,41 +239,7 @@ public class GenerateProject : BuildToolAction
             return;
         }
         
-        CreateOrUpdateLaunchSettings(launchSettingsPath);
-    }
-    
-    void CreateOrUpdateLaunchSettings(string launchSettingsPath)
-    {
-        Root root = new Root();
-
-        string executablePath = string.Empty;
-        if (OperatingSystem.IsWindows())
-        {
-            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Win64", "UnrealEditor.exe");
-        }
-        else if (OperatingSystem.IsMacOS())
-        {
-            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Mac", "UnrealEditor");
-        }
-        string commandLineArgs = Program.FixPath(Program.GetUProjectFilePath());
-        
-        // Create a new profile if it doesn't exist
-        if (root.Profiles == null)
-        {
-            root.Profiles = new Profiles();
-        }
-            
-        root.Profiles.ProfileName = new Profile
-        {
-            CommandName = "Executable",
-            ExecutablePath = executablePath,
-            CommandLineArgs = $"\"{commandLineArgs}\"",
-        };
-        
-        string newJsonString = JsonConvert.SerializeObject(root, Newtonsoft.Json.Formatting.Indented);
-        StreamWriter writer = File.CreateText(launchSettingsPath);
-        writer.Write(newJsonString);
-        writer.Close();
+        Program.CreateOrUpdateLaunchSettings(launchSettingsPath);
     }
 }
 

--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/WeaveProject.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/WeaveProject.cs
@@ -24,18 +24,12 @@ public class WeaveProject : BuildToolAction
     
     private bool Weave(DirectoryInfo scriptFolder, string weaverPath)
     {
-        FileInfo[] csprojFiles = scriptFolder.GetFiles("*.csproj", SearchOption.AllDirectories);
-        FileInfo[] fsprojFiles = scriptFolder.GetFiles("*.fsproj", SearchOption.AllDirectories);
-        
-        if (csprojFiles.Length == 0 && fsprojFiles.Length == 0)
+        List<FileInfo> allProjectFiles = Program.GetAllProjectFiles(scriptFolder);
+        if (allProjectFiles.Count == 0)
         {
             Console.WriteLine("No project files found. Skipping weaving...");
             return true;
         }
-        
-        List<FileInfo> allProjectFiles = new List<FileInfo>(csprojFiles.Length + fsprojFiles.Length);
-        allProjectFiles.AddRange(csprojFiles);
-        allProjectFiles.AddRange(fsprojFiles);
         
         BuildToolProcess weaveProcess = new BuildToolProcess();
         weaveProcess.StartInfo.ArgumentList.Add(weaverPath);


### PR DESCRIPTION
When managing a project with Git, it is necessary to ignore the Properties/launchSettings.json file in all .NET projects within the Script folder because this file stores the absolute paths of Unreal Engine and the project on the local machine. However, the Properties/launchSettings.json file is only generated when a C# project is initially created. Therefore, a mechanism is needed to detect all .NET projects in the Script folder (excluding ProjectGlue) upon each project startup and automatically add the Properties/launchSettings.json file to the ignore list.