### PR TITLE
Fixes an issue with default tick settings not reapplying after hotreload

### DIFF
--- a/Source/UnrealSharpCore/TypeGenerator/Register/CSGeneratedClassBuilder.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Register/CSGeneratedClassBuilder.cpp
@@ -85,7 +85,8 @@ void FCSGeneratedClassBuilder::UpdateClassDefaultObject() const
 	
 	OwningAssembly->RemoveManagedObject(ClassDefaultObject);
 	
-	Field->GetDefaultObject(true);
+	UObject* DefaultObject = Field->GetDefaultObject(true);
+	SetupDefaultTickSettings(DefaultObject, Field);
 }
 
 void FCSGeneratedClassBuilder::CreateBlueprint(UClass* SuperClass)


### PR DESCRIPTION
This issue fixes default tick settings not being reapplied to the new CDO after a hot reload.

Fixes #383 