### PR TITLE
`UFunction`s with `CustomStructureParam`s are exported and invoked as generic c# functions

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Interop/UFunctionExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/UFunctionExporter.cs
@@ -4,4 +4,8 @@ namespace UnrealSharp.Interop;
 public static unsafe partial class UFunctionExporter
 {
     public static delegate* unmanaged<IntPtr, UInt16> GetNativeFunctionParamsSize;
+
+    public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, IntPtr> CreateNativeFunctionCustomStructSpecialization;
+
+    public static delegate* unmanaged<IntPtr, IntPtr, void> InitializeFunctionParams;
 }

--- a/Managed/UnrealSharp/UnrealSharp/MarshalledStruct.cs
+++ b/Managed/UnrealSharp/UnrealSharp/MarshalledStruct.cs
@@ -1,0 +1,12 @@
+﻿namespace UnrealSharp;
+
+public interface MarshalledStruct<Self> where Self : MarshalledStruct<Self>
+{
+    public static abstract IntPtr GetNativeClassPtr();
+    
+    public static abstract int GetNativeDataSize();
+
+    public static abstract Self FromNative(IntPtr buffer);
+
+    public void ToNative(IntPtr buffer);
+}

--- a/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Marshallers.cs
@@ -136,3 +136,16 @@ public static class StringMarshaller
         }
     }
 }
+
+public static class StructMarshaller<T> where T : MarshalledStruct<T>
+{
+    public static T FromNative(IntPtr nativeBuffer, int arrayIndex)
+    {
+        return T.FromNative(nativeBuffer + (arrayIndex * T.GetNativeDataSize()));
+    }
+
+    public static void ToNative(IntPtr nativeBuffer, int arrayIndex, T obj)
+    {
+        obj.ToNative(nativeBuffer + arrayIndex * T.GetNativeDataSize());
+    }
+}

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverHelper.cs
@@ -66,6 +66,8 @@ public static class WeaverHelper
     public static MethodReference GetNativePropertyFromNameMethod;
     public static MethodReference GetNativeFunctionFromClassAndNameMethod;
     public static MethodReference GetNativeFunctionParamsSizeMethod;
+    public static MethodReference CreateNativeFunctionCustomStructSpecializationMethod;
+    public static MethodReference InitializeFunctionParamsMethod;
     public static MethodReference GetNativeStructSizeMethod;
     public static MethodReference InvokeNativeFunctionMethod;
     public static MethodReference GetSignatureFunction;
@@ -128,6 +130,9 @@ public static class WeaverHelper
         GetNativePropertyFromNameMethod = FindExporterMethod(FPropertyCallbacks, "CallGetNativePropertyFromName");
         GetNativeFunctionFromClassAndNameMethod = FindExporterMethod(UClassCallbacks, "CallGetNativeFunctionFromClassAndName");
         GetNativeFunctionParamsSizeMethod = FindExporterMethod(UFunctionCallbacks, "CallGetNativeFunctionParamsSize");
+        CreateNativeFunctionCustomStructSpecializationMethod = FindExporterMethod(UFunctionCallbacks,
+            "CallCreateNativeFunctionCustomStructSpecialization");
+        InitializeFunctionParamsMethod = FindExporterMethod(UFunctionCallbacks, "CallInitializeFunctionParams");
         GetNativeStructSizeMethod = FindExporterMethod(UScriptStructCallbacks, "CallGetNativeStructSize");
         InvokeNativeFunctionMethod = FindExporterMethod(UObjectCallbacks, "CallInvokeNativeFunction");
         GetSignatureFunction = FindExporterMethod(MulticastDelegatePropertyCallbacks, "CallGetSignatureFunction");

--- a/Source/UnrealSharpCore/Export/UFunctionExporter.cpp
+++ b/Source/UnrealSharpCore/Export/UFunctionExporter.cpp
@@ -5,6 +5,8 @@
 void UUFunctionExporter::ExportFunctions(FRegisterExportedFunction RegisterExportedFunction)
 {
 	EXPORT_FUNCTION(GetNativeFunctionParamsSize)
+	EXPORT_FUNCTION(CreateNativeFunctionCustomStructSpecialization)
+	EXPORT_FUNCTION(InitializeFunctionParams)
 }
 
 uint16 UUFunctionExporter::GetNativeFunctionParamsSize(const UFunction* NativeFunction)
