### PR TITLE
Added support for using custom getters/setters for properties

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Attributes/UPropertyAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/UPropertyAttribute.cs
@@ -128,4 +128,6 @@ public sealed class UPropertyAttribute(PropertyFlags flags = PropertyFlags.None)
     public string BlueprintGetter = "";
     
     public int ArrayDim = 1;
+
+    public string? BackingField;
 }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/PropertyMetaData.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/PropertyMetaData.cs
@@ -1,4 +1,5 @@
-﻿using Mono.Cecil;
+﻿using System.Text.Json.Serialization;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using UnrealSharpWeaver.NativeTypes;
 using UnrealSharpWeaver.Utilities;
@@ -13,6 +14,10 @@ public class PropertyMetaData : BaseMetaData
     public LifetimeCondition LifetimeCondition { get; set; } = LifetimeCondition.None;
     public string BlueprintSetter { get; set; } = string.Empty;
     public string BlueprintGetter { get; set; } = string.Empty;
+    public string? BackingField { get; set; } = null;
+    public bool HasCustomAccessors { get; set; } = false;
+    [JsonIgnore]
+    public PropertyDefinition? GeneratedAccessorProperty { get; set; } = null;
 
     // Non-serialized for JSON
     public FieldDefinition? PropertyOffsetField;
@@ -70,14 +75,31 @@ public class PropertyMetaData : BaseMetaData
             throw new InvalidPropertyException(property, "Unreal properties must have a default get method");
         }
         
-        if (!getter.MethodIsCompilerGenerated())
-        {
-            throw new InvalidPropertyException(property, "Getter can not have a body for Unreal properties");
-        }
+        // Check if we have custom accessors
+        bool hasCustomGetter = !getter.MethodIsCompilerGenerated();
+        bool hasCustomSetter = setter != null && !setter.MethodIsCompilerGenerated();
 
-        if (setter != null && !getter.MethodIsCompilerGenerated())
+        HasCustomAccessors = hasCustomGetter || hasCustomSetter;
+
+        // Allow custom getter/setter implementations
+        if (!HasCustomAccessors)
         {
-            throw new InvalidPropertyException(property, "Setter can not have a body for Unreal properties");
+            // Only throw exception if not a custom accessor
+            if (!getter.MethodIsCompilerGenerated())
+            {
+                throw new InvalidPropertyException(property, "Getter can not have a body for Unreal properties unless it's a custom accessor");
+            }
+
+            if (setter != null && !setter.MethodIsCompilerGenerated())
+            {
+                throw new InvalidPropertyException(property, "Setter can not have a body for Unreal properties unless it's a custom accessor");
+            }
+        }
+        else
+        {
+            // Register custom accessors as UFunctions if they have BlueprintGetter/Setter specified
+            RegisterPropertyAccessorAsUFunction(property.GetMethod, true);
+            RegisterPropertyAccessorAsUFunction(property.SetMethod, false);
         }
         
         if (getter.IsPrivate && PropertyFlags.HasFlag(PropertyFlags.BlueprintVisible))
@@ -192,6 +214,12 @@ public class PropertyMetaData : BaseMetaData
         }
         
         PropertyFlags = flags;
+
+        CustomAttributeArgument? backingFieldArgument = upropertyAttribute.FindAttributeField("BackingField");
+        if (backingFieldArgument.HasValue)
+        {
+            BackingField = (string) backingFieldArgument.Value.Value;
+        }
     }
     
     public void InitializePropertyPointers(ILProcessor processor, Instruction loadNativeType, Instruction setPropertyPointer)
