### PR TITLE
Remove world context object

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
@@ -208,7 +208,7 @@ public partial class UObject
     /// <returns> The spawned actor. </returns>
     public T SpawnActor<T>(FTransform spawnTransform, TSubclassOf<T> actorType, FCSSpawnActorParameters spawnParameters) where T : AActor
     {
-        return (T) UCSWorldExtensions.SpawnActor(this, new TSubclassOf<AActor>(actorType), spawnTransform, spawnParameters);
+        return (T) UCSWorldExtensions.SpawnActor(new TSubclassOf<AActor>(actorType), spawnTransform, spawnParameters);
     }
     
     /// <summary>

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/AssetManager.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/AssetManager.cs
@@ -38,7 +38,7 @@ public partial class UAssetManager
     /// <param name="onLoaded">The callback to execute when the asset is loaded</param>
     public void LoadPrimaryAsset(FPrimaryAssetId primaryAsset, IList<FName> bundles, OnPrimaryAssetLoaded onLoaded)
     {
-        UAsyncActionLoadPrimaryAsset loadPrimaryAsset = UAsyncActionLoadPrimaryAsset.AsyncLoadPrimaryAsset(WorldContextObject, primaryAsset, bundles);
+        UAsyncActionLoadPrimaryAsset loadPrimaryAsset = UAsyncActionLoadPrimaryAsset.AsyncLoadPrimaryAsset(primaryAsset, bundles);
         loadPrimaryAsset.Completed += onLoaded;
         loadPrimaryAsset.Activate();
     }
@@ -65,7 +65,7 @@ public partial class UAssetManager
     /// <param name="onLoaded">The callback to execute when the assets are loaded</param>
     public void LoadPrimaryAssets(IList<FPrimaryAssetId> primaryAssets, IList<FName> bundles, OnPrimaryAssetListLoaded onLoaded)
     {
-        UAsyncActionLoadPrimaryAssetList loadPrimaryAssets = UAsyncActionLoadPrimaryAssetList.AsyncLoadPrimaryAssetList(WorldContextObject, primaryAssets, bundles);
+        UAsyncActionLoadPrimaryAssetList loadPrimaryAssets = UAsyncActionLoadPrimaryAssetList.AsyncLoadPrimaryAssetList(primaryAssets, bundles);
         loadPrimaryAssets.Completed += onLoaded;
         loadPrimaryAssets.Activate();
     }
@@ -92,7 +92,7 @@ public partial class UAssetManager
     /// <param name="onLoaded">The callback to execute when the asset is loaded</param>
     public void LoadPrimaryAssetClass(FPrimaryAssetId primaryAsset, IList<FName> bundles, OnPrimaryAssetClassLoaded onLoaded)
     {
-        UAsyncActionLoadPrimaryAssetClass loadPrimaryAssetClass = UAsyncActionLoadPrimaryAssetClass.AsyncLoadPrimaryAssetClass(WorldContextObject, primaryAsset, bundles);
+        UAsyncActionLoadPrimaryAssetClass loadPrimaryAssetClass = UAsyncActionLoadPrimaryAssetClass.AsyncLoadPrimaryAssetClass(primaryAsset, bundles);
         loadPrimaryAssetClass.Completed += onLoaded;
         loadPrimaryAssetClass.Activate();
     }
@@ -119,7 +119,7 @@ public partial class UAssetManager
     /// <param name="onLoaded">The callback to execute when the classes are loaded</param>
     public void LoadPrimaryAssetClasses(IList<FPrimaryAssetId> primaryAssets, IList<FName> bundles, OnPrimaryAssetClassListLoaded onLoaded)
     {
-        UAsyncActionLoadPrimaryAssetClassList loadPrimaryAssetClasses = UAsyncActionLoadPrimaryAssetClassList.AsyncLoadPrimaryAssetClassList(WorldContextObject, primaryAssets, bundles);
+        UAsyncActionLoadPrimaryAssetClassList loadPrimaryAssetClasses = UAsyncActionLoadPrimaryAssetClassList.AsyncLoadPrimaryAssetClassList(primaryAssets, bundles);
         loadPrimaryAssetClasses.Completed += onLoaded;
         loadPrimaryAssetClasses.Activate();
     }

