### PR TITLE
Updated UnrealSharp.Editor build tool nuget version

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Editor/UnrealSharp.Editor.csproj
+++ b/Managed/UnrealSharp/UnrealSharp.Editor/UnrealSharp.Editor.csproj
@@ -26,7 +26,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Build" Version="17.13.9" ExcludeAssets="runtime" />
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="15.1.548" ExcludeAssets="runtime" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.13.9" ExcludeAssets="runtime" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
This PR updates old version of Microsoft build tools being used instead of recent up-to-date version causing an issue with other nuget package.