### PR TITLE
Implicit boolean operator for UObjects

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
@@ -75,7 +75,12 @@ public partial class UObject
     {
         return NativeObject.GetHashCode();
     }
-    
+
+    public static implicit operator bool(UObject Object)
+    {
+        return Object != null && UObjectExporter.CallNativeIsValid(Object.NativeObject);
+    }
+
     /// <summary>
     /// Prints a message to the screen and/or console.
     /// </summary>


### PR DESCRIPTION
This pr allows for implicit boolean operations on UObjects so you can check if they valid as a bool in an if statement similar to how you can in Unreal.