@@ -12,3 +14,85 @@ uint16 UUFunctionExporter::GetNativeFunctionParamsSize(const UFunction* NativeFu
 	check(NativeFunction);
 	return NativeFunction->ParmsSize;
 }
+
+UFunction* UUFunctionExporter::CreateNativeFunctionCustomStructSpecialization(UFunction* NativeFunction,
+	FProperty** CustomStructParams, UScriptStruct** CustomStructs)
+{
+	UClass* Outer = NativeFunction->GetOuterUClass();
+	UFunction* Specialization = NewObject<UFunction>(Outer, UFunction::StaticClass());
+	Specialization->FunctionFlags = NativeFunction->FunctionFlags;
+	Specialization->SetSuperStruct(NativeFunction);
+	Specialization->SetNativeFunc(NativeFunction->GetNativeFunc());
+
+	TArray<FProperty*> FunctionProperties;
+	for (TFieldIterator<FProperty> PropIt(NativeFunction); PropIt && PropIt->PropertyFlags & CPF_Parm; ++PropIt)
+	{
+		FProperty* Property = *PropIt;
+		FProperty* OutProperty;
+		if(Property == *CustomStructParams)
+		{
+			FStructProperty* CustomStructParam = new FStructProperty(Specialization, Property->GetFName(), Property->GetFlags());
+			UScriptStruct* Struct = *CustomStructs++;
+			CustomStructParam->Struct = Struct;
+			EPropertyFlags Flags = Property->GetPropertyFlags() | CPF_BlueprintVisible | CPF_BlueprintReadOnly;
+			if (const auto CppStructOps = Struct->GetCppStructOps())
+			{
+				const auto Capabilities = CppStructOps->GetCapabilities();
+				if(Capabilities.HasZeroConstructor)
+				{
+					Flags |= CPF_ZeroConstructor;
+				}
+				else
+				{
+					Flags &= ~(CPF_ZeroConstructor);
+				}
+				if(Capabilities.IsPlainOldData)
+				{
+					Flags |= CPF_IsPlainOldData;
+				}
+				else
+				{
+					Flags &= ~(CPF_IsPlainOldData);
+				}
+			}
+			else
+			{
+				Flags &= ~(CPF_ZeroConstructor | CPF_IsPlainOldData);
+			}
+			CustomStructParam->PropertyFlags = Flags;
+			OutProperty = CastField<FProperty>(CustomStructParam);
+			CustomStructParams++;
+		}
+		else
+		{
+			OutProperty = CastField<FProperty>(FField::Duplicate(Property, Specialization, Property->GetFName(), RF_AllFlags, EInternalObjectFlags_AllFlags & ~EInternalObjectFlags::Native));
+			OutProperty->PropertyFlags |= CPF_BlueprintVisible | CPF_BlueprintReadOnly;
+			OutProperty->Next = nullptr;
+		}
+		Specialization->Script.Add(OutProperty->PropertyFlags & CPF_OutParm ? EX_LocalOutVariable : EX_LocalVariable);
+		Specialization->Script.Append((uint8*)&OutProperty, sizeof(FProperty*));
+		FunctionProperties.Add(OutProperty);
+	}
+
+	for(int32 i = FunctionProperties.Num(); i-- > 0;)
+	{
+		Specialization->AddCppProperty(FunctionProperties[i]);
+	}
+
+	Specialization->Next = Outer->Children;
+	Outer->Children = Specialization;
+
+	Specialization->StaticLink(true);
+
+	return Specialization;
+}
+
+void UUFunctionExporter::InitializeFunctionParams(UFunction* NativeFunction, void* Params)
+{
+	check(NativeFunction && Params)
+	for (TFieldIterator<FProperty> PropIt(NativeFunction); PropIt; ++PropIt)
+	{
+		PropIt->InitializeValue_InContainer(Params);
+	}
+}
+

