### PR TITLE
-fix native and managed function size mismatch due to wrong parameter definition

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Rotator.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Rotator.cs
@@ -76,7 +76,7 @@ public partial struct FRotator
     // Convert the rotator into a vector facing in its direction.
     public FVector ToVector()
     {
-        return FVectorExporter.CallFromRotator(out this);
+        return FVectorExporter.CallFromRotator(this);
     }
 
     public static FRotator operator + (FRotator lhs, FRotator rhs)

--- a/Managed/UnrealSharp/UnrealSharp/Interop/FVectorExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/FVectorExporter.cs
@@ -6,5 +6,5 @@ namespace UnrealSharp.Interop;
 [NativeCallbacks]
 public unsafe partial class FVectorExporter
 {
-    public static delegate* unmanaged<out FRotator, FVector> FromRotator;
+    public static delegate* unmanaged<FRotator, FVector> FromRotator;
 }


### PR DESCRIPTION
fix for the NativeFunction.Size (48) and ManagedFunctionSize (32) size mismatch.