### PR TITLE
Added support for the marshalling of FFieldPath and TFieldPath

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/FieldPath.cs
+++ b/Managed/UnrealSharp/UnrealSharp/FieldPath.cs
@@ -1,0 +1,86 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using UnrealSharp.Core;
+using UnrealSharp.Core.Marshallers;
+using UnrealSharp.CoreUObject;
+using UnrealSharp.Interop;
+
+namespace UnrealSharp;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct FFieldPathUnsafe {
+    internal IntPtr ResolvedField;
+#if !PACKAGE
+    internal IntPtr InitialFieldClass;
+    internal int FieldPathSerialNumber;
+#endif
+    internal TWeakObjectPtr<UStruct> ResolvedOwner;
+    internal UnmanagedArray Path;
+
+    
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct FFieldPath : IEquatable<FFieldPath> {
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    internal FFieldPathUnsafe PathUnsafe;
+    
+    public bool IsValid => FFieldPathExporter.CallIsValid(ref PathUnsafe).ToManagedBool();
+    public bool IsStale => FFieldPathExporter.CallIsStale(ref PathUnsafe).ToManagedBool();
+
+    public FFieldPath(FFieldPathUnsafe pathUnsafe) {
+        PathUnsafe = pathUnsafe;
+    }
+    
+    public override string ToString() {
+        unsafe
+        {
+            UnmanagedArray buffer = new();
+            try
+            {
+                FFieldPathExporter.CallFieldPathToString(ref PathUnsafe, ref buffer);
+                return new string((char*)buffer.Data);
+            }
+            finally
+            {
+                buffer.Destroy();
+            }
+        }
+    }
+    
+    public bool Equals(FFieldPath other) {
+        return FFieldPathExporter.CallFieldPathsEqual(ref PathUnsafe, ref other.PathUnsafe).ToManagedBool();
+    }
+
+    public override bool Equals(object obj) {
+        return obj is FFieldPath path && Equals(path);
+    }
+
+    public static bool operator ==(FFieldPath lhs, FFieldPath rhs)
+    {
+        return lhs.Equals(rhs);
+    }
+    public static bool operator !=(FFieldPath lhs, FFieldPath rhs)
+    {
+        return !lhs.Equals(rhs);
+    }
+
+    public override int GetHashCode() {
+        return FFieldPathExporter.CallGetFieldPathHashCode(ref PathUnsafe);
+    }
+    
+}
+
+public static class FieldPathMarshaller
+{
+    public static void ToNative(IntPtr nativeBuffer, int arrayIndex, FFieldPath obj)
+    {
+        BlittableMarshaller<FFieldPathUnsafe>.ToNative(nativeBuffer, arrayIndex, obj.PathUnsafe);
+    }
+    
+    public static FFieldPath FromNative(IntPtr nativeBuffer, int arrayIndex)
+    {
+        FFieldPathUnsafe fieldPathUnsafe = BlittableMarshaller<FFieldPathUnsafe>.FromNative(nativeBuffer, arrayIndex);
+        return new FFieldPath(fieldPathUnsafe);
+    }
+}

--- a/Managed/UnrealSharp/UnrealSharp/Interop/FFieldPathExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/FFieldPathExporter.cs
@@ -1,0 +1,13 @@
+﻿using UnrealSharp.Binds;
+using UnrealSharp.Core;
+
+namespace UnrealSharp.Interop;
+
+[NativeCallbacks]
+public static unsafe partial class FFieldPathExporter {
+    public static delegate* unmanaged<ref FFieldPathUnsafe, NativeBool> IsValid;
+    public static delegate* unmanaged<ref FFieldPathUnsafe, NativeBool> IsStale;
+    public static delegate* unmanaged<ref FFieldPathUnsafe, ref UnmanagedArray, void> FieldPathToString;
+    public static delegate* unmanaged<ref FFieldPathUnsafe, ref FFieldPathUnsafe, NativeBool> FieldPathsEqual;
+    public static delegate* unmanaged<ref FFieldPathUnsafe, int> GetFieldPathHashCode;
+}

--- a/Source/UnrealSharpBinds/Public/CSExportedFunction.h
+++ b/Source/UnrealSharpBinds/Public/CSExportedFunction.h
@@ -1,15 +1,40 @@
 #pragma once
 
+/**
+ * Thin wrapper around sizeof(T) used for getting the size of a function's arguments.
+ * @tparam T The type we want the size of
+ */
+template <typename T>
+struct TArgSize {
+	constexpr static size_t Size = sizeof(T);
+};
+
+/**
+ * Specialization for reference qualified types so we can get the size of the pointer instead of the object itself.
+ * @tparam T The type we want the size of
+ */
+template <typename T>
+struct TArgSize<T&> {
+	constexpr static size_t Size = sizeof(T*);
+};
+
+/**
+ * Constant expression for the size of an argument
+ * @tparam T The type we want the size of
+ */
+template <typename T>
+constexpr size_t ArgSize = TArgSize<T>::Size;
+
 template <typename ReturnType, typename... Args>
 constexpr size_t GetFunctionSize(ReturnType (*)(Args...))
 {
 	if constexpr (std::is_void_v<ReturnType>)
 	{
-		return (sizeof(Args) + ... + 0);
+		return (ArgSize<Args> + ... + 0);
 	}
 	else
 	{
-		return sizeof(ReturnType) + (sizeof(Args) + ... + 0);
+		return ArgSize<ReturnType> + (ArgSize<Args> + ... + 0);
 	}
 }
 

--- a/Source/UnrealSharpCore/Export/FFieldPathExporter.cpp
+++ b/Source/UnrealSharpCore/Export/FFieldPathExporter.cpp
@@ -1,0 +1,26 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "FFieldPathExporter.h"
+
+bool UFFieldPathExporter::IsValid(const TFieldPath<FField>& FieldPath) {
+	return FieldPath != nullptr;
+}
+
+bool UFFieldPathExporter::IsStale(const FFieldPath& FieldPath) {
+	return FieldPath.IsStale();
+}
+
+void UFFieldPathExporter::FieldPathToString(const FFieldPath& FieldPath, FString* OutString) {
+	*OutString = FieldPath.ToString();
+}
+
+bool UFFieldPathExporter::FieldPathsEqual(const FFieldPath& A, const FFieldPath& B) {
+	return A == B;
+}
+
+int32 UFFieldPathExporter::GetFieldPathHashCode(const FFieldPath& FieldPath) {
+	// GetHashCode returns a signed integer in C#, but GetTypeHash returns an unsigned integer, thus
+	// the cast is necessary
+	return static_cast<int32>(GetTypeHash(FieldPath));
+}

--- a/Source/UnrealSharpCore/Export/FFieldPathExporter.h
+++ b/Source/UnrealSharpCore/Export/FFieldPathExporter.h
@@ -1,0 +1,32 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CSBindsManager.h"
+#include "UObject/Object.h"
+#include "FFieldPathExporter.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class UNREALSHARPCORE_API UFFieldPathExporter : public UObject {
+	GENERATED_BODY()
+
+public:
+	UNREALSHARP_FUNCTION()
+	static bool IsValid(const TFieldPath<FField>& FieldPath);
+
+	UNREALSHARP_FUNCTION()
+	static bool IsStale(const FFieldPath& FieldPath);
+
+	UNREALSHARP_FUNCTION()
+	static void FieldPathToString(const FFieldPath& FieldPath, FString* OutString);
+
+	UNREALSHARP_FUNCTION()
+	static bool FieldPathsEqual(const FFieldPath& A, const FFieldPath& B);
+
+	UNREALSHARP_FUNCTION()
+	static int32 GetFieldPathHashCode(const FFieldPath& FieldPath);
+};