--- a/Source/UnrealSharpCore/Export/UFunctionExporter.h
+++ b/Source/UnrealSharpCore/Export/UFunctionExporter.h
@@ -20,5 +20,9 @@ public:
 private:
 
 	static uint16 GetNativeFunctionParamsSize(const UFunction* NativeFunction);
-	
+
+	static UFunction* CreateNativeFunctionCustomStructSpecialization(UFunction* NativeFunction, FProperty** CustomStructParams, UScriptStruct** CustomStructs);
+
+	static void InitializeFunctionParams(UFunction* NativeFunction, void* Params);
+
 };

--- a/Source/UnrealSharpCore/Export/UObjectExporter.cpp
+++ b/Source/UnrealSharpCore/Export/UObjectExporter.cpp
@@ -44,6 +44,7 @@ void UUObjectExporter::InvokeNativeFunction(UObject* NativeObject, UFunction* Na
 {
 	FFrame NewStack(NativeObject, NativeFunction, Params, nullptr, NativeFunction->ChildProperties);
 	NewStack.CurrentNativeFunction = NativeFunction;
+	const bool bHasReturnParam = NativeFunction->ReturnValueOffset != MAX_uint16;
 	
 	if (NativeFunction->HasAllFunctionFlags(FUNC_Net))
 	{
@@ -94,7 +95,6 @@ void UUObjectExporter::InvokeNativeFunction(UObject* NativeObject, UFunction* Na
 		}
 	}
 	
-	const bool bHasReturnParam = NativeFunction->ReturnValueOffset != MAX_uint16;
 	uint8* ReturnValueAddress = bHasReturnParam ? Params + NativeFunction->ReturnValueOffset : nullptr;
 	NativeFunction->Invoke(NativeObject, NewStack, ReturnValueAddress);
 }

--- a/Source/UnrealSharpCore/Export/UScriptStructExporter.cpp
+++ b/Source/UnrealSharpCore/Export/UScriptStructExporter.cpp
@@ -10,10 +10,11 @@ void UUScriptStructExporter::ExportFunctions(FRegisterExportedFunction RegisterE
 
 int UUScriptStructExporter::GetNativeStructSize(const UScriptStruct* ScriptStruct)
 {
-	if (ScriptStruct->GetCppStructOps())
+	if (const auto CppStructOps = ScriptStruct->GetCppStructOps())
 	{
-		return ScriptStruct->GetCppStructOps()->GetSize();
+		return CppStructOps->GetSize();
 	}
 	
 	return ScriptStruct->GetStructureSize();
 }
+

--- a/Source/UnrealSharpCore/Export/UScriptStructExporter.h
+++ b/Source/UnrealSharpCore/Export/UScriptStructExporter.h
@@ -18,5 +18,4 @@ public:
 private:
 
 	static int GetNativeStructSize(const UScriptStruct* ScriptStruct);
-	
 };

--- a/Source/UnrealSharpScriptGenerator/GeneratorStringBuilder.cs
+++ b/Source/UnrealSharpScriptGenerator/GeneratorStringBuilder.cs
@@ -163,19 +163,25 @@ public class GeneratorStringBuilder : IDisposable
         GenerateTypeSkeleton(type.GetNamespace());
     }
     
