### PR TITLE
Auto generates StructLayout on blittable types

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/TimerHandle.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/TimerHandle.cs
@@ -3,7 +3,6 @@ using UnrealSharp.Attributes;
 
 namespace UnrealSharp.Engine;
 
-[StructLayout(LayoutKind.Sequential)]
 public partial struct FTimerHandle
 {
     private const uint IndexBits = 24;

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/EnhancedInput/InputActionValue.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/EnhancedInput/InputActionValue.cs
@@ -4,7 +4,6 @@ using UnrealSharp.CoreUObject;
 
 namespace UnrealSharp.EnhancedInput;
 
-[StructLayout(LayoutKind.Sequential)]
 public partial struct FInputActionValue
 {
     private FVector AxisValue;

--- a/Source/UnrealSharpScriptGenerator/Exporters/StructExporter.cs
+++ b/Source/UnrealSharpScriptGenerator/Exporters/StructExporter.cs
@@ -36,18 +36,19 @@ public static class StructExporter
                 propertyNames.Add(scriptName);
             }
         }
-        
-        string typeNameSpace = structObj.GetNamespace();
-        stringBuilder.GenerateTypeSkeleton(typeNameSpace);
-        
+
         bool isBlittable = structObj.IsStructBlittable();
-        
+
+        string typeNameSpace = structObj.GetNamespace();
+        stringBuilder.GenerateTypeSkeleton(typeNameSpace, isBlittable);
+                
         stringBuilder.AppendTooltip(structObj);
         
         AttributeBuilder attributeBuilder = new AttributeBuilder(structObj);
         if (isBlittable)
         {
             attributeBuilder.AddIsBlittableAttribute();
+            attributeBuilder.AddStructLayoutAttribute(System.Runtime.InteropServices.LayoutKind.Sequential);
         }
         attributeBuilder.AddGeneratedTypeAttribute(structObj);
         attributeBuilder.Finish();

--- a/Source/UnrealSharpScriptGenerator/GeneratorStringBuilder.cs
+++ b/Source/UnrealSharpScriptGenerator/GeneratorStringBuilder.cs
@@ -148,10 +148,15 @@ public class GeneratorStringBuilder : IDisposable
         CloseBrace();
     }
     
-    public void GenerateTypeSkeleton(string typeNameSpace)
+    public void GenerateTypeSkeleton(string typeNameSpace, bool blittable = false)
     {
         DeclareDirective(ScriptGeneratorUtilities.AttributeNamespace);
         DeclareDirective(ScriptGeneratorUtilities.InteropNamespace);
+
+        if (blittable)
+        {
+            DeclareDirective(ScriptGeneratorUtilities.InteropServicesNamespace);
+        }
 
         AppendLine();
         AppendLine($"namespace {typeNameSpace};");

--- a/Source/UnrealSharpScriptGenerator/Utilities/AttributeBuilder.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/AttributeBuilder.cs
@@ -38,6 +38,12 @@ public class AttributeBuilder
         AddAttribute("BlittableType");
     }
 
+    public void AddStructLayoutAttribute(System.Runtime.InteropServices.LayoutKind layoutKind)
+    {
+        AddAttribute("StructLayout");
+        AddArgument($"LayoutKind.{layoutKind}");
+    }
+
     private static string GetAttributeForType(UhtType type)
     {
         if (type is UhtClass uhtClass)

--- a/Source/UnrealSharpScriptGenerator/Utilities/ScriptGeneratorUtilities.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/ScriptGeneratorUtilities.cs
@@ -77,7 +77,8 @@ public static class ScriptGeneratorUtilities
 {
     public const string InteropNamespace = "UnrealSharp.Interop";
     public const string AttributeNamespace = "UnrealSharp.Attributes";
-    
+    public const string InteropServicesNamespace = "System.Runtime.InteropServices";
+
     public static string TryGetPluginDefine(string key)
     {
         Program.PluginModule.TryGetDefine(key, out string? generatedCodePath);


### PR DESCRIPTION
This pr auto generates StructLayout on blittable type no longer requiring adding it manually, this also fixes potential issue with compiler optimizing the data layout of a blittable type in a way that would cause problems.