### PR TITLE
Input Actions can be unbound from c#

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/EnhancedInput/EnhancedInputComponent.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/EnhancedInput/EnhancedInputComponent.cs
@@ -5,13 +5,27 @@ namespace UnrealSharp.EnhancedInput;
 
 public partial class UEnhancedInputComponent
 {
-    public void BindAction(UInputAction action, ETriggerEvent triggerEvent, Action<FInputActionValue, float, float, UInputAction> callback)
+    public bool BindAction(UInputAction action, ETriggerEvent triggerEvent, Action<FInputActionValue, float, float, UInputAction> callback, out uint handle)
     {
         if (callback.Target is not UObject unrealObject)
         {
             throw new ArgumentException("The callback must be a method within a UObject class.", nameof(callback));
         }
-        
-        UEnhancedInputComponentExporter.CallBindAction(NativeObject, action.NativeObject, triggerEvent, unrealObject.NativeObject, callback.Method.Name);
+        unsafe
+        {
+            fixed (uint* handlePtr = &handle)
+            {
+                return UEnhancedInputComponentExporter.CallBindAction(NativeObject, action.NativeObject, triggerEvent, unrealObject.NativeObject, callback.Method.Name, handlePtr);
+            }
+        }
+    }
+
+    public bool BindAction(UInputAction action, ETriggerEvent triggerEvent,
+        Action<FInputActionValue, float, float, UInputAction> callback) =>
+        BindAction(action, triggerEvent, callback, out var dummy);
+
+    public bool RemoveBinding(uint handle)
+    {
+        return UEnhancedInputComponentExporter.CallRemoveBindingByHandle(NativeObject, handle);
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp/Interop/UEnhancedInputComponentExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/UEnhancedInputComponentExporter.cs
@@ -6,5 +6,7 @@ namespace UnrealSharp.Interop;
 [NativeCallbacks]
 public static unsafe partial class UEnhancedInputComponentExporter
 {
-    public static delegate* unmanaged<IntPtr, IntPtr, ETriggerEvent, IntPtr, FName, void> BindAction;
+    public static delegate* unmanaged<IntPtr, IntPtr, ETriggerEvent, IntPtr, FName, IntPtr, bool> BindAction;
+
+    public static delegate* unmanaged<IntPtr, uint, bool> RemoveBindingByHandle;
 }

--- a/Source/UnrealSharpCore/Export/UEnhancedInputComponentExporter.cpp
+++ b/Source/UnrealSharpCore/Export/UEnhancedInputComponentExporter.cpp
@@ -1,12 +1,22 @@
 ﻿#include "UEnhancedInputComponentExporter.h"
 #include "EnhancedInputComponent.h"
 
-void UUEnhancedInputComponentExporter::BindAction(UEnhancedInputComponent* InputComponent, UInputAction* InputAction, ETriggerEvent TriggerEvent, UObject* Object, const FName FunctionName)
+bool UUEnhancedInputComponentExporter::BindAction(UEnhancedInputComponent* InputComponent, UInputAction* InputAction, ETriggerEvent TriggerEvent, UObject* Object, const FName FunctionName, uint32* OutHandle)
 {
 	if (!IsValid(InputComponent) || !IsValid(InputAction))
 	{
-		return;
+		return false;
 	}
-	
-	InputComponent->BindAction(InputAction, TriggerEvent, Object, FunctionName);
+	*OutHandle = InputComponent->BindAction(InputAction, TriggerEvent, Object, FunctionName).GetHandle();
+	return true;
+}
+
+bool UUEnhancedInputComponentExporter::RemoveBindingByHandle(UEnhancedInputComponent* InputComponent, const uint32 Handle)
+{
+	if (!IsValid(InputComponent))
+	{
+		return false;
+	}
+
+	return InputComponent->RemoveBindingByHandle(Handle);
 }

--- a/Source/UnrealSharpCore/Export/UEnhancedInputComponentExporter.h
+++ b/Source/UnrealSharpCore/Export/UEnhancedInputComponentExporter.h
@@ -17,6 +17,9 @@ class UNREALSHARPCORE_API UUEnhancedInputComponentExporter : public UObject
 public:
 
 	UNREALSHARP_FUNCTION()
-	static void BindAction(UEnhancedInputComponent* InputComponent, UInputAction* InputAction, ETriggerEvent TriggerEvent, UObject* Object, const FName FunctionName);
+	static bool BindAction(UEnhancedInputComponent* InputComponent, UInputAction* InputAction, ETriggerEvent TriggerEvent, UObject* Object, const FName FunctionName, uint32* OutHandle);
+
+	UNREALSHARP_FUNCTION()
+	static bool RemoveBindingByHandle(UEnhancedInputComponent* InputComponent, const uint32 Handle);
 	
 };


### PR DESCRIPTION
This PR allows input actions to be unbound after binding them. To do this, `UEnhancedInputComponent.BindAction` now has an `out uint` parameter that returns the binding's unique handle. The old signature is now an overload that discards the handle parameter. You can pass the output handle to `UEnhancedInputComponent.UnbindAction` to unbind the Action from the Input Action. Both `BindAction` and `UnbindAction` now return `bool`, specifying whether their respective operations were successful.