### PR TITLE
Support for DeterminesOutputType automatic generics generation in UFunctions

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/Actor.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/Actor.cs
@@ -89,23 +89,7 @@ public partial class AActor
     /// <returns>The component if added, otherwise null</returns>
     public UActorComponent AddComponentByClass(TSubclassOf<UActorComponent> @class, bool bManualAttachment, FTransform relativeTransform) 
         => AddComponentByClass(@class, bManualAttachment, relativeTransform, deferredFinish: false);
- 
-    /// <summary>
-    /// Tries to get a component by class, will return null if the component is not found.
-    /// </summary>
-    /// <typeparam name="T">The type of the component to get</typeparam>
-    /// <param name="class">The class of the component to get. Can be left null.</param>
-    /// <returns>The component if found, otherwise null</returns>
-    public T? GetComponentByClass<T>(TSubclassOf<UActorComponent>? @class = null) where T : UActorComponent
-    {
-        if (@class == null)
-        {
-            @class = new TSubclassOf<UActorComponent>(typeof(T));
-        }
-        
-        return GetComponentByClass(@class.Value) as T;
-    }
-	    
+ 	    
     /// <summary>
     /// Finish spawning deferred actor with default transform.
     /// </summary>

--- a/Source/UnrealSharpScriptGenerator/Exporters/FunctionExporter.cs
+++ b/Source/UnrealSharpScriptGenerator/Exporters/FunctionExporter.cs
@@ -876,18 +876,18 @@ public class FunctionExporter
         
         attributeBuilder.AddGeneratedTypeAttribute(_function);
 
-        if (_genericParam != null)
+        if (_function.HasMetadata("DeterminesOutputType"))
         {
             attributeBuilder.AddAttribute("UMetaData");
             attributeBuilder.AddArgument($"\"DeterminesOutputType\"");
-            attributeBuilder.AddArgument($"\"{_genericParam.GetParameterName()}\"");
+            attributeBuilder.AddArgument($"\"{_function.GetMetadata("DeterminesOutputType")}\"");
         }
 
-        if (_dynamicOutputParam != null)
+        if (_function.HasMetadata("DynamicOutputParam"))
         {
             attributeBuilder.AddAttribute("UMetaData");
             attributeBuilder.AddArgument($"\"DynamicOutputParam\"");
-            attributeBuilder.AddArgument($"\"{_dynamicOutputParam.GetParameterName()}\"");
+            attributeBuilder.AddArgument($"\"{_function.GetMetadata("DynamicOutputParam")}\"");
         }
 
         attributeBuilder.Finish();

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/BlittableTypePropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/BlittableTypePropertyTranslator.cs
@@ -21,4 +21,6 @@ public class BlittableTypePropertyTranslator : SimpleTypePropertyTranslator
         string defaultValueString = ConvertCPPDefaultValue(defaultValue, function, paramProperty);
         builder.AppendLine($"{ManagedType} {variableName} = {defaultValueString};");
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/ClassPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/ClassPropertyTranslator.cs
@@ -12,8 +12,14 @@ public class ClassPropertyTranslator : SimpleTypePropertyTranslator
 
     public override string GetManagedType(UhtProperty property)
     {
-        UhtClassProperty classProperty = (UhtClassProperty) property;
+        UhtClassProperty classProperty = (UhtClassProperty)property;
         string fullName = classProperty.MetaClass!.GetFullManagedName();
+
+        if (property.HasMetaData("GenericType"))
+        {
+            fullName = property.GetMetaData("GenericType");
+        }
+
         return $"TSubclassOf<{fullName}>";
     }
 
@@ -21,6 +27,26 @@ public class ClassPropertyTranslator : SimpleTypePropertyTranslator
     {
         UhtClassProperty classProperty = (UhtClassProperty)property;
         string fullName = classProperty.MetaClass!.GetFullManagedName();
+
+        if (property.HasMetaData("GenericType"))
+        {
+            fullName = property.GetMetaData("GenericType");
+        }
+
         return $"SubclassOfMarshaller<{fullName}>";
+    }
+
+    public override void ExportToNative(GeneratorStringBuilder builder, UhtProperty property, string propertyName, string destinationBuffer, string offset, string source)
+    {
+        if (property.HasMetaData("GenericType"))
+        {
+            var genericParam = property.GetMetaData("GenericType");
+
+            builder.AppendLine($"{GetMarshaller(property)}.ToNative(IntPtr.Add({destinationBuffer}, {offset}), 0, typeof({genericParam}));");
+        }
+        else
+        {
+            base.ExportToNative(builder, property, propertyName, destinationBuffer, offset, source);
+        }
     }
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/ClassPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/ClassPropertyTranslator.cs
@@ -13,12 +13,8 @@ public class ClassPropertyTranslator : SimpleTypePropertyTranslator
     public override string GetManagedType(UhtProperty property)
     {
         UhtClassProperty classProperty = (UhtClassProperty)property;
-        string fullName = classProperty.MetaClass!.GetFullManagedName();
-
-        if (property.HasMetaData("GenericType"))
-        {
-            fullName = property.GetMetaData("GenericType");
-        }
+        string fullName = property.IsGenericType() ? "DOT" 
+            : classProperty.MetaClass!.GetFullManagedName();
 
         return $"TSubclassOf<{fullName}>";
     }
