### PR TITLE
Fixes WorldContext not being set during Async

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Interop/AsyncExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/AsyncExporter.cs
@@ -3,6 +3,6 @@
 [NativeCallbacks]
 public static unsafe partial class AsyncExporter
 {
-    public static delegate* unmanaged<int, IntPtr, void> RunOnThread;
+    public static delegate* unmanaged<IntPtr, int, IntPtr, void> RunOnThread;
     public static delegate* unmanaged<int> GetCurrentNamedThread;
 }

--- a/Managed/UnrealSharp/UnrealSharp/UnrealSynchronizationContext.cs
+++ b/Managed/UnrealSharp/UnrealSharp/UnrealSynchronizationContext.cs
@@ -65,6 +65,7 @@ namespace UnrealSharp
         {
             var previousContext = SynchronizationContext.Current;
             var unrealContext = UnrealSynchronizationContext.GetContext(thread);
+            unrealContext.WorldContextObject = FCSManagerExporter.CallGetCurrentWorldContext();
 
             SynchronizationContext.SetSynchronizationContext(unrealContext);
 
@@ -83,6 +84,7 @@ namespace UnrealSharp
         {
             var previousContext = SynchronizationContext.Current;
             var unrealContext = UnrealSynchronizationContext.GetContext(thread);
+            unrealContext.WorldContextObject = FCSManagerExporter.CallGetCurrentWorldContext();
 
             SynchronizationContext.SetSynchronizationContext(unrealContext);
 
@@ -102,6 +104,7 @@ namespace UnrealSharp
         {
             var previousContext = SynchronizationContext.Current;
             var unrealContext = UnrealSynchronizationContext.GetContext(thread);
+            unrealContext.WorldContextObject = FCSManagerExporter.CallGetCurrentWorldContext();
 
             SynchronizationContext.SetSynchronizationContext(unrealContext);
 
@@ -122,6 +125,7 @@ namespace UnrealSharp
         {
             var previousContext = SynchronizationContext.Current;
             var unrealContext = UnrealSynchronizationContext.GetContext(thread);
+            unrealContext.WorldContextObject = FCSManagerExporter.CallGetCurrentWorldContext();
 
             SynchronizationContext.SetSynchronizationContext(unrealContext);
 
@@ -149,10 +153,11 @@ namespace UnrealSharp
             => syncContextCache.GetOrAdd(thread, static thread => new(thread));
 
         public NamedThread Thread = thread;
+        public nint WorldContextObject;
 
         public override void Post(SendOrPostCallback d, object? state)
         {
-            RunOnThread(Thread, () => d(state));
+            RunOnThread(WorldContextObject, Thread, () => d(state));
         }
 
         public override void Send(SendOrPostCallback d, object? state)
@@ -163,7 +168,7 @@ namespace UnrealSharp
                 return;
             }
             var semaphore = new ManualResetEventSlim(initialState: false);
-            RunOnThread(Thread, () =>
+            RunOnThread(WorldContextObject, Thread, () =>
             {
                 d(state);
                 semaphore.Set();
@@ -171,12 +176,12 @@ namespace UnrealSharp
             semaphore.Wait();
         }
 
-        public static void RunOnThread(NamedThread thread, Action callback)
+        public static void RunOnThread(nint worldContextObject, NamedThread thread, Action callback)
         {
             unsafe
             {
                 GCHandle gcHandle = GCHandle.Alloc(callback);
-                AsyncExporter.CallRunOnThread((int)thread, GCHandle.ToIntPtr(gcHandle));
+                AsyncExporter.CallRunOnThread(worldContextObject, (int)thread, GCHandle.ToIntPtr(gcHandle));
             }
         }
     }

--- a/Source/UnrealSharpCore/Export/AsyncExporter.cpp
+++ b/Source/UnrealSharpCore/Export/AsyncExporter.cpp
@@ -8,13 +8,18 @@ void UAsyncExporter::ExportFunctions(FRegisterExportedFunction RegisterExportedF
 	EXPORT_FUNCTION(GetCurrentNamedThread)
 }
 
-void UAsyncExporter::RunOnThread(ENamedThreads::Type Thread, GCHandleIntPtr DelegateHandle)
+void UAsyncExporter::RunOnThread(UObject* WorldContextObject, ENamedThreads::Type Thread, GCHandleIntPtr DelegateHandle)
 {
 	AsyncTask(Thread, [=]()
 	{
+		UCSManager& Manager = UCSManager::Get();
+		Manager.SetCurrentWorldContext(WorldContextObject);
+
 		FGCHandle GCHandle(DelegateHandle);
 		FCSManagedCallbacks::ManagedCallbacks.InvokeDelegate(DelegateHandle);
 		GCHandle.Dispose();
+
+		Manager.SetCurrentWorldContext(nullptr);
 	});
 }
 

--- a/Source/UnrealSharpCore/Export/AsyncExporter.h
+++ b/Source/UnrealSharpCore/Export/AsyncExporter.h
@@ -19,7 +19,7 @@ public:
 
 private:
 	
-	static void RunOnThread(ENamedThreads::Type Thread, GCHandleIntPtr DelegateHandle);
+	static void RunOnThread(UObject* WorldContextObject, ENamedThreads::Type Thread, GCHandleIntPtr DelegateHandle);
 	static int GetCurrentNamedThread();
 	
 };


### PR DESCRIPTION
Async delegates do not have WorldContext set causing errors for anything that requires it, this PR fixes that.