### PR TITLE
Fix ScriptGeneratorUtilities.GetExportedFunctions bug

### DIFF
--- a/Source/UnrealSharpScriptGenerator/Utilities/ScriptGeneratorUtilities.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/ScriptGeneratorUtilities.cs
@@ -177,11 +177,11 @@ public static class ScriptGeneratorUtilities
         return package.IsPartOfEngine() || package.GetModule() == Program.Factory.PluginModule;
     }
     
-    public static void GetExportedFunctions(UhtClass classObj, List<UhtFunction> functions, List<UhtFunction> overridableFunctions, Dictionary<string, GetterSetterPair> getterSetterPairs)
+     public static void GetExportedFunctions(UhtClass classObj, List<UhtFunction> functions, List<UhtFunction> overridableFunctions, Dictionary<string, GetterSetterPair> getterSetterPairs)
     {
-        List<UhtFunction> exportedFunctions = new();
+        List<UhtFunction> processedFunctions = new();
         
-        bool HasFunction(List<UhtFunction> functionsToCheck, UhtFunction functionToTest)
+        bool HasFunctionProcessed(List<UhtFunction> functionsToCheck, UhtFunction functionToTest)
         {
             foreach (UhtFunction function in functionsToCheck)
             {
@@ -202,6 +202,7 @@ public static class ScriptGeneratorUtilities
             
             if (function.IsAnyGetter() || function.IsAnySetter())
             {
+                processedFunctions.Add(function);
                 continue;
             }
 
@@ -218,7 +219,8 @@ public static class ScriptGeneratorUtilities
                     continue;
                 }
                 
-                if (structToConvertProperty.Package.IsPackagePartOfEngine() != function.Package.IsPackagePartOfEngine())
+                if (structToConvertProperty.Package.IsPackagePartOfEngine() != function.Package.IsPackagePartOfEngine()
+                    || structToConvertProperty.ScriptStruct.Package.IsPackagePartOfEngine() != function.Package.IsPackagePartOfEngine())
                 {
                     // For auto-casts to work, they both need to be in the same generated assembly. 
                     // Currently not supported, as we separate engine and project generated assemblies.
@@ -232,7 +234,7 @@ public static class ScriptGeneratorUtilities
                 functions.Add(function);
             }
 
-            exportedFunctions.Add(function);
+            processedFunctions.Add(function);
         }
 
         foreach (UhtClass declaration in classObj.GetInterfaces())
@@ -246,7 +248,7 @@ public static class ScriptGeneratorUtilities
             
             foreach (UhtFunction function in interfaceClass.Functions)
             {
-                if (HasFunction(exportedFunctions, function) || !CanExportFunction(function))
+                if (HasFunctionProcessed(processedFunctions, function) || !CanExportFunction(function))
                 {
                     continue;
                 }
@@ -259,6 +261,8 @@ public static class ScriptGeneratorUtilities
                 {
                     functions.Add(function);
                 }
+                
+                processedFunctions.Add(function);
             }
         }
     }

--- a/Source/UnrealSharpScriptGenerator/Utilities/ScriptGeneratorUtilities.cs
+++ b/Source/UnrealSharpScriptGenerator/Utilities/ScriptGeneratorUtilities.cs
@@ -177,7 +177,7 @@ public static class ScriptGeneratorUtilities
         return package.IsPartOfEngine() || package.GetModule() == Program.Factory.PluginModule;
     }
     
-     public static void GetExportedFunctions(UhtClass classObj, List<UhtFunction> functions, List<UhtFunction> overridableFunctions, Dictionary<string, GetterSetterPair> getterSetterPairs)
+    public static void GetExportedFunctions(UhtClass classObj, List<UhtFunction> functions, List<UhtFunction> overridableFunctions, Dictionary<string, GetterSetterPair> getterSetterPairs)
     {
         List<UhtFunction> processedFunctions = new();
         


### PR DESCRIPTION
## Fix two bug
- Fix AutocastExporter use wrong managed name in generated class.  Example see original issue https://github.com/UnrealSharp/UnrealSharp/pull/362

- Fix interface function exported twice if it is identified as a property getter or setter.

Example:

```c++
class MYGAME_API IMyInterface
{
  GENERATED_IINTERFACE_BODY()
  
  UFUNCTION()
  virtual WeaponObj* GetWeapon();
}

class MYGAME_API AMyActor: public IMyInterface
{
  GENERATED_UCLASS_BODY()
  
  UPROPERTY()
  WeaponObj* Weapon;
  
  UFUNCTION()
  virtual WeaponObj* GetWeapon() override
  {
    return Weapon;
  }
}
```

> P.S. It can be fixed by removing `UFUNCTION()` in the implementation class. But it is unnatural and generator can solve it more elegantly.