@@ -212,5 +240,55 @@ public class PropertyMetaData : BaseMetaData
     public static PropertyMetaData FromTypeReference(TypeReference typeRef, string paramName, ParameterType modifier = ParameterType.None)
     {
         return new PropertyMetaData(typeRef, paramName, modifier);
+    }
+    
+    private void RegisterPropertyAccessorAsUFunction(MethodDefinition accessorMethod, bool isGetter)
+    {
+        if (accessorMethod == null)
+        {
+            return;
+        }
+
+        // Set the appropriate blueprint accessor name based on getter or setter
+        if (isGetter)
+        {
+            BlueprintGetter = accessorMethod.Name;
+        }
+        else
+        {
+            BlueprintSetter = accessorMethod.Name;
+        }
+
+        // Add UFunction attribute if not already present
+        if (!accessorMethod.IsUFunction())
+        {
+            var ufunctionCtor = WeaverImporter.Instance.UserAssembly.MainModule.ImportReference(
+                WeaverImporter.Instance.UFunctionAttributeConstructor);
+
+            // Create constructor arguments array
+            var ctorArgs = new[]
+            {
+                // First argument - FunctionFlags (combine BlueprintCallable with BlueprintPure for getters)
+                new CustomAttributeArgument(
+                    WeaverImporter.Instance.UInt64TypeRef,
+                    (ulong)(isGetter 
+                        ? EFunctionFlags.BlueprintCallable | EFunctionFlags.BlueprintPure 
+                        : EFunctionFlags.BlueprintCallable))
+            };
+
+            var ufunctionAttribute = new CustomAttribute(ufunctionCtor)
+            {
+                ConstructorArguments = { ctorArgs[0] }
+            };
+
+            accessorMethod.CustomAttributes.Add(ufunctionAttribute);
+            
+            var blueprintInternalUseOnlyCtor = WeaverImporter.Instance.UserAssembly.MainModule.ImportReference(
+                WeaverImporter.Instance.BlueprintInternalUseAttributeConstructor);
+            accessorMethod.CustomAttributes.Add(new CustomAttribute(blueprintInternalUseOnlyCtor));
+        }
+
+        // Make the method public to be accessible from Blueprint
+        accessorMethod.Attributes = (accessorMethod.Attributes & ~MethodAttributes.MemberAccessMask) | MethodAttributes.Public;
     }
 }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/PropertyProcessor.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/PropertyProcessor.cs
@@ -3,6 +3,7 @@ using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
 using UnrealSharpWeaver.MetaData;
 using UnrealSharpWeaver.NativeTypes;
+using UnrealSharpWeaver.Utilities;
 
 namespace UnrealSharpWeaver.TypeProcessors;
 
@@ -40,11 +41,24 @@ public static class PropertyProcessor
             
             if (prop.MemberRef.Resolve() is PropertyDefinition propertyRef)
             {
-                prop.PropertyDataType.WriteGetter(type, propertyRef.GetMethod, loadBuffer, nativePropertyField);
-                prop.PropertyDataType.WriteSetter(type, propertyRef.SetMethod, loadBuffer, nativePropertyField);
+                if (prop.HasCustomAccessors)
+                {
+                    // For custom accessors, create a private property with marshalling code
+                    string backingFieldName = RemovePropertyBackingField(type, prop);
+                    PropertyDefinition privateProperty = CreatePrivateAccessorProperty(type, prop, propertyRef, loadBuffer, nativePropertyField);
+                    prop.GeneratedAccessorProperty = privateProperty;
 
-                string backingFieldName = RemovePropertyBackingField(type, prop);
-                removedBackingFields.Add(backingFieldName, (prop, propertyRef, offsetField, nativePropertyField));
+                    removedBackingFields.Add(backingFieldName, (prop, privateProperty, offsetField, nativePropertyField));
+                }
+                else
+                {
+                    // Standard property handling
+                    prop.PropertyDataType.WriteGetter(type, propertyRef.GetMethod, loadBuffer, nativePropertyField);
+                    prop.PropertyDataType.WriteSetter(type, propertyRef.SetMethod, loadBuffer, nativePropertyField);
+
+                    string backingFieldName = RemovePropertyBackingField(type, prop);
+                    removedBackingFields.Add(backingFieldName, (prop, propertyRef, offsetField, nativePropertyField));
+                }
             }
             
             prop.PropertyOffsetField = offsetField;
@@ -53,24 +67,25 @@ public static class PropertyProcessor
         RemoveBackingFieldReferences(type, removedBackingFields);
     }
     
