### PR TITLE
Natively-called c# Overrides Properly Copy Output Params

### DIFF
--- a/Source/UnrealSharpCore/TypeGenerator/Factories/CSFunctionFactory.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Factories/CSFunctionFactory.cpp
@@ -62,7 +62,7 @@ UCSFunctionBase* FCSFunctionFactory::CreateFunctionFromMetaData(UClass* Outer, c
 
 UCSFunctionBase* FCSFunctionFactory::CreateOverriddenFunction(UClass* Outer, UFunction* ParentFunction)
 {
-	const EFunctionFlags FunctionFlags = ParentFunction->FunctionFlags & (FUNC_FuncInherit | FUNC_Public | FUNC_Protected | FUNC_Private | FUNC_BlueprintPure);
+	const EFunctionFlags FunctionFlags = ParentFunction->FunctionFlags & (FUNC_FuncInherit | FUNC_Public | FUNC_Protected | FUNC_Private | FUNC_BlueprintPure | FUNC_HasOutParms);
 	UCSFunctionBase* NewFunction = CreateFunction(Outer, ParentFunction->GetFName(), FCSFunctionMetaData(), FunctionFlags, ParentFunction);
 	
 	TArray<FProperty*> FunctionProperties;

--- a/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
@@ -60,6 +60,10 @@ void UCSFunction_Params::InvokeManagedMethod_Params(UObject* ObjectToInvokeOn, F
 			FunctionParameter->CopyCompleteValue(ArgumentData.GetData() + FunctionParameter->GetOffset_ForInternal(), ValueAddress);
 		}
 	}
+	else
+	{
+		OutParameters = Stack.OutParms;
+	}
 	
 	if (!InvokeManagedEvent(ObjectToInvokeOn, Stack, Function, ArgumentBuffer, RESULT_PARAM))
 	{


### PR DESCRIPTION
`CSFunctionFactory::CreateOverriddenFunction` did not apply the `HasOutParms` function flag to overrides of functions that do.
This prevented `UObject::ProcessEvent` from creating an output property chain when invoking such functions. This is relevant for c# implementations of UInterface functions, as `ProcessEvent` is part of the code path used to execute non-native implementations of said functions.

Additionally, `CSFunction_Params::InvokeManagedMethod_Params` uses the output property chain of the passed in function (if present) when the function is being called from native code. This allows native invocations to correctly receive the output params of the c# function.