### PR TITLE
Fixes issues with loading UnrealSharp.metadata.json

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -80,7 +80,7 @@ public static class Program
             WriteIndented = false,
         });
 
-        var fileName = Path.Combine(outputDirectory.FullName, "UnrealSharp.metadata.json");
+        var fileName = Path.Combine(outputDirectory.FullName, "UnrealSharp.assemblyloadorder.json");
         File.WriteAllText(fileName, metaDataContent);
     }
     

--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -177,7 +177,7 @@ FString FCSProcHelper::GetUserAssemblyDirectory()
 
 FString FCSProcHelper::GetUnrealSharpMetadataPath()
 {
-	return FPaths::Combine(GetUserAssemblyDirectory(), "UnrealSharp.metadata.json");
+	return FPaths::Combine(GetUserAssemblyDirectory(), "UnrealSharp.assemblyloadorder.json");
 }
 
 void FCSProcHelper::GetProjectNamesByLoadOrder(TArray<FString>& UserProjectNames, const bool bIncludeProjectGlue)


### PR DESCRIPTION
This PR fixes some json errors when parsing UnrealSharp.metadata.json. Since the metadata is a different kinda of data structure it fails to get the normal fields in a user assembly.