--- a/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
@@ -85,14 +85,19 @@ public static class BitfieldBoolMarshaller
 
 public static class ObjectMarshaller<T> where T : UnrealSharpObject
 {
-    public static void ToNative(IntPtr nativeBuffer, int arrayIndex, T obj)
+    public static void ToNative(IntPtr nativeBuffer, int arrayIndex, IntPtr nativeObj)
     {
         IntPtr uObjectPosition = nativeBuffer + arrayIndex * IntPtr.Size;
 
         unsafe
         {
-            *(IntPtr*) uObjectPosition = obj?.NativeObject ?? IntPtr.Zero;
+            *(IntPtr*)uObjectPosition = nativeObj;
         }
+    }
+    
+    public static void ToNative(IntPtr nativeBuffer, int arrayIndex, T obj)
+    {
+        ToNative(nativeBuffer, arrayIndex, obj?.NativeObject ?? IntPtr.Zero);
     }
     
     public static T FromNative(IntPtr nativeBuffer, int arrayIndex)

--- a/Source/UnrealSharpCore/Export/FCSManagerExporter.cpp
+++ b/Source/UnrealSharpCore/Export/FCSManagerExporter.cpp
@@ -15,7 +15,8 @@ void* UFCSManagerExporter::FindManagedObject(UObject* Object)
 
 void* UFCSManagerExporter::GetCurrentWorldContext()
 {
-	return FindManagedObject(UCSManager::Get().GetCurrentWorldContext());
+	UObject* WorldContext = UCSManager::Get().GetCurrentWorldContext();
+	return WorldContext;
 }
 
 void* UFCSManagerExporter::GetCurrentWorldPtr()

--- a/Source/UnrealSharpScriptGenerator/Exporters/FunctionExporter.cs
+++ b/Source/UnrealSharpScriptGenerator/Exporters/FunctionExporter.cs
@@ -197,6 +197,11 @@ public class FunctionExporter
             string refQualifier = GetRefQualifier(parameter);
             string parameterName = GetParameterName(parameter);
 
+            if (!translator.ShouldExportParameter)
+            {
+                continue;
+            }
+
             if (_selfParameter == parameter)
             {
                 if (string.IsNullOrEmpty(_paramsStringCall))

--- a/Source/UnrealSharpScriptGenerator/Exporters/FunctionExporter.cs
+++ b/Source/UnrealSharpScriptGenerator/Exporters/FunctionExporter.cs
@@ -197,7 +197,7 @@ public class FunctionExporter
             string refQualifier = GetRefQualifier(parameter);
             string parameterName = GetParameterName(parameter);
 
-            if (!translator.ShouldExportParameter)
+            if (!translator.ShouldBeDeclaredAsParameter)
             {
                 continue;
             }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/ObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/ObjectPropertyTranslator.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using EpicGames.Core;
+﻿using EpicGames.Core;
 using EpicGames.UHT.Types;
 using UnrealSharpScriptGenerator.Utilities;
 

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslator.cs
@@ -26,6 +26,7 @@ public abstract class PropertyTranslator
     public virtual bool SupportsSetter => true;
     public virtual bool ExportDefaultParameter => true;
     public virtual bool CacheProperty => false;
+    public virtual bool ShouldExportParameter => true;
     
     public PropertyTranslator(EPropertyUsageFlags supportedPropertyUsage)
     {

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslator.cs
@@ -26,7 +26,10 @@ public abstract class PropertyTranslator
     public virtual bool SupportsSetter => true;
     public virtual bool ExportDefaultParameter => true;
     public virtual bool CacheProperty => false;
-    public virtual bool ShouldExportParameter => true;
+    
+    // Should this property be declared as a parameter in the function signature? 
+    // A property can support being a parameter but not be declared as one, such as WorldContextObjectPropertyTranslator
+    public virtual bool ShouldBeDeclaredAsParameter => true;
     
     public PropertyTranslator(EPropertyUsageFlags supportedPropertyUsage)
     {

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslatorManager.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslatorManager.cs
@@ -44,10 +44,18 @@ public static class PropertyTranslatorManager
         AddPropertyTranslator(typeof(UhtTextProperty), new TextPropertyTranslator());
         
         AddPropertyTranslator(typeof(UhtWeakObjectPtrProperty), new WeakObjectPropertyTranslator());
-        AddPropertyTranslator(typeof(UhtObjectPropertyBase), new ObjectPropertyTranslator());
-        AddPropertyTranslator(typeof(UhtObjectPtrProperty), new ObjectPropertyTranslator());
-        AddPropertyTranslator(typeof(UhtObjectProperty), new ObjectPropertyTranslator());
-        AddPropertyTranslator(typeof(UhtLazyObjectPtrProperty), new ObjectPropertyTranslator());
+        
+        WorldContextObjectPropertyTranslator worldContextObjectPropertyTranslator = new();
+        AddPropertyTranslator(typeof(UhtObjectPropertyBase), worldContextObjectPropertyTranslator);
+        AddPropertyTranslator(typeof(UhtObjectPtrProperty), worldContextObjectPropertyTranslator);
+        AddPropertyTranslator(typeof(UhtObjectProperty), worldContextObjectPropertyTranslator);
+        AddPropertyTranslator(typeof(UhtLazyObjectPtrProperty), worldContextObjectPropertyTranslator);
+        
+        ObjectPropertyTranslator objectPropertyTranslator = new();
+        AddPropertyTranslator(typeof(UhtObjectPropertyBase), objectPropertyTranslator);
+        AddPropertyTranslator(typeof(UhtObjectPtrProperty), objectPropertyTranslator);
+        AddPropertyTranslator(typeof(UhtObjectProperty), objectPropertyTranslator);
+        AddPropertyTranslator(typeof(UhtLazyObjectPtrProperty), objectPropertyTranslator);
         
         AddPropertyTranslator(typeof(UhtClassProperty), new ClassPropertyTranslator());
         AddPropertyTranslator(typeof(UhtClassPtrProperty), new ClassPropertyTranslator());

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/WorldContextObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/WorldContextObjectPropertyTranslator.cs
@@ -1,0 +1,36 @@
+using EpicGames.UHT.Types;
+using UnrealSharpScriptGenerator.Utilities;
+
+namespace UnrealSharpScriptGenerator.PropertyTranslators;
+
+public class WorldContextObjectPropertyTranslator : ObjectPropertyTranslator
+{
+    public override bool ShouldExportParameter => false;
+
+    public override bool CanExport(UhtProperty property)
+    {
+        if (!base.CanExport(property))
+        {
+            return false;
+        }
+
+        if (property.Outer is not UhtFunction function)
+        {
+            return false;
+        }
+
+        if (property is not UhtObjectProperty objectProperty || objectProperty.Class != Program.Factory.Session.UObject)
+        {
+            return false;
+        }
+
+        string sourceName = property.SourceName;
+        return function.GetMetadata("WorldContext") == sourceName || sourceName is "WorldContextObject" or "WorldContext" or "ContextObject";
+    }
+
+    public override void ExportToNative(GeneratorStringBuilder builder, UhtProperty property, string propertyName, string destinationBuffer,
+        string offset, string source)
+    {
+        builder.AppendLine($"{GetMarshaller(property)}.ToNative(IntPtr.Add({destinationBuffer}, {offset}), 0, FCSManagerExporter.CallGetCurrentWorldContext());");
+    }
+}

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/WorldContextObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/WorldContextObjectPropertyTranslator.cs
@@ -5,7 +5,7 @@ namespace UnrealSharpScriptGenerator.PropertyTranslators;
 
 public class WorldContextObjectPropertyTranslator : ObjectPropertyTranslator
 {
-    public override bool ShouldExportParameter => false;
+    public override bool ShouldBeDeclaredAsParameter => false;
 
     public override bool CanExport(UhtProperty property)
     {
@@ -31,6 +31,6 @@ public class WorldContextObjectPropertyTranslator : ObjectPropertyTranslator
     public override void ExportToNative(GeneratorStringBuilder builder, UhtProperty property, string propertyName, string destinationBuffer,
         string offset, string source)
     {
-        builder.AppendLine($"{GetMarshaller(property)}.ToNative(IntPtr.Add({destinationBuffer}, {offset}), 0, FCSManagerExporter.CallGetCurrentWorldContext());");
+        base.ExportToNative(builder, property, propertyName, destinationBuffer, offset, "FCSManagerExporter.CallGetCurrentWorldContext()");
     }
 }


### PR DESCRIPTION
Removed the need for WorldContextObject (usually you had to type "this") when calling certain static functions, now it automatically defaults to the current world object instead

Before:
```
SystemLibrary.LineTraceByChannel(this, start, end, traceChannel, false, new List<AActor>(), EDrawDebugTrace.None, out FHitResult hit, true);
```

Now:
```
SystemLibrary.LineTraceByChannel(start, end, traceChannel, false, new List<AActor>(), EDrawDebugTrace.None, out FHitResult hit, true);
```