-    public void DeclareType(UhtType? type , string typeName, string declaredTypeName, string? baseType = null, bool isPartial = true, List<UhtClass>? interfaces = default)
+    public void DeclareType(UhtType? type , string typeName, string declaredTypeName, string? baseType = null, bool isPartial = true, List<UhtClass>? nativeInterfaces = default, List<string>? csInterfaces = default)
     {
         string partialSpecifier = isPartial ? "partial " : string.Empty;
-        string baseSpecifier = !string.IsNullOrEmpty(baseType) ? $" : {baseType}" : string.Empty;
-        string interfacesDeclaration = string.Empty;
+        List<string> inheritingFrom = new List<string>();
+        
+        if (!string.IsNullOrEmpty(baseType)) inheritingFrom.Add(baseType);
 
-        if (interfaces != null)
+        if (nativeInterfaces != null)
         {
-            foreach (UhtType @interface in interfaces)
+            foreach (UhtType @interface in nativeInterfaces)
             {
                 string fullInterfaceName = @interface.GetFullManagedName();
-                interfacesDeclaration += $", {fullInterfaceName}";
+                inheritingFrom.Add(fullInterfaceName);
             }
+        }
+
+        if (csInterfaces != null)
+        {
+            foreach (string @interface in csInterfaces) inheritingFrom.Add(@interface);
         }
 
         string accessSpecifier = "public";
@@ -183,8 +189,11 @@ public class GeneratorStringBuilder : IDisposable
         {
             accessSpecifier = "internal";
         }
+
+        string inheritanceSpecifier =
+            inheritingFrom.Count > 0 ? $" : {string.Join(", ", inheritingFrom)}" : string.Empty;
         
-        AppendLine($"{accessSpecifier} {partialSpecifier}{typeName} {declaredTypeName}{baseSpecifier}{interfacesDeclaration}");
+        AppendLine($"{accessSpecifier} {partialSpecifier}{typeName} {declaredTypeName}{inheritanceSpecifier}");
         OpenBrace();
     }
     
@@ -197,7 +206,7 @@ public class GeneratorStringBuilder : IDisposable
     public void AppendStackAllocFunction(string sizeVariableName, string structName)
     {
         AppendStackAlloc(sizeVariableName);
-        AppendLine($"{ExporterCallbacks.UStructCallbacks}.CallInitializeStruct({structName}, ParamsBuffer);");
+        AppendLine($"{ExporterCallbacks.UFunctionCallbacks}.CallInitializeFunctionParams({structName}, ParamsBuffer);");
     }
 
     public void AppendStackAllocProperty(string sizeVariableName, string sourcePropertyName)

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/IntPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/IntPropertyTranslator.cs
@@ -1,0 +1,34 @@
+﻿using System.Linq;
+using EpicGames.UHT.Types;
+using UnrealSharpScriptGenerator.Utilities;
+
+namespace UnrealSharpScriptGenerator.PropertyTranslators;
+
+public class IntPropertyTranslator : BlittableTypePropertyTranslator
+{
+    public IntPropertyTranslator() : base(typeof(UhtIntProperty), "int")
+    {
+    }
+
+    public override string GetManagedType(UhtProperty property)
+    {
+        if (property.Outer is UhtFunction function && property.IsCustomStructureType())
+        {
+            if (function.GetCustomStructParamCount() == 1) return "CSP";
+            return $"CSP{property.GetPrecedingCustomStructParams()}";
+        }
+        
+        return base.GetManagedType(property);
+    }
+
+    public override string GetMarshaller(UhtProperty property)
+    {
+        if (property.Outer is UhtFunction && property.IsCustomStructureType())
+        {
+            return $"StructMarshaller<{GetManagedType(property)}>";
+        }
+        return base.GetMarshaller(property);
+    }
+
+    public override bool CanSupportCustomStruct(UhtProperty property) => true;
+}

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslatorManager.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/PropertyTranslatorManager.cs
@@ -20,7 +20,6 @@ public static class PropertyTranslatorManager
         
         AddBlittablePropertyTranslator(typeof(UhtInt8Property), "sbyte");
         AddBlittablePropertyTranslator(typeof(UhtInt16Property), "short");
-        AddBlittablePropertyTranslator(typeof(UhtIntProperty), "int");
         AddBlittablePropertyTranslator(typeof(UhtInt64Property), "long");
         AddBlittablePropertyTranslator(typeof(UhtUInt16Property), "ushort");
         AddBlittablePropertyTranslator(typeof(UhtUInt32Property), "uint");
@@ -29,6 +28,7 @@ public static class PropertyTranslatorManager
         AddBlittablePropertyTranslator(typeof(UhtByteProperty), "byte");
         AddBlittablePropertyTranslator(typeof(UhtLargeWorldCoordinatesRealProperty), "double");
         AddPropertyTranslator(typeof(UhtFloatProperty), new FloatPropertyTranslator());
