### PR TITLE
Removed autogen .props files and added them to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,5 @@ DerivedDataCache/*
 bin/
 Generated/
 obj/
+
+*.props

--- a/Source/UnrealSharpScriptGenerator/UnrealSharpScriptGenerator.ubtplugin.csproj.props
+++ b/Source/UnrealSharpScriptGenerator/UnrealSharpScriptGenerator.ubtplugin.csproj.props
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<PropertyGroup>
-		<EngineDir Condition="'$(EngineDir)' == ''">C:\Program Files\Epic Games\UE_5.5\Engine</EngineDir>
-	</PropertyGroup>
-</Project>


### PR DESCRIPTION
This PR removes UnrealSharpScriptGenerator props file as it gets autogen when generating project files.

fixes #351