### PR TITLE
Fixed TSoftClassPtr<T>

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/AssetManager.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/AssetManager.cs
@@ -236,7 +236,7 @@ public partial class UAssetManager
     /// </summary>
     /// <param name="primaryAssetId">The Primary Asset Id to get the object for</param>
     /// <returns>The Blueprint Class Id associated with the Primary Asset Id</returns>
-    public TSoftClassPtr<UClass> GetSoftClassReferenceFromPrimaryAssetId(FPrimaryAssetId primaryAssetId)
+    public TSoftClassPtr<UObject> GetSoftClassReferenceFromPrimaryAssetId(FPrimaryAssetId primaryAssetId)
     {
         return SystemLibrary.GetSoftClassReference(primaryAssetId);
     }

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/SoftClassPropertyTranslator.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/SoftClassPropertyTranslator.cs
@@ -14,7 +14,7 @@ public class SoftClassPropertyTranslator : SimpleTypePropertyTranslator
     {
         UhtSoftClassProperty softClassProperty = (UhtSoftClassProperty)property;
         string fullName = property.IsGenericType()
-             ? "DOT" : softClassProperty.Class.GetFullManagedName();
+             ? "DOT" : softClassProperty.MetaClass.GetFullManagedName();
 
         return $"TSoftClassPtr<{fullName}>";
     }
@@ -23,7 +23,7 @@ public class SoftClassPropertyTranslator : SimpleTypePropertyTranslator
     {
         UhtSoftClassProperty softClassProperty = (UhtSoftClassProperty) property;
         string fullName = property.IsGenericType()
-             ? "DOT" : softClassProperty.Class.GetFullManagedName();
+             ? "DOT" : softClassProperty.MetaClass.GetFullManagedName();
 
         return $"SoftClassMarshaller<{fullName}>";
     }


### PR DESCRIPTION
`softClassProperty.Class.GetFullManagedName()` translated T as UClass, which is supposed to be an UObject.