### PR TITLE
Fix alphabetical struct processing issue where a struct could be processed before its dependency.

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/UnrealStructProcessor.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/UnrealStructProcessor.cs
@@ -1,4 +1,4 @@
-﻿using Mono.Cecil;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using UnrealSharpWeaver.MetaData;
 using UnrealSharpWeaver.Utilities;
@@ -20,7 +20,31 @@ public static class UnrealStructProcessor
         var structHandlingOrder = new List<TypeDefinition>();
         var structMetadata = new Dictionary<TypeDefinition, StructMetaData>();
 
-        foreach (var unrealStruct in structs.Where(unrealStruct => !pushedStructs.Contains(unrealStruct)))
+        var sortedStructs = structs.ToList();
+        sortedStructs.Sort((a, b) =>
+        {
+            var aMetadata = new StructMetaData(a);
+            var bMetadata = new StructMetaData(b);
+
+            foreach (var Field in aMetadata.Fields)
+            {
+                if (Field.PropertyDataType.CSharpType.FullName.Contains(bMetadata.TypeRef.FullName))
+                {
+                    return 1;
+                }
+            }
+
+            foreach (var Field in bMetadata.Fields)
+            {
+                if (Field.PropertyDataType.CSharpType.FullName.Contains(aMetadata.TypeRef.Name))
+                {
+                    return -1;
+                }
+            }
+            return 0;
+        });
+
+        foreach (var unrealStruct in sortedStructs.Where(unrealStruct => !pushedStructs.Contains(unrealStruct)))
         {
             structStack.Push(unrealStruct);
             pushedStructs.Add(unrealStruct);
@@ -47,10 +71,9 @@ public static class UnrealStructProcessor
                 }
             }
         }
-        
         assemblyMetadata.StructMetaData = structMetadata.Values.ToList();
         
-        foreach (var currentStruct in structHandlingOrder) 
+        foreach (var currentStruct in structHandlingOrder)
         {
             ProcessStruct(currentStruct, structMetadata[currentStruct]);
         }


### PR DESCRIPTION
Fix for following error
"
Error during assembly processing: Could not find marshaller class FPointMarshaller for type ManagedTesting.FPoint
System.AggregateException: Assembly processing failed (Could not find marshaller class FPointMarshaller for type ManagedTesting.FPoint)
 ---> System.Exception: Could not find marshaller class FPointMarshaller for type ManagedTesting.FPoint
".

 
The issue occurs because FContainerData is processed before FPoint, preventing the processor from locating the corresponding Marshaller class.

Test code below
File: ContainerData.cs
```
using UnrealSharp.Attributes;

namespace ManagedTesting
{
    [UStruct]
    public struct FContainerData
    {
        [UProperty(PropertyFlags.BlueprintReadOnly)]
        public IList<FPoint> X;
    }
}
```

File: Point.cs
```
using UnrealSharp.Attributes;

namespace ManagedTesting
{
    [UStruct]
    public struct FPoint
    {
        [UProperty(PropertyFlags.BlueprintReadOnly)]
        public int X;

        [UProperty(PropertyFlags.BlueprintReadOnly)]
        public int Y;

        [UProperty(PropertyFlags.BlueprintReadOnly)]
        public bool IsValid;
    }
}
    ```