### PR TITLE
Adds OnHotReload callback support

### DIFF
--- a/Source/UnrealSharpCore/CSAssembly.cpp
+++ b/Source/UnrealSharpCore/CSAssembly.cpp
@@ -368,6 +368,21 @@ UClass* FCSAssembly::FindClass(const FCSFieldName& FieldName) const
 	return Class;
 }
 
+
+TArray<UClass*> FCSAssembly::GetAllClasses() const
+{
+	 TArray<UClass*> AllClasses;
+	 for (const auto& Pair : Classes)
+	 {
+	 	UClass* uclass = FindClass(Pair.Key);
+	 	if ((uclass))
+	 	{
+	 		AllClasses.Add(uclass);
+	 	}
+	 }
+	return AllClasses;
+}
+
 UScriptStruct* FCSAssembly::FindStruct(const FCSFieldName& StructName) const
 {
 	UScriptStruct* Struct;

--- a/Source/UnrealSharpCore/CSAssembly.h
+++ b/Source/UnrealSharpCore/CSAssembly.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CSManagedGCHandle.h"
 #include "UnrealSharpCore.h"
@@ -27,7 +27,8 @@ struct FCSAssembly final : TSharedFromThis<FCSAssembly>, FUObjectArray::FUObject
 	UNREALSHARPCORE_API bool LoadAssembly(bool bIsCollectible = true);
 	UNREALSHARPCORE_API bool UnloadAssembly();
 	UNREALSHARPCORE_API bool IsValidAssembly() const { return ManagedAssemblyHandle.IsValid() && !ManagedAssemblyHandle->IsNull(); }
-
+	UNREALSHARPCORE_API TArray<UClass*> GetAllClasses() const;
+	
 	static UPackage* GetPackage(const FCSNamespace Namespace);
 
 	FName GetAssemblyName() const { return AssemblyName; }
@@ -51,6 +52,7 @@ struct FCSAssembly final : TSharedFromThis<FCSAssembly>, FUObjectArray::FUObject
 	TSharedPtr<FCSharpInterfaceInfo> FindInterfaceInfo(const FCSFieldName& InterfaceName) const;
 	
 	UClass* FindClass(const FCSFieldName& FieldName) const;
+
 	UScriptStruct* FindStruct(const FCSFieldName& StructName) const;
 	UEnum* FindEnum(const FCSFieldName& EnumName) const;
 	UClass* FindInterface(const FCSFieldName& InterfaceName) const;

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.h
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.h
@@ -36,6 +36,7 @@ public:
     // End
     
     void OnCSharpCodeModified(const TArray<struct FFileChangeData>& ChangedFiles);
+    void CallHotReloadCallbacks() const;
     void StartHotReload(bool bRebuild = true);
 
     bool IsHotReloading() const { return HotReloadStatus == Active; }


### PR DESCRIPTION
Enables UClasses to implement OnHotReload method, which is called after hot reload.

This allows for code to be executed after code changes are applied during runtime.

I've tested it on Pawns, Actors and UObjects, this is called per instance of object during RUNTIME only.  


```csharp
    [UFunction]
    public void OnHotReload()
    {
        Logger.Log($"UOBJECT {GetType().Name} Hot Reloaded");
    }
```