### PR TITLE
Fixed an issue where if a project plugin lacked a config directory the UHT would crash

### DIFF
--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslatorManager.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslatorManager.cs
@@ -27,6 +27,7 @@ public static class PropertyTranslatorManager
             .Select(x => Path.Combine(x, "Config"))
             .Concat([configDirectory])
             .Select(x => new DirectoryInfo(x))
+            .Where(x => x.Exists)
             .SelectMany(x => x.GetFiles("*.UnrealSharpTypes.json", SearchOption.AllDirectories))
             .Select(x => x.FullName);
         foreach (var pluginFile in files)


### PR DESCRIPTION
This fixed an issue that was reported where having plugins in the project without a Config directory the project could not be built.