+        AddPropertyTranslator(typeof(UhtIntProperty), new IntPropertyTranslator());
 
         MulticastDelegatePropertyTranslator multicastDelegatePropertyTranslator = new();
         AddPropertyTranslator(typeof(UhtMulticastSparseDelegateProperty), multicastDelegatePropertyTranslator);

--- a/Source/UnrealSharpScriptGenerator/PropertyTranslators/StructPropertyTranslator.cs
+++ b/Source/UnrealSharpScriptGenerator/PropertyTranslators/StructPropertyTranslator.cs
@@ -19,7 +19,7 @@ public class StructPropertyTranslator : SimpleTypePropertyTranslator
 
     public override string GetMarshaller(UhtProperty property)
     {
-        return $"{GetManagedType(property)}Marshaller";
+        return $"StructMarshaller<{GetManagedType(property)}>";
     }
 
     public override void ExportCppDefaultParameterAsLocalVariable(GeneratorStringBuilder builder, string variableName, string defaultValue,

--- a/Source/UnrealSharpScriptGenerator/Utilities/FunctionUtilities.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/FunctionUtilities.cs
@@ -223,4 +223,30 @@ public static class FunctionUtilities
 
         return propertyDeterminingOutputType?.GetGenericManagedType() ?? string.Empty;
     }
+
+    public static bool HasCustomStructParamSupport(this UhtFunction function)
+    {
+        if (!function.HasMetadata("CustomStructureParam")) return false;
+
+        var customStructParams = function.GetCustomStructParams();
+        return customStructParams.All(customParamName =>
+            function.Properties.Count(param => param.EngineName == customParamName) == 1);
+    }
+
+    public static List<string> GetCustomStructParams(this UhtFunction function)
+    {
+        if (!function.HasMetadata("CustomStructureParam")) return new List<string>();
+
+        return function.GetMetadata("CustomStructureParam").Split(",").ToList();
+    }
+    
+    public static int GetCustomStructParamCount(this UhtFunction function) => function.GetCustomStructParams().Count;
+    
+    public static List<string> GetCustomStructParamTypes(this UhtFunction function)
+    {
+        if (!function.HasMetadata("CustomStructureParam")) return new List<string>();
+        int paramCount = function.GetCustomStructParamCount();
+        if (paramCount == 1) return new List<string> { "CSP" };
+        return Enumerable.Range(0, paramCount).ToList().ConvertAll(i => $"CSP{i}");
+    }
 }

--- a/Source/UnrealSharpScriptGenerator/Utilities/PropertyUtilities.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/PropertyUtilities.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection.Metadata;
 using EpicGames.Core;
@@ -303,5 +304,34 @@ public static class PropertyUtilities
         }
 
         return "";
+    }
+
+    public static bool IsCustomStructureType(this UhtProperty property)
+    {
+        if (property.Outer is not UhtFunction function) return false;
+        if (!function.HasCustomStructParamSupport()) return false;
+
+        if (function.GetCustomStructParams().Contains(property.EngineName))
+        {
+            PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(property);
+            return translator.CanSupportCustomStruct(property);
+        }
+
+        return false;
+    }
+
+    public static List<UhtProperty>? GetPrecedingParams(this UhtProperty property)
+    {
+        if (property.Outer is not UhtFunction function) return null;
+        return function.Children.Cast<UhtProperty>().TakeWhile(param => param != property).ToList();
+    }
+    
+    public static int GetPrecedingCustomStructParams(this UhtProperty property)
+    {
+        if (property.Outer is not UhtFunction function) return 0;
+        if (!function.HasCustomStructParamSupport()) return 0;
+
+        return property.GetPrecedingParams()!
+            .Count(param => param.IsCustomStructureType());
     }
 }


### PR DESCRIPTION
This PR moderately reworks struct and function exporting to allow for `UFunction`s with the `CustomStructureParam` metadata specifier to be exported as generic functions. This is accomplished with the following changes:

