### PR TITLE
Added memcpy fallback for NativeCopy

### DIFF
--- a/Source/UnrealSharpCore/Export/UScriptStructExporter.cpp
+++ b/Source/UnrealSharpCore/Export/UScriptStructExporter.cpp
@@ -14,7 +14,15 @@ bool UUScriptStructExporter::NativeCopy(const UScriptStruct* ScriptStruct, void*
 {
 	if (const auto CppStructOps = ScriptStruct->GetCppStructOps())
 	{
-		return CppStructOps->Copy(Dest, Src, 1);
+		if (CppStructOps->HasCopy())
+		{
+			return CppStructOps->Copy(Dest, Src, 1);
+		}
+		else
+		{
+			FMemory::Memcpy(Dest, Src, CppStructOps->GetSize());
+			return true;
+		}
 	}
 	
 	return false;


### PR DESCRIPTION
This PR adds a fallback memcpy if the CppStructOps doesn't have the capability of copying.