### PR TITLE
fix CsExporter cache

### DIFF
--- a/Source/UnrealSharpCore/UnrealSharpCore.Build.cs
+++ b/Source/UnrealSharpCore/UnrealSharpCore.Build.cs
@@ -143,8 +143,10 @@ public class UnrealSharpCore : ModuleRules
 		process.StartInfo.ArgumentList.Add($"\"{projectRootDirectory}\"");
 		
 		process.StartInfo.ArgumentList.Add($"-p:PublishDir=\"{_managedBinariesPath}\"");
-		
-		process.Start();
+
+        Console.WriteLine($"Start publish solution: {projectRootDirectory}");
+
+        process.Start();
 		process.WaitForExit();
 		
 		if (process.ExitCode != 0)

--- a/Source/UnrealSharpManagedGlue/CSharpExporter.cs
+++ b/Source/UnrealSharpManagedGlue/CSharpExporter.cs
@@ -111,7 +111,7 @@ public static class CSharpExporter
         string generatedCodeDirectory = Program.PluginModule.OutputDirectory;
         string timestampFilePath = Path.Combine(generatedCodeDirectory, "Timestamp");
         
-        if (!File.Exists(timestampFilePath))
+        if (!File.Exists(timestampFilePath) || !Directory.Exists(Program.EngineGluePath) || !Directory.Exists(Program.ProjectGluePath))
         {
             return true;
         }


### PR DESCRIPTION
1. when load glue info from json succeed, skip export again, CSharpExporter.cs:37
2. when user deleted glue folder, regenerate glue code, CSharpExporter.cs:120
3. add a log for PublishSolution step, it tooks long time