### PR TITLE
Defensive code to stop a crash on Reinstancing in Hot-Reload

### DIFF
--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.cpp
@@ -15,6 +15,8 @@
 #include "Serialization/ArchiveReplaceObjectRef.h"
 #include "UnrealSharpBlueprint/K2Node_CSAsyncAction.h"
 
+DEFINE_LOG_CATEGORY(LogUnrealSharpReinstancer);
+
 FCSReinstancer& FCSReinstancer::Get()
 {
 	static FCSReinstancer Instance;
@@ -159,6 +161,13 @@ void FCSReinstancer::StartReinstancing()
 				continue;
 			}
 			
+			if (Old->IsRooted()) 
+			{
+				// something didn't go right
+				UE_LOG(LogUnrealSharpReinstancer, Error, TEXT("Cannot mark %s for GarbageCollection because IsRooted"), *Old->GetName());
+				continue;
+			}
+
 			Old->ClearFlags(RF_Standalone);
 			Old->MarkAsGarbage();
 		}

--- a/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
+++ b/Source/UnrealSharpEditor/Reinstancing/CSReinstancer.h
@@ -1,5 +1,8 @@
 ﻿#pragma once
 
+#include "Logging/LogMacros.h"
+DECLARE_LOG_CATEGORY_EXTERN(LogUnrealSharpReinstancer, Log, All);
+
 class UK2Node_CSAsyncAction;
 class UK2Node_CallFunction;
 class FCSReload;


### PR DESCRIPTION
Defensive code to stop a crash on Hot-Reload when an old object is marked for garbage collection while it is still `IsRooted`
(`Old->MarkAsGarbage()` does an assertion on this and crashes when the check fails)

Will write up an issue to match, since there's likely an underlying issue that caused the bad state, but this helps stop the editor from crashing, adds some logging on which object has the problem, and let's you continue.