-    static void RemoveBackingFieldReferences(TypeDefinition type, Dictionary<string, (PropertyMetaData, PropertyDefinition, FieldDefinition, FieldDefinition?)> strippedFields)
+    private static void RemoveBackingFieldReferences(TypeDefinition type, Dictionary<string, (PropertyMetaData, PropertyDefinition, FieldDefinition, FieldDefinition?)> strippedFields)
     {
-        foreach (MethodDefinition? constructor in type.GetConstructors().ToList())
+        foreach (MethodDefinition? method in type.GetMethods())
         {
-            if (!constructor.HasBody)
+            if (!method.HasBody)
             {
                 continue;
             }
 
+            bool isConstructor = method.IsConstructor;
             bool baseCallFound = false;
             var alteredInstructions = new List<Instruction>();
             var deferredInstructions = new List<Instruction>();
 
-            foreach (Instruction? instr in constructor.Body.Instructions)
+            foreach (Instruction? instr in method.Body.Instructions)
             {
                 alteredInstructions.Add(instr);
 
-                if (instr.Operand is MethodReference baseCtor && baseCtor.Name == ".ctor")
+                if (isConstructor && instr.Operand is MethodReference baseCtor && baseCtor.Name == ".ctor")
                 {
                     baseCallFound = true;
                     alteredInstructions.AddRange(deferredInstructions);
@@ -87,10 +102,16 @@ public static class PropertyProcessor
                     continue;
                 }
 
-                // for now, we only handle simple stores
+                // Handle both loads (Ldfld) and stores (Stfld)
+                if (instr.OpCode == OpCodes.Ldfld)
+                {
+                    ReplaceFieldLoadWithPropertyGetter(prop, instr, alteredInstructions);
+                    continue;
+                }
+                
                 if (instr.OpCode != OpCodes.Stfld)
                 {
-                    throw new UnableToFixPropertyBackingReferenceException(constructor, prop.def, instr.OpCode);
+                    throw new UnableToFixPropertyBackingReferenceException(method, prop.def, instr.OpCode);
                 }
 
                 MethodDefinition? setMethod = prop.def.SetMethod;
@@ -105,67 +126,86 @@ public static class PropertyProcessor
                     setMethod.Parameters.Add(new ParameterDefinition(prop.def.PropertyType));
                     type.Methods.Add(setMethod);
                     
-                    Instruction[] loadBuffer = NativeDataType.GetArgumentBufferInstructions(null, prop.offsetField);
-                    prop.meta.PropertyDataType.WriteSetter(type, prop.def.SetMethod, loadBuffer, prop.nativePropertyField);
+                    // If this is a property with custom accessors, we need to use the generated property
+                    if (prop.meta.HasCustomAccessors && prop.meta.GeneratedAccessorProperty != null)
+                    {
+                        // Use the generated accessor's set method
+                        setMethod = prop.meta.GeneratedAccessorProperty.SetMethod;
+                    }
+                    else
+                    {
+                        // Standard property handling
+                        Instruction[] loadBuffer = NativeDataType.GetArgumentBufferInstructions(null, prop.offsetField);
+                        prop.meta.PropertyDataType.WriteSetter(type, prop.def.SetMethod, loadBuffer, prop.nativePropertyField);
+                    }
                 }
 
-                var newInstr = Instruction.Create((setMethod.IsReuseSlot && setMethod.IsVirtual) ? OpCodes.Callvirt : OpCodes.Call, setMethod);
+                // Determine which setter to call based on whether we have custom accessors
+                var methodToCall = (prop.meta.HasCustomAccessors && prop.meta.GeneratedAccessorProperty != null) 
+                    ? prop.meta.GeneratedAccessorProperty.SetMethod 
+                    : setMethod;
+
+                var newInstr = Instruction.Create((methodToCall.IsReuseSlot && methodToCall.IsVirtual) ? OpCodes.Callvirt : OpCodes.Call, methodToCall);
                 newInstr.Offset = instr.Offset;
                 alteredInstructions[alteredInstructions.Count - 1] = newInstr;
 
-                // now the hairy bit. initializers happen _before_ the base ctor call, so the NativeObject is not yet set, and they fail
-                //we need to relocate these to after the base ctor call
-                if (baseCallFound)
+                // Only perform constructor-specific operations for constructors
+                if (isConstructor)
                 {
-                    // if they're after the base ctor call it's fine
-                    continue;
-                }
+                    // now the hairy bit. initializers happen _before_ the base ctor call, so the NativeObject is not yet set, and they fail
+                    //we need to relocate these to after the base ctor call
+                    if (baseCallFound)
+                    {
+                        // if they're after the base ctor call it's fine
+                        continue;
+                    }
 
-                //handle the simple pattern `ldarg0; ldconst*; call set_*`
-                if (alteredInstructions[^3].OpCode != OpCodes.Ldarg_0)
-                {
-                    throw new UnsupportedPropertyInitializerException(prop.def); 
-                }
+                    //handle the simple pattern `ldarg0; ldconst*; call set_*`
+                    if (alteredInstructions[^3].OpCode != OpCodes.Ldarg_0)
+                    {
+                        throw new UnsupportedPropertyInitializerException(prop.def); 
+                    }
 
-                var ldconst = alteredInstructions[^2];
-                
-                if (!IsLdconst(ldconst))
-                {
-                    throw new UnsupportedPropertyInitializerException(prop.def);
+                    var ldconst = alteredInstructions[^2];
+
+                    if (!IsLdconst(ldconst))
+                    {
+                        throw new UnsupportedPropertyInitializerException(prop.def);
+                    }
+
+                    CopyLastElements(alteredInstructions, deferredInstructions, 3);
                 }
-                
-                CopyLastElements(alteredInstructions, deferredInstructions, 3);
             }
 
             //add back the instructions and fix up their offsets
-            constructor.Body.Instructions.Clear();
+            method.Body.Instructions.Clear();
             int offset = 0;
             foreach (var instr in alteredInstructions)
             {
                 int oldOffset = instr.Offset;
                 instr.Offset = offset;
-                constructor.Body.Instructions.Add(instr);
+                method.Body.Instructions.Add(instr);
 
                 //fix up the sequence point offsets too
-                if (constructor.DebugInformation == null || oldOffset == offset)
+                if (method.DebugInformation == null || oldOffset == offset)
                 {
                     continue;
                 }
-                
+
                 //this only uses the offset so doesn't matter that we replaced the instruction
-                var seqPoint = constructor.DebugInformation?.GetSequencePoint(instr);
+                var seqPoint = method.DebugInformation?.GetSequencePoint(instr);
                 if (seqPoint == null)
                 {
                     continue;
                 }
-                
-                if (constructor.DebugInformation == null)
+
+                if (method.DebugInformation == null)
                 {
                     continue;
                 }
-                
-                constructor.DebugInformation.SequencePoints.Remove(seqPoint);
-                constructor.DebugInformation.SequencePoints.Add(
+
+                method.DebugInformation.SequencePoints.Remove(seqPoint);
+                method.DebugInformation.SequencePoints.Add(
                     new SequencePoint(instr, seqPoint.Document)
                     {
                         StartLine = seqPoint.StartLine,
@@ -176,10 +216,24 @@ public static class PropertyProcessor
             }
         }
     }
-        
-    static string RemovePropertyBackingField(TypeDefinition type, PropertyMetaData prop)
+    private static void ReplaceFieldLoadWithPropertyGetter((PropertyMetaData meta, PropertyDefinition def, FieldDefinition offsetField, FieldDefinition? nativePropertyField) prop, Instruction instr, List<Instruction> alteredInstructions)
     {
-        string backingFieldName = $"<{prop.Name}>k__BackingField";
+        // Replace field load with property getter call
+        MethodDefinition? getMethod = prop.def.GetMethod;
+
+        // Determine which getter to call based on whether we have custom accessors
+        var methodToCall = (prop.meta.HasCustomAccessors && prop.meta.GeneratedAccessorProperty != null)
+            ? prop.meta.GeneratedAccessorProperty.GetMethod
+            : getMethod;
+
+        var newInstr = Instruction.Create((methodToCall.IsReuseSlot && methodToCall.IsVirtual) ? OpCodes.Callvirt : OpCodes.Call, methodToCall);
+        newInstr.Offset = instr.Offset;
+        alteredInstructions[alteredInstructions.Count - 1] = newInstr;
+    }
+
+    private static string RemovePropertyBackingField(TypeDefinition type, PropertyMetaData prop)
+    {
+        string backingFieldName = prop.BackingField ?? $"<{prop.Name}>k__BackingField";
 
         for (var i = 0; i < type.Fields.Count; i++)
         {
@@ -231,5 +285,26 @@ public static class PropertyProcessor
         {
             from.RemoveAt(i);
         }
+    }
+
+    private static PropertyDefinition CreatePrivateAccessorProperty(TypeDefinition type, PropertyMetaData prop, PropertyDefinition originalProperty, Instruction[] loadBuffer, FieldDefinition? nativePropertyField)
+    {
+        // Create a new private property with the same type for marshalling
+        string privatePropertyName = $"<{prop.Name}>k__MarshallingProperty";
+        PropertyDefinition privateProperty = new PropertyDefinition(privatePropertyName, PropertyAttributes.None, originalProperty.PropertyType);
+        privateProperty.GetMethod = new MethodDefinition($"get_{privatePropertyName}", MethodAttributes.Private | MethodAttributes.SpecialName | MethodAttributes.HideBySig, originalProperty.PropertyType);
+        privateProperty.SetMethod = new MethodDefinition($"set_{privatePropertyName}", MethodAttributes.Private | MethodAttributes.SpecialName | MethodAttributes.HideBySig, WeaverImporter.Instance.VoidTypeRef);
+        privateProperty.SetMethod.Parameters.Add(new ParameterDefinition("value", ParameterAttributes.None, originalProperty.PropertyType));
+
+        // Add the methods and property to the type
+        type.Methods.Add(privateProperty.GetMethod);
+        type.Methods.Add(privateProperty.SetMethod);
+        type.Properties.Add(privateProperty);
+
+        // Generate the getter and setter implementations
+        prop.PropertyDataType.WriteGetter(type, privateProperty.GetMethod, loadBuffer, nativePropertyField);
+        prop.PropertyDataType.WriteSetter(type, privateProperty.SetMethod, loadBuffer, nativePropertyField);
+
+        return privateProperty;
     }
 }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverImporter.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverImporter.cs
@@ -30,6 +30,8 @@ public class WeaverImporter
     public static readonly string UObjectCallbacks = "UObjectExporter";
     public static readonly string UScriptStructCallbacks = "UScriptStructExporter";
     public static readonly string UFunctionCallbacks = "UFunctionExporter";
+    public MethodReference? UFunctionAttributeConstructor => UnrealSharpAssembly.FindType("UFunctionAttribute", "UnrealSharp.Attributes")?.FindMethod(".ctor");
+    public MethodReference? BlueprintInternalUseAttributeConstructor => UnrealSharpAssembly.FindType("BlueprintInternalUseOnlyAttribute", "UnrealSharp.Attributes.MetaTags")?.FindMethod(".ctor");
     public static readonly string MulticastDelegatePropertyCallbacks = "FMulticastDelegatePropertyExporter";
     public static readonly string UStructCallbacks = "UStructExporter";
     
@@ -51,6 +53,7 @@ public class WeaverImporter
     public TypeDefinition IInterfaceType = null!;
     public MethodReference GetNativeFunctionFromInstanceAndNameMethod = null!;
     public TypeReference Int32TypeRef = null!;
+    public TypeReference UInt64TypeRef = null!;
     public TypeReference VoidTypeRef = null!;
     public TypeReference ByteTypeRef = null!;
     public MethodReference GetNativeClassFromNameMethod = null!;
@@ -96,6 +99,7 @@ public class WeaverImporter
         TypeSystem typeSystem = UserAssembly.MainModule.TypeSystem;
         
         Int32TypeRef = typeSystem.Int32;
+        UInt64TypeRef = typeSystem.UInt64;
         VoidTypeRef = typeSystem.Void;
         ByteTypeRef = typeSystem.Byte;
         

--- a/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
@@ -8,6 +8,7 @@ void UCSFunction_Params::InvokeManagedMethod_Params(UObject* ObjectToInvokeOn, F
 	FOutParmRec* OutParameters = nullptr;
 	FOutParmRec** LastOut = &OutParameters;
 	uint8* ArgumentBuffer = Stack.Locals;
+	uint8* LocalsCache = Stack.Locals;
 
 	// If we're calling this from BP, we need to copy the parameters to a new buffer
 	if (Stack.Code)
@@ -82,4 +83,7 @@ void UCSFunction_Params::InvokeManagedMethod_Params(UObject* ObjectToInvokeOn, F
 	{
 		Function->DestroyStruct(ArgumentBuffer);
 	}
+
+	// Restore the local pointer so we are still pointing to the right location
+	Stack.Locals = LocalsCache;
 }


### PR DESCRIPTION
Closes #135 

This has been an outstanding feature request that is going to help reduce a fair amount of boilerplate.
 
The following changes have been applied:

1. UProperties are now allowed to have custom getters/setters
2. A new attribute field has been added to specify the name of the backing field. If left empty, it will default to the compiler-generated backing field name, which should allow for the use of the [upcomming field keywork in C# 14](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/field-keyword)
3. If a property has either a custom getter or custom setter-defined the getter and setter are marked a UFunctions with BlueprintCallable and BlueprintInternalUseOnly, and those functions are automatically asigned to the getter and setter.
4. The backing field is replaced like it was before but now when replacements are made it scans the entire class for field access and replaces those with calls to accessing a new weaver generated property that contains the native interop. This way the user should be able to use the field within the class internals for access.

There only known limitation of this that I am aware of when debugging if you hover over the backing field it doesn't claims that it is unknown in the current context. I'm not sure if we need to make additional changes to the debug symbols to handle that gracefully, or if the generated property should share the name of the field.