--- a/Source/UnrealSharpCore/TypeGenerator/Register/MetaData/CSPropertyType.h
+++ b/Source/UnrealSharpCore/TypeGenerator/Register/MetaData/CSPropertyType.h
@@ -49,7 +49,7 @@ enum class ECSPropertyType : uint8
 	String,
 	Name,
 	Text,
-
+	
 	GameplayTag,
 	GameplayTagContainer,
 

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/FieldPathPropertyTranslator.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/FieldPathPropertyTranslator.cs
@@ -1,0 +1,27 @@
+﻿using EpicGames.UHT.Types;
+
+namespace UnrealSharpScriptGenerator.PropertyTranslators;
+
+public class FieldPathPropertyTranslator : SimpleTypePropertyTranslator {
+
+    public FieldPathPropertyTranslator() : base(typeof(UhtFieldPathProperty)) {
+        
+    }
+    
+    public override bool CanExport(UhtProperty property)
+    {
+        return property is UhtFieldPathProperty;
+    }
+
+    public override string GetManagedType(UhtProperty property)
+    {
+        return "FFieldPath";
+    }
+
+    public override string GetMarshaller(UhtProperty property)
+    {
+        return "FieldPathMarshaller";
+    }
+
+    public override bool CanSupportGenericType(UhtProperty property) => false;
+}

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslatorManager.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslatorManager.cs
@@ -74,6 +74,7 @@ public static class PropertyTranslatorManager
 #endif
         AddPropertyTranslator(typeof(UhtSoftClassProperty), new SoftClassPropertyTranslator());
         AddPropertyTranslator(typeof(UhtSoftObjectProperty), new SoftObjectPropertyTranslator());
+        AddPropertyTranslator(typeof(UhtFieldPathProperty), new FieldPathPropertyTranslator());
         
         AddBlittableCustomStructPropertyTranslator("FVector", "UnrealSharp.CoreUObject.FVector");
         AddBlittableCustomStructPropertyTranslator("FVector2D", "UnrealSharp.CoreUObject.FVector2D");


### PR DESCRIPTION
TFieldPath is a viable type for UPROPERTIES, used in a few places, most notably in FGameplayAttribute. To aid those trying to use this plugin with the GAS, having this type correctly marshalled and unmarshalled from struct types is imperative.