- Creates an interface `MarshalledStruct<T> where T: MarshalledStruct<T>`, containing several abstract static and member methods for generically getting the native `UScriptStruct` pointer and the native struct size, along with translating the structs to/from native buffers.
- Changes the script generator to automatically implement `MarshalledStruct` for all exported `UStruct`s, including manually exported blittable structs.
  - If requested, the automatically generated implementations can be manually copied to the manually exported types, and the code to generate the implementation for manually exported blittable types can be removed.
- `StructMarshaller<T> where T: MarshalledStruct<T>` has been implemented as a generic static class.
  - `UhtStructProperty`s now use `StructMarshaller<{engineName}>` as their marshaller type.
  - This leaves the mirror struct marshallers automatically generated by the script generator as dead code. The generation of these marshallers can be removed if requested.
- `UhtIntProperty`s that correspond to `CustomStructureParam`s of `UFunction`s export a generic type identifier as their managed type instead of `int`. This corresponds to a convention established in the Unreal source code, wherein any `UFunction` with `CustomStructureParam`s declares those parameters as `const int32&`s.
  - The marshaller used for these properties is exported as a `StructMarshaller` for the aforementioned generic type identifier.
- Adds the `UUFunctionExporter::CreateNativeFunctionCustomStructSpecialization` function, which creates a `UFunction` that is a copy of the base function, but with the appropriate set of `FProperty`s for the given custom structure types passed in. This is to ensure that the params buffer offsets are correct when invoking the function on the c++ side.
- Makes the following changes to function definition generation for any `UFunction` that has `CustomStructureParam`s.
  - `{functionName}_ParamsSize` is a generic function with a number of type parameters equal to the number of the function's `CustomStructureParam`s, and returns what size the params buffer should be given the passed in types.
  - For every parameter that comes after at least one `CustomStructureParam` in the native function's definition, `{functionName}_{parameterName}_NativeOffset` is a generic function. The number of type parameters of this function is equal to the number of `CustomStructureParam`s that come before the specified parameter in the definition, and returns what the actual offset of the parameter in the params buffer will be if the preceding `CustomStructureParam`s are the passed in types.
  - Adds a static member `Dictionary<{key}, IntPtr> {functionName}_Specializations`. The key for this member is a tuple of `UScriptStruct` pointers, and the value is a `UFunction` pointer.
  - Adds a static method `{functionName}_GetSpecialization`. This function tries to get the `UFunction` pointer from `{functionName}_Specializations` corresponding to the tuple of `UScriptStruct` pointers passed in. If no such function pointer exists in the dictionary, `UUFunctionExporter::CreateNativeFunctionCustomStructSpecialization` is called and the return value is saved to the dictionary and returned.
  - The function is exported with generic types in its signature, where each generic type `CSP{i}` implements `MarshalledStruct<CSP{i}>`.
  - During invocation, the pointer used in the call to `UUObjectExporter::InvokeNativeFunction` is obtained by calling `{functionName}_GetSpecialization`.
 ---
As a somewhat related change, I also added the exporter callback `UUFunctionExporter::InitializeFunctionParams`. While `UFunction` inherits `InitializeStruct` from `UStruct`, it does not provide an implementation for this method. As a result, initializing the params buffer using `UUStructExporter::InitializeStruct` did not properly initialize the struct parameters for the native function being invoked.

This only becomes a problem for non-POD `UStruct`s, which get copied from c# to c++ without a proper vtable pointer (at least, that's how it is when compiling using VC++, but similar problems likely exist for most other compilers). If such an improperly-initialized struct is passed to a function (particularly `UFunction`s with `CustomStructureParam`s), any attempts to call a virtual member function on that struct will result in an invalid pointer dereference.

`UUFunctionExporter::InitializeFunctionParams` manually iterates through the properties of the passed in `UFunction`, and initializes its structure params at the appropriate offsets in the passed in params buffer, ensuring they have correct vtable pointers by the time the marshallers translate c# structs to c++.

There were some other changes I need to do to get my desired use case working, but those are outside the scope of this PR, and could probably be accomplished by simply manually exporting the responsible type in a later PR.