### PR TITLE
Adds support for marshalling structs using `CppStructOps::Copy`, exports `FMoverDataCollection` using this functionality

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Interop/UScriptStructExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/UScriptStructExporter.cs
@@ -6,4 +6,6 @@ namespace UnrealSharp.Interop;
 public static unsafe partial class UScriptStructExporter
 {
     public static delegate* unmanaged<IntPtr, int> GetNativeStructSize;
+
+    public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, bool> NativeCopy;
 }

--- a/Source/UnrealSharpCore/Export/UScriptStructExporter.cpp
+++ b/Source/UnrealSharpCore/Export/UScriptStructExporter.cpp
@@ -10,3 +10,13 @@ int UUScriptStructExporter::GetNativeStructSize(const UScriptStruct* ScriptStruc
 	return ScriptStruct->GetStructureSize();
 }
 
+bool UUScriptStructExporter::NativeCopy(const UScriptStruct* ScriptStruct, void* Src, void* Dest)
+{
+	if (const auto CppStructOps = ScriptStruct->GetCppStructOps())
+	{
+		return CppStructOps->Copy(Dest, Src, 1);
+	}
+	
+	return false;
+}
+

--- a/Source/UnrealSharpCore/Export/UScriptStructExporter.h
+++ b/Source/UnrealSharpCore/Export/UScriptStructExporter.h
@@ -11,4 +11,7 @@ class UNREALSHARPCORE_API UUScriptStructExporter : public UObject
 public:
 	UNREALSHARP_FUNCTION()
 	static int GetNativeStructSize(const UScriptStruct* ScriptStruct);
+
+	UNREALSHARP_FUNCTION()
+	static bool NativeCopy(const UScriptStruct* ScriptStruct, void* Src, void* Dest);
 };

--- a/Source/UnrealSharpManagedGlue/CSharpExporter.cs
+++ b/Source/UnrealSharpManagedGlue/CSharpExporter.cs
@@ -235,7 +235,7 @@ public static class CSharpExporter
     
     private static void ExportType(UhtType type)
     {
-        bool isManualExport = PropertyTranslatorManager.ManuallyExportedTypes.Contains(type.SourceName);
+        bool isManualExport = PropertyTranslatorManager.BlittableTypes.Contains(type.SourceName);
 
         if (type.HasMetadata("NotGeneratorValid"))
         {

--- a/Source/UnrealSharpManagedGlue/Exporters/StructExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/StructExporter.cs
@@ -201,7 +201,7 @@ public static class StructExporter
         
         if (structObj.IsStructNativelyCopyable())
         {
-            builder.AppendLine("if(Allocation is null)");
+            builder.AppendLine("if (Allocation is null)");
             builder.OpenBrace();
             builder.AppendLine("Allocation = new byte[NativeDataSize];");
             builder.CloseBrace();

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslatorManager.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslatorManager.cs
@@ -7,12 +7,15 @@ namespace UnrealSharpScriptGenerator.PropertyTranslators;
 public static class PropertyTranslatorManager
 {
     private static readonly Dictionary<Type, List<PropertyTranslator>?> RegisteredTranslators = new();
-    public static readonly List<string> ManuallyExportedTypes = new();
+    public static readonly List<string> BlittableTypes = new();
+    public static readonly List<string> NativelyCopyableTypes = new();
     
     static PropertyTranslatorManager()
     {
-        ManuallyExportedTypes.Add("EStreamingSourcePriority");
-        ManuallyExportedTypes.Add("ETriggerEvent");
+        BlittableTypes.Add("EStreamingSourcePriority");
+        BlittableTypes.Add("ETriggerEvent");
+        
+        NativelyCopyableTypes.Add("FMoverDataCollection");
 
         EnumPropertyTranslator enumPropertyTranslator = new();
         AddPropertyTranslator(typeof(UhtEnumProperty), enumPropertyTranslator);
@@ -134,6 +137,6 @@ public static class PropertyTranslatorManager
     private static void AddBlittableCustomStructPropertyTranslator(string nativeName, string managedType)
     {
         AddPropertyTranslator(typeof(UhtStructProperty), new BlittableCustomStructTypePropertyTranslator(nativeName, managedType));
-        ManuallyExportedTypes.Add(nativeName);
+        BlittableTypes.Add(nativeName);
     }
 }

--- a/Source/UnrealSharpManagedGlue/Utilities/StructUtilities.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/StructUtilities.cs
@@ -8,7 +8,7 @@ public static class StructUtilities
 {
     public static bool IsStructBlittable(this UhtStruct structObj)
     {
-        if (PropertyTranslatorManager.ManuallyExportedTypes.Contains(structObj.SourceName))
+        if (PropertyTranslatorManager.BlittableTypes.Contains(structObj.SourceName))
         {
             return true;
         }
@@ -19,5 +19,10 @@ public static class StructUtilities
         // but have a non-UPROPERTY property that is not picked up by UHT, that makes it not blittable causing a mismatch in memory layout.
         // This is a temporary solution until we can get that working.
         return false;
+    }
+
+    public static bool IsStructNativelyCopyable(this UhtStruct structObj)
+    {
+        return PropertyTranslatorManager.NativelyCopyableTypes.Contains(structObj.SourceName);
     }
 }


### PR DESCRIPTION
`FMoverDataCollection` is a non-POD data type due to it having virtual methods (at least `StaticStruct`). However, it can be copied using `CppStructOps::Copy`, and has to be, due to possessing a non-reflected member property that is relevant for reflection-exposed functions. This PR adds support for marshalling structs by performing a native cpp struct ops copy, and adds that support to `FMoverDataCollection`.