### PR TITLE
Added support for TStrongObjectPtr in C# code

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Interop/TStrongObjectPtrExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/TStrongObjectPtrExporter.cs
@@ -1,0 +1,10 @@
+﻿using UnrealSharp.Binds;
+
+namespace UnrealSharp.Interop;
+
+[NativeCallbacks]
+public static unsafe partial class TStrongObjectPtrExporter
+{
+    public static delegate* unmanaged<ref FStrongObjectPtr, IntPtr, void> ConstructStrongObjectPtr;
+    public static delegate* unmanaged<ref FStrongObjectPtr, void> DestroyStrongObjectPtr;
+}

--- a/Managed/UnrealSharp/UnrealSharp/StrongObjectPtr.cs
+++ b/Managed/UnrealSharp/UnrealSharp/StrongObjectPtr.cs
@@ -1,0 +1,98 @@
+﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
+using UnrealSharp.Attributes;
+using UnrealSharp.Core;
+using UnrealSharp.Core.Attributes;
+using UnrealSharp.Core.Marshallers;
+using UnrealSharp.CoreUObject;
+using UnrealSharp.Engine;
+using UnrealSharp.Interop;
+
+namespace UnrealSharp;
+
+[StructLayout(LayoutKind.Sequential)]
+public struct FStrongObjectPtr
+{
+    internal IntPtr NativeObject;
+}
+
+public abstract class TStrongObjectPtr : IEquatable<TStrongObjectPtr>, IDisposable
+{
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private FStrongObjectPtr _nativePtr;
+
+    private bool _isDisposed;
+
+    protected TStrongObjectPtr(UObject? obj = null)
+    {
+        TStrongObjectPtrExporter.CallConstructStrongObjectPtr(ref _nativePtr, obj?.NativeObject ?? IntPtr.Zero);
+    }
+
+    ~TStrongObjectPtr()
+    {
+        Dispose();
+    }
+    
+    public bool IsValid => !_isDisposed && _nativePtr.NativeObject != IntPtr.Zero;
+    public UObject? Value
+    {
+        get
+        {
+            if (!IsValid)
+            {
+                return null;
+            }
+            
+            IntPtr handle = FCSManagerExporter.CallFindManagedObject(_nativePtr.NativeObject);
+            return GCHandleUtilities.GetObjectFromHandlePtr<UObject>(handle);
+        }
+    }
+
+    public bool Equals(TStrongObjectPtr? other)
+    {
+        if (other is null)
+        {
+            return _nativePtr.NativeObject == IntPtr.Zero;
+        }
+        
+        return _nativePtr.NativeObject == other._nativePtr.NativeObject;
+    }
+    
+    public override bool Equals(object? obj)
+    {
+        return obj is TStrongObjectPtr ptr && Equals(ptr);
+    }
+
+    public static bool operator ==(TStrongObjectPtr? a, TStrongObjectPtr? b)
+    {
+        return a?.Equals(b) ?? b is null;
+    }
+
+    public static bool operator !=(TStrongObjectPtr? a, TStrongObjectPtr? b)
+    {
+        return !(a == b);
+    }
+
+    public override int GetHashCode()
+    {
+        return _nativePtr.NativeObject.GetHashCode();
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+        
+        TStrongObjectPtrExporter.CallDestroyStrongObjectPtr(ref _nativePtr);
+        _isDisposed = true;
+        GC.SuppressFinalize(this);
+    }
+}
+
+[Binding]
+public sealed class TStrongObjectPtr<T>(T? obj = null) : TStrongObjectPtr(obj) where T : UObject
+{
+    public new T? Value => (T?) base.Value;
+}

--- a/Managed/UnrealSharp/UnrealSharp/StrongObjectPtr.cs
+++ b/Managed/UnrealSharp/UnrealSharp/StrongObjectPtr.cs
@@ -95,4 +95,6 @@ public abstract class TStrongObjectPtr : IEquatable<TStrongObjectPtr>, IDisposab
 public sealed class TStrongObjectPtr<T>(T? obj = null) : TStrongObjectPtr(obj) where T : UObject
 {
     public new T? Value => (T?) base.Value;
+    
+    public static implicit operator TStrongObjectPtr<T>(T? obj) => new(obj);
 }

--- a/Source/UnrealSharpCore/Export/TStrongObjectPtrExporter.cpp
+++ b/Source/UnrealSharpCore/Export/TStrongObjectPtrExporter.cpp
@@ -1,0 +1,18 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "TStrongObjectPtrExporter.h"
+
+void UTStrongObjectPtrExporter::ConstructStrongObjectPtr(TStrongObjectPtr<UObject>* Ptr, UObject* Object)
+{
+    static_assert(sizeof(TStrongObjectPtr<UObject>) == sizeof(UObject*), "TStrongObjectPtr<UObject> must be the same size as UObject*");
+    check(Ptr != nullptr);
+    std::construct_at(Ptr, Object);
+}
+
+void UTStrongObjectPtrExporter::DestroyStrongObjectPtr(TStrongObjectPtr<UObject>* Ptr)
+{
+    static_assert(sizeof(TStrongObjectPtr<UObject>) == sizeof(UObject*), "TStrongObjectPtr<UObject> must be the same size as UObject*");
+    check(Ptr != nullptr);
+    std::destroy_at(Ptr);
+}

--- a/Source/UnrealSharpCore/Export/TStrongObjectPtrExporter.h
+++ b/Source/UnrealSharpCore/Export/TStrongObjectPtrExporter.h
@@ -1,0 +1,24 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CSBindsManager.h"
+#include "UObject/Object.h"
+#include "TStrongObjectPtrExporter.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class UNREALSHARPCORE_API UTStrongObjectPtrExporter : public UObject
+{
+    GENERATED_BODY()
+
+public:
+    UNREALSHARP_FUNCTION()
+    static void ConstructStrongObjectPtr(TStrongObjectPtr<UObject>* Ptr, UObject* Object);
+    
+    UNREALSHARP_FUNCTION()
+    static void DestroyStrongObjectPtr(TStrongObjectPtr<UObject>* Ptr);
+};


### PR DESCRIPTION
Added a C# equivalent to the C++ only class TStrongObjectPtr which is a way to storing a single UObject in a class that is not part of the UProperty system. This provides the benefit of allowing for regular C# classes to hold a reference to a UObject without fear of it getting garbage collected by the engine. This type is able to be used as such:

```C#
public class MyRegularClass 
{
    private readonly TStrongObjectPtr<UMyObjectType> _myObject;

    public MyRegularClass(UMyObjectType myObject) 
    {
        _myObject = myObject; // Implicit conversion operator
    }
}
```

This will ensure that so long as the TStrongObjectPtr is in memory so will the object it wraps. Alternatively the user can also manually manage the lifetime of the object by using the Dispose pattern, which is recommended since it provided more deterministic guarentees about object lifetime, which is helpful in avoiding fatal engine crashes from things like not allowing Actors to be collected when the world is.