@@ -26,27 +22,22 @@ public class ClassPropertyTranslator : SimpleTypePropertyTranslator
     public override string GetMarshaller(UhtProperty property)
     {
         UhtClassProperty classProperty = (UhtClassProperty)property;
-        string fullName = classProperty.MetaClass!.GetFullManagedName();
-
-        if (property.HasMetaData("GenericType"))
-        {
-            fullName = property.GetMetaData("GenericType");
-        }
+        string fullName = property.IsGenericType() ? "DOT"
+            : classProperty.MetaClass!.GetFullManagedName();
 
         return $"SubclassOfMarshaller<{fullName}>";
     }
 
+    /*
     public override void ExportToNative(GeneratorStringBuilder builder, UhtProperty property, string propertyName, string destinationBuffer, string offset, string source)
     {
-        if (property.HasMetaData("GenericType"))
+        if (property.IsGenericType())
         {
-            var genericParam = property.GetMetaData("GenericType");
-
-            builder.AppendLine($"{GetMarshaller(property)}.ToNative(IntPtr.Add({destinationBuffer}, {offset}), 0, typeof({genericParam}));");
+            builder.AppendLine($"{GetMarshaller(property)}.ToNative(IntPtr.Add({destinationBuffer}, {offset}), 0, typeof(DOT));");
         }
         else
         {
             base.ExportToNative(builder, property, propertyName, destinationBuffer, offset, source);
         }
-    }
+    }*/
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/ContainerPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/ContainerPropertyTranslator.cs
@@ -64,6 +64,8 @@ public class ContainerPropertyTranslator : PropertyTranslator
     {
         base.ExportPropertyVariables(builder, property, propertyEngineName);
 
+        if (property.HasMetaData("GenericType")) return;
+
         string wrapperType = GetWrapperType(property);
         if (property.IsOuter<UhtScriptStruct>())
         {
@@ -81,7 +83,9 @@ public class ContainerPropertyTranslator : PropertyTranslator
     {
         base.ExportParameterVariables(builder, function, nativeMethodName, property, propertyEngineName);
         builder.AppendLine($"static IntPtr {nativeMethodName}_{propertyEngineName}_NativeProperty;");
-        
+
+        if (property.HasMetaData("GenericType")) return;
+
         string wrapperType = GetWrapperType(property);
         if (function.FunctionFlags.HasAnyFlags(EFunctionFlags.Static))
         {
@@ -133,11 +137,17 @@ public class ContainerPropertyTranslator : PropertyTranslator
 
         if (!reuseRefMarshallers)
         {
-            builder.AppendLine($"{marshaller} ??= new {marshallerType}({nativeProperty}, {marshallingDelegates});");
-            
+            if (property.HasMetaData("GenericType"))
+            {
+                builder.AppendLine($"var {marshaller} = new {marshallerType}({nativeProperty}, {marshallingDelegates});");
+            }
+            else
+            {
+                builder.AppendLine($"{marshaller} ??= new {marshallerType}({nativeProperty}, {marshallingDelegates});");
+            }
             builder.AppendLine($"IntPtr {propertyName}_NativeBuffer = IntPtr.Add({sourceBuffer}, {offset});");
         }
-        
+
         builder.AppendLine($"{assignmentOrReturn} {marshaller}.FromNative({propertyName}_NativeBuffer, 0);");
         
         if (bCleanupSourceBuffer)
@@ -165,8 +175,15 @@ public class ContainerPropertyTranslator : PropertyTranslator
         
         string marshallerType = GetWrapperType(property);
         string marshallingDelegates = translator.ExportMarshallerDelegates(valueProperty);
-        
-        builder.AppendLine($"{marshaller} ??= new {marshallerType}({nativeProperty}, {marshallingDelegates});");
+
+        if (property.HasMetaData("GenericType"))
+        {
+            builder.AppendLine($"var {marshaller} = new {marshallerType}({nativeProperty}, {marshallingDelegates});");
+        }
+        else
+        {
+            builder.AppendLine($"{marshaller} ??= new {marshallerType}({nativeProperty}, {marshallingDelegates});");
+        }
         builder.AppendLine($"IntPtr {propertyName}_NativeBuffer = IntPtr.Add({destinationBuffer}, {offset});");
         builder.AppendLine($"{marshaller}.ToNative({propertyName}_NativeBuffer, 0, {source});");
     }
@@ -189,17 +206,31 @@ public class ContainerPropertyTranslator : PropertyTranslator
         bool isParameter = property.IsOuter<UhtFunction>();
         UhtContainerBaseProperty containerProperty = (UhtContainerBaseProperty) property;
         PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
-        
+
+        string innerManagedType = property.HasMetaData("GenericType") ?
+            property.GetMetaData("GenericType") : translator.GetManagedType(containerProperty.ValueProperty);
+
         string containerType = isStructProperty || isParameter ? CopyMarshallerName : property.PropertyFlags.HasAnyFlags(EPropertyFlags.BlueprintReadOnly) ? ReadOnlyMarshallerName : MarshallerName;
-        return $"{containerType}<{translator.GetManagedType(containerProperty.ValueProperty)}>";
+        return $"{containerType}<{innerManagedType}>";
     }
 
     private string GetWrapperInterface(UhtProperty property)
     {
         UhtContainerBaseProperty containerProperty = (UhtContainerBaseProperty) property;
         PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
-        string innerManagedType = translator.GetManagedType(containerProperty.ValueProperty);
+
+        string innerManagedType = property.HasMetaData("GenericType") ? 
+            property.GetMetaData("GenericType") : translator.GetManagedType(containerProperty.ValueProperty);
+
         string interfaceType = property.PropertyFlags.HasAnyFlags(EPropertyFlags.BlueprintReadOnly) ? ReadOnlyInterfaceName : InterfaceName;
         return $"System.Collections.Generic.{interfaceType}<{innerManagedType}>";
+    }
+
+    public override bool CanSupportGenericType(UhtProperty property)
+    {
+        UhtContainerBaseProperty containerProperty = (UhtContainerBaseProperty)property;
+        PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
+
+        return translator.CanSupportGenericType(containerProperty.ValueProperty);
     }
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/ContainerPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/ContainerPropertyTranslator.cs
@@ -64,7 +64,7 @@ public class ContainerPropertyTranslator : PropertyTranslator
     {
         base.ExportPropertyVariables(builder, property, propertyEngineName);
 
-        if (property.HasMetaData("GenericType")) return;
+        if (property.IsGenericType()) return;
 
         string wrapperType = GetWrapperType(property);
         if (property.IsOuter<UhtScriptStruct>())
@@ -84,7 +84,7 @@ public class ContainerPropertyTranslator : PropertyTranslator
         base.ExportParameterVariables(builder, function, nativeMethodName, property, propertyEngineName);
         builder.AppendLine($"static IntPtr {nativeMethodName}_{propertyEngineName}_NativeProperty;");
 
-        if (property.HasMetaData("GenericType")) return;
+        if (property.IsGenericType()) return;
 
         string wrapperType = GetWrapperType(property);
         if (function.FunctionFlags.HasAnyFlags(EFunctionFlags.Static))
@@ -137,7 +137,7 @@ public class ContainerPropertyTranslator : PropertyTranslator
 
         if (!reuseRefMarshallers)
         {
-            if (property.HasMetaData("GenericType"))
+            if (property.IsGenericType())
             {
                 builder.AppendLine($"var {marshaller} = new {marshallerType}({nativeProperty}, {marshallingDelegates});");
             }
@@ -176,7 +176,7 @@ public class ContainerPropertyTranslator : PropertyTranslator
         string marshallerType = GetWrapperType(property);
         string marshallingDelegates = translator.ExportMarshallerDelegates(valueProperty);
 
-        if (property.HasMetaData("GenericType"))
+        if (property.IsGenericType())
         {
             builder.AppendLine($"var {marshaller} = new {marshallerType}({nativeProperty}, {marshallingDelegates});");
         }
@@ -207,8 +207,8 @@ public class ContainerPropertyTranslator : PropertyTranslator
         UhtContainerBaseProperty containerProperty = (UhtContainerBaseProperty) property;
         PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
 
-        string innerManagedType = property.HasMetaData("GenericType") ?
-            property.GetMetaData("GenericType") : translator.GetManagedType(containerProperty.ValueProperty);
+        string innerManagedType = property.IsGenericType() ?
+            "DOT" : translator.GetManagedType(containerProperty.ValueProperty);
 
         string containerType = isStructProperty || isParameter ? CopyMarshallerName : property.PropertyFlags.HasAnyFlags(EPropertyFlags.BlueprintReadOnly) ? ReadOnlyMarshallerName : MarshallerName;
         return $"{containerType}<{innerManagedType}>";
@@ -219,8 +219,8 @@ public class ContainerPropertyTranslator : PropertyTranslator
         UhtContainerBaseProperty containerProperty = (UhtContainerBaseProperty) property;
         PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
 
-        string innerManagedType = property.HasMetaData("GenericType") ? 
-            property.GetMetaData("GenericType") : translator.GetManagedType(containerProperty.ValueProperty);
+        string innerManagedType = property.IsGenericType() ? 
+            "DOT" : translator.GetManagedType(containerProperty.ValueProperty);
 
         string interfaceType = property.PropertyFlags.HasAnyFlags(EPropertyFlags.BlueprintReadOnly) ? ReadOnlyInterfaceName : InterfaceName;
         return $"System.Collections.Generic.{interfaceType}<{innerManagedType}>";

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/DelegateBasePropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/DelegateBasePropertyTranslator.cs
@@ -69,4 +69,6 @@ public class DelegateBasePropertyTranslator : PropertyTranslator
     {
         throw new System.NotImplementedException();
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/InterfacePropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/InterfacePropertyTranslator.cs
@@ -20,5 +20,5 @@ public class InterfacePropertyTranslator : SimpleTypePropertyTranslator
         return $"{GetManagedType(property)}Marshaller";
     }
 
-    public override bool CanSupportGenericType(UhtProperty property) => false;
+    public override bool CanSupportGenericType(UhtProperty property) => true;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/InterfacePropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/InterfacePropertyTranslator.cs
@@ -19,4 +19,6 @@ public class InterfacePropertyTranslator : SimpleTypePropertyTranslator
     {
         return $"{GetManagedType(property)}Marshaller";
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/MapPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/MapPropertyTranslator.cs
@@ -210,4 +210,6 @@ public class MapPropertyTranslator : PropertyTranslator
         
         return $"{marshallerType}<{keyType}, {valueType}>";
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/ObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/ObjectPropertyTranslator.cs
@@ -28,8 +28,7 @@ public class ObjectPropertyTranslator : SimpleTypePropertyTranslator
 
     public override string GetManagedType(UhtProperty property)
     {
-        if (property.HasMetaData("GenericType"))
-            return property.GetMetaData("GenericType");
+        if (property.IsGenericType()) return "DOT";
 
         UhtObjectProperty objectProperty = (UhtObjectProperty)property;
         return objectProperty.Class.GetFullManagedName();
@@ -37,10 +36,9 @@ public class ObjectPropertyTranslator : SimpleTypePropertyTranslator
 
     public override string GetMarshaller(UhtProperty property)
     {
-        if (property.Outer != null 
-            && property.Outer.HasMetadata("GenericType"))
+        if (property.Outer is UhtProperty outerProperty && outerProperty.IsGenericType())
         {
-            return $"ObjectMarshaller<{property.Outer.GetMetadata("GenericType")}>";
+            return $"ObjectMarshaller<DOT>";
         }
 
         return $"ObjectMarshaller<{GetManagedType(property)}>";

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/ObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/ObjectPropertyTranslator.cs
@@ -28,12 +28,23 @@ public class ObjectPropertyTranslator : SimpleTypePropertyTranslator
 
     public override string GetManagedType(UhtProperty property)
     {
+        if (property.HasMetaData("GenericType"))
+            return property.GetMetaData("GenericType");
+
         UhtObjectProperty objectProperty = (UhtObjectProperty)property;
         return objectProperty.Class.GetFullManagedName();
     }
 
     public override string GetMarshaller(UhtProperty property)
     {
+        if (property.Outer != null 
+            && property.Outer.HasMetadata("GenericType"))
+        {
+            return $"ObjectMarshaller<{property.Outer.GetMetadata("GenericType")}>";
+        }
+
         return $"ObjectMarshaller<{GetManagedType(property)}>";
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => true;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslator.cs
@@ -39,7 +39,10 @@ public abstract class PropertyTranslator
     
     // Can we export this property?
     public abstract bool CanExport(UhtProperty property);
-    
+
+    // Can we support generic types?
+    public abstract bool CanSupportGenericType(UhtProperty property);
+
     // Get the managed type for this property
     // Example: "int" for a property of type "int32"
     public abstract string GetManagedType(UhtProperty property);

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/SimpleTypePropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/SimpleTypePropertyTranslator.cs
@@ -70,6 +70,9 @@ public class SimpleTypePropertyTranslator : PropertyTranslator
 
     public override string GetManagedType(UhtProperty property)
     {
+		if (property.HasMetaData("GenericType"))
+			return property.GetMetaData("GenericType");
+
         return ManagedType;
     }
 
@@ -140,4 +143,6 @@ public class SimpleTypePropertyTranslator : PropertyTranslator
     {
 	    // No cleanup needed
     }
+
+	public override bool CanSupportGenericType(UhtProperty property) => true;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/SimpleTypePropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/SimpleTypePropertyTranslator.cs
@@ -70,10 +70,7 @@ public class SimpleTypePropertyTranslator : PropertyTranslator
 
     public override string GetManagedType(UhtProperty property)
     {
-		if (property.HasMetaData("GenericType"))
-			return property.GetMetaData("GenericType");
-
-        return ManagedType;
+        return property.IsGenericType() ? "DOT" : ManagedType;
     }
 
     protected void ExportDefaultStructParameter(GeneratorStringBuilder builder, string variableName, string cppDefaultValue,

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/SoftClassPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/SoftClassPropertyTranslator.cs
@@ -14,6 +14,12 @@ public class SoftClassPropertyTranslator : SimpleTypePropertyTranslator
     {
         UhtSoftClassProperty softClassProperty = (UhtSoftClassProperty)property;
         string fullName = softClassProperty.Class.GetFullManagedName();
+
+        if (property.HasMetaData("GenericType"))
+        {
+            fullName = property.GetMetaData("GenericType");
+        }
+
         return $"TSoftClassPtr<{fullName}>";
     }
 
@@ -21,6 +27,12 @@ public class SoftClassPropertyTranslator : SimpleTypePropertyTranslator
     {
         UhtSoftClassProperty softClassProperty = (UhtSoftClassProperty) property;
         string fullName = softClassProperty.Class.GetFullManagedName();
+
+        if (property.HasMetaData("GenericType"))
+        {
+            fullName = property.GetMetaData("GenericType");
+        }
+
         return $"SoftClassMarshaller<{fullName}>";
     }
 

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/SoftClassPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/SoftClassPropertyTranslator.cs
@@ -13,12 +13,8 @@ public class SoftClassPropertyTranslator : SimpleTypePropertyTranslator
     public override string GetManagedType(UhtProperty property)
     {
         UhtSoftClassProperty softClassProperty = (UhtSoftClassProperty)property;
-        string fullName = softClassProperty.Class.GetFullManagedName();
-
-        if (property.HasMetaData("GenericType"))
-        {
-            fullName = property.GetMetaData("GenericType");
-        }
+        string fullName = property.IsGenericType()
+             ? "DOT" : softClassProperty.Class.GetFullManagedName();
 
         return $"TSoftClassPtr<{fullName}>";
     }
@@ -26,12 +22,8 @@ public class SoftClassPropertyTranslator : SimpleTypePropertyTranslator
     public override string GetMarshaller(UhtProperty property)
     {
         UhtSoftClassProperty softClassProperty = (UhtSoftClassProperty) property;
-        string fullName = softClassProperty.Class.GetFullManagedName();
-
-        if (property.HasMetaData("GenericType"))
-        {
-            fullName = property.GetMetaData("GenericType");
-        }
+        string fullName = property.IsGenericType()
+             ? "DOT" : softClassProperty.Class.GetFullManagedName();
 
         return $"SoftClassMarshaller<{fullName}>";
     }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/SoftObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/SoftObjectPropertyTranslator.cs
@@ -28,4 +28,6 @@ public class SoftObjectPropertyTranslator : SimpleTypePropertyTranslator
         string fullName = softClassProperty.Class.GetFullManagedName();
         return $"SoftObjectMarshaller<{fullName}>";
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/StringPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/StringPropertyTranslator.cs
@@ -69,4 +69,6 @@ public class StringPropertyTranslator : PropertyTranslator
     {
         return "\"" + defaultValue + "\"";
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/StructPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/StructPropertyTranslator.cs
@@ -27,4 +27,6 @@ public class StructPropertyTranslator : SimpleTypePropertyTranslator
     {
         ExportDefaultStructParameter(builder, variableName, defaultValue, paramProperty, this);
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/TextPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/TextPropertyTranslator.cs
@@ -27,4 +27,6 @@ public class TextPropertyTranslator : BlittableTypePropertyTranslator
     {
         return "TextMarshaller";
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/WeakObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/WeakObjectPropertyTranslator.cs
@@ -24,4 +24,6 @@ public class WeakObjectPropertyTranslator : BlittableTypePropertyTranslator
     {
         return property is UhtWeakObjectPtrProperty;
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/WorldContextObjectPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/WorldContextObjectPropertyTranslator.cs
@@ -33,4 +33,6 @@ public class WorldContextObjectPropertyTranslator : ObjectPropertyTranslator
     {
         builder.AppendLine($"BlittableMarshaller<IntPtr>.ToNative(IntPtr.Add({destinationBuffer}, {offset}), 0, FCSManagerExporter.CallGetCurrentWorldContext());");
     }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
 }

--- a/Source/UnrealSharpScriptGenerator/Utilities/FunctionUtilities.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/FunctionUtilities.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using EpicGames.Core;
 using EpicGames.UHT.Types;
 using UnrealSharpScriptGenerator.Exporters;
+using UnrealSharpScriptGenerator.PropertyTranslators;
 
 namespace UnrealSharpScriptGenerator.Utilities;
 
@@ -151,5 +152,53 @@ public static class FunctionUtilities
         
         return function.IsBlueprintAccessor("BlueprintSetter", property => property.GetBlueprintSetter()) 
                || function.IsNativeAccessor(GetterSetterMode.Set);
+    }
+
+    public static bool HasGenericTypeSupport(this UhtFunction function)
+    {
+        if (!function.HasMetadata("DeterminesOutputType")) return false;
+
+        var propertyDOTEngineName = function.GetMetadata("DeterminesOutputType");
+
+        var propertyDeterminingOutputType = function.Properties
+            .Where(p => p.EngineName == propertyDOTEngineName)
+            .FirstOrDefault();
+
+        if (propertyDeterminingOutputType == null) return false;
+
+        PropertyTranslator dotParamTranslator = PropertyTranslatorManager.GetTranslator(propertyDeterminingOutputType)!;
+        if (!dotParamTranslator.CanSupportGenericType(propertyDeterminingOutputType)) return false;
+
+        if (function.HasMetadata("DynamicOutputParam"))
+        {
+            var propertyDynamicOutputParam = function.Properties
+                .Where(p => p.EngineName == function.GetMetadata("DynamicOutputParam"))
+                .FirstOrDefault();
+
+            if (propertyDynamicOutputParam == null) return false;
+
+            if (propertyDeterminingOutputType!.GetGenericManagedType() != propertyDynamicOutputParam.GetGenericManagedType()) return false;
+
+            PropertyTranslator dopParamTranslator = PropertyTranslatorManager.GetTranslator(propertyDynamicOutputParam)!;
+            return dopParamTranslator.CanSupportGenericType(propertyDynamicOutputParam);
+        }
+        else if (function.HasReturnProperty)
+        {
+            PropertyTranslator returnParamTranslator = PropertyTranslatorManager.GetTranslator(function.ReturnProperty!)!;
+            return returnParamTranslator.CanSupportGenericType(function.ReturnProperty!);
+        }
+
+        return false;
+    }
+
+    public static string GetGenericTypeConstraint(this UhtFunction function)
+    {
+        if (!function.HasMetadata("DeterminesOutputType")) return string.Empty;
+
+        var propertyDeterminingOutputType = function.Properties
+            .Where(p => p.EngineName == function.GetMetadata("DeterminesOutputType"))
+            .FirstOrDefault();
+
+        return propertyDeterminingOutputType?.GetGenericManagedType() ?? string.Empty;
     }
 }

--- a/Source/UnrealSharpScriptGenerator/Utilities/PropertyUtilities.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/PropertyUtilities.cs
@@ -2,6 +2,7 @@
 using EpicGames.Core;
 using EpicGames.UHT.Types;
 using UnrealSharpScriptGenerator.Exporters;
+using UnrealSharpScriptGenerator.PropertyTranslators;
 
 namespace UnrealSharpScriptGenerator.Utilities;
 
@@ -11,152 +12,152 @@ public static class PropertyUtilities
     {
         return property.Outer is T;
     }
-    
+
     public static bool HasAnyFlags(this UhtProperty property, EPropertyFlags flags)
     {
         return (property.PropertyFlags & flags) != 0;
     }
-    
+
     public static bool HasAllFlags(this UhtProperty property, EPropertyFlags flags)
     {
         return (property.PropertyFlags & flags) == flags;
     }
-    
+
     public static string GetMetaData(this UhtProperty property, string key)
     {
         return property.MetaData.TryGetValue(key, out var value) ? value : string.Empty;
     }
-    
+
     public static bool HasMetaData(this UhtProperty property, string key)
     {
         return property.MetaData.ContainsKey(key);
     }
-    
+
     public static bool HasNativeGetter(this UhtProperty property)
     {
         if (property.Outer is UhtScriptStruct)
         {
             return false;
         }
-        
+
         return !string.IsNullOrEmpty(property.Getter);
     }
-    
+
     public static bool HasNativeSetter(this UhtProperty property)
     {
         if (property.Outer is UhtScriptStruct)
         {
             return false;
         }
-        
+
         return !string.IsNullOrEmpty(property.Setter);
     }
-    
+
     public static bool HasAnyNativeGetterSetter(this UhtProperty property)
     {
         return property.HasNativeGetter() || property.HasNativeSetter();
     }
-    
+
     public static bool HasBlueprintGetter(this UhtProperty property)
     {
         return property.GetBlueprintGetter() != null;
     }
-    
+
     public static bool HasBlueprintSetter(this UhtProperty property)
     {
         return property.GetBlueprintSetter() != null;
     }
-    
+
     public static bool HasBlueprintGetterOrSetter(this UhtProperty property)
     {
         return property.HasBlueprintGetter() || property.HasBlueprintSetter();
     }
-    
+
     public static bool HasBlueprintGetterSetterPair(this UhtProperty property)
     {
         return property.HasBlueprintGetter() && property.HasBlueprintSetter();
     }
-    
+
     public static bool HasAnyGetterOrSetter(this UhtProperty property)
     {
         return property.HasAnyNativeGetterSetter() || property.HasBlueprintGetterOrSetter();
     }
-    
+
     public static bool HasAnyGetter(this UhtProperty property)
     {
         return property.HasNativeGetter() || property.HasBlueprintGetter();
     }
-    
+
     public static bool HasAnySetter(this UhtProperty property)
     {
         return property.HasNativeSetter() || property.HasBlueprintSetter();
     }
-    
+
     public static bool HasGetterSetterPair(this UhtProperty property)
     {
         return property.HasAnyGetter() && property.HasAnySetter();
     }
-    
+
     public static UhtFunction? GetBlueprintGetter(this UhtProperty property)
     {
         return property.TryGetBlueprintAccessor(GetterSetterMode.Get);
     }
-    
+
     public static UhtFunction? GetBlueprintSetter(this UhtProperty property)
     {
         return property.TryGetBlueprintAccessor(GetterSetterMode.Set);
     }
-    
+
     public static bool HasReadWriteAccess(this UhtProperty property)
     {
         return property.HasAnyFlags(EPropertyFlags.Edit | EPropertyFlags.BlueprintAssignable) || property.HasAnySetter();
     }
-    
+
     public static UhtFunction? TryGetBlueprintAccessor(this UhtProperty property, GetterSetterMode accessorType)
     {
         if (property.Outer is UhtScriptStruct)
         {
             return null;
         }
-        
+
         UhtClass classObj = (property.Outer as UhtClass)!;
-        
+
         UhtFunction? TryFindFunction(string name)
         {
             UhtFunction? function = classObj.FindFunctionByName(name, (uhtFunction, typeName) =>
             {
                 if (uhtFunction.SourceName == typeName
-                    || (uhtFunction.SourceName.Length == typeName.Length 
+                    || (uhtFunction.SourceName.Length == typeName.Length
                         && uhtFunction.SourceName.Contains(typeName, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     return true;
                 }
-                
+
                 if (uhtFunction.GetScriptName() == typeName
-                    || (uhtFunction.GetScriptName().Length == typeName.Length 
+                    || (uhtFunction.GetScriptName().Length == typeName.Length
                         && uhtFunction.GetScriptName().Contains(typeName, StringComparison.InvariantCultureIgnoreCase)))
                 {
                     return true;
                 }
-                
+
                 return false;
             });
-        
+
             if (function != null && function.VerifyBlueprintAccessor(property))
             {
                 return function;
             }
-            
+
             return null;
         }
-        
+
         string accessorName = property.GetMetaData(accessorType == GetterSetterMode.Get ? "BlueprintGetter" : "BlueprintSetter");
         UhtFunction? function = TryFindFunction(accessorName);
         if (function != null)
         {
             return function;
         }
-        
+
         function = TryFindFunction(accessorType + property.SourceName);
         if (function != null)
         {
@@ -168,16 +169,16 @@ public static class PropertyUtilities
         {
             return function;
         }
-        
+
         function = TryFindFunction(accessorType + NameMapper.ScriptifyName(property.SourceName, ENameType.Property));
         if (function != null)
         {
             return function;
         }
-        
+
         return null;
     }
-    
+
     public static string GetNativePropertyName(this UhtProperty property)
     {
         return $"{property.SourceName}_NativeProperty";
@@ -187,23 +188,23 @@ public static class PropertyUtilities
     {
         UhtClass? classObj = property.Outer as UhtClass;
         bool isClassOwner = classObj != null;
-        
+
         if (isClassOwner && property.HasAnyGetterOrSetter())
         {
             UhtFunction? getter = property.GetBlueprintGetter();
             UhtFunction? setter = property.GetBlueprintSetter();
-    
+
             if ((getter != null && getter.FunctionFlags.HasAnyFlags(EFunctionFlags.Public)) || (setter != null && setter.FunctionFlags.HasAnyFlags(EFunctionFlags.Public)))
             {
                 return "public ";
             }
-            
+
             if ((getter != null && getter.FunctionFlags.HasAnyFlags(EFunctionFlags.Protected)) || (setter != null && setter.FunctionFlags.HasAnyFlags(EFunctionFlags.Protected)))
             {
                 return "protected ";
             }
         }
-    
+
         if (property.HasAllFlags(EPropertyFlags.NativeAccessSpecifierPublic) ||
             (property.HasAllFlags(EPropertyFlags.NativeAccessSpecifierPrivate) && property.HasMetaData("AllowPrivateAccess")) ||
             (!isClassOwner && property.HasAllFlags(EPropertyFlags.Protected)))
@@ -218,5 +219,28 @@ public static class PropertyUtilities
         {
             return "private ";
         }
+    }
+
+    public static string GetGenericManagedType(this UhtProperty property)
+    {
+        if (property is UhtClassProperty classProperty)
+        {
+            return classProperty.MetaClass!.GetFullManagedName();
+        }
+        else if (property is UhtSoftClassProperty softClassProperty)
+        {
+            return softClassProperty.MetaClass!.GetFullManagedName();
+        }
+        else if (property is UhtContainerBaseProperty containerProperty)
+        {
+            PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
+            return translator.GetManagedType(containerProperty.ValueProperty);
+        }
+        else if (property is UhtObjectProperty objectProperty)
+        {
+            return objectProperty.Class.GetFullManagedName();
+        }
+
+        return "";
     }
 }


### PR DESCRIPTION
This PR is to support a feature of automatic generic generation in UFunctions using the DeterminesOutputType and DynamicOutputParam MetaData that Uht has on UFunctions.

Example of Generic Source Gen:

```CSharp
    public static void GetAllActorsOfClass<DOT>(out System.Collections.Generic.IList<DOT> outActors) where DOT : UnrealSharp.Engine.AActor
    {
        GetAllActorsOfClass<DOT>(typeof(DOT), out outActors);
    }
    
    /// <summary>
    /// Find all Actors in the world of the specified class.
    /// This is a slow operation, use with caution e.g. do not use every frame.
    /// 
    /// </summary>
    [UFunction, GeneratedType("GetAllActorsOfClass"), UMetaData("DeterminesOutputType", "ActorClass"), UMetaData("DynamicOutputParam", "OutActors")]
    public static void GetAllActorsOfClass<DOT>(TSubclassOf<DOT> actorClass, out System.Collections.Generic.IList<DOT> outActors) where DOT : UnrealSharp.Engine.AActor
    {
        unsafe
        {
            byte* ParamsBufferAllocation = stackalloc byte[GetAllActorsOfClass_ParamsSize];
            nint ParamsBuffer = (nint) ParamsBufferAllocation;
            UStructExporter.CallInitializeStruct(GetAllActorsOfClass_NativeFunction, ParamsBuffer);
            BlittableMarshaller<IntPtr>.ToNative(IntPtr.Add(ParamsBuffer, GetAllActorsOfClass_WorldContextObject_Offset), 0, FCSManagerExporter.CallGetCurrentWorldContext());
            SubclassOfMarshaller<DOT>.ToNative(IntPtr.Add(ParamsBuffer, GetAllActorsOfClass_ActorClass_Offset), 0, actorClass);
            
            UObjectExporter.CallInvokeNativeStaticFunction(NativeClassPtr, GetAllActorsOfClass_NativeFunction, ParamsBuffer);
            
            var GetAllActorsOfClass_OutActors_Marshaller = new ArrayCopyMarshaller<DOT>(GetAllActorsOfClass_OutActors_NativeProperty, ObjectMarshaller<DOT>.ToNative, ObjectMarshaller<DOT>.FromNative);
            IntPtr OutActors_NativeBuffer = IntPtr.Add(ParamsBuffer, GetAllActorsOfClass_OutActors_Offset);
            outActors = GetAllActorsOfClass_OutActors_Marshaller.FromNative(OutActors_NativeBuffer, 0);
            GetAllActorsOfClass_OutActors_Marshaller.DestructInstance(OutActors_NativeBuffer, 0);
            
        }
    }
```

This removes the need for manual casting on a lot of blueprint methods.