### PR TITLE
Fixed stack frame corruption when calling to C# from Blueprints

### DIFF
--- a/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
@@ -8,6 +8,7 @@ void UCSFunction_Params::InvokeManagedMethod_Params(UObject* ObjectToInvokeOn, F
 	FOutParmRec* OutParameters = nullptr;
 	FOutParmRec** LastOut = &OutParameters;
 	uint8* ArgumentBuffer = Stack.Locals;
+	uint8* LocalsCache = Stack.Locals;
 
 	// If we're calling this from BP, we need to copy the parameters to a new buffer
 	if (Stack.Code)
@@ -82,4 +83,7 @@ void UCSFunction_Params::InvokeManagedMethod_Params(UObject* ObjectToInvokeOn, F
 	{
 		Function->DestroyStruct(ArgumentBuffer);
 	}
+
+	// Restore the local pointer so we are still pointing to the right location
+	Stack.Locals = LocalsCache;
 }


### PR DESCRIPTION
Fixed an issue where the location of the local variables in the stack frame is changed and not restored before the call ends, leading to stack corruption when making additional calls.