### PR TITLE
Allow users to define analyzers in their project code

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Program.cs
@@ -16,11 +16,11 @@ public static class Program
             Console.WriteLine(">>> UnrealSharpBuildTool");
             Parser parser = new Parser(with => with.HelpWriter = null);
             ParserResult<BuildToolOptions> result = parser.ParseArguments<BuildToolOptions>(args);
-            
+
             if (result.Tag == ParserResultType.NotParsed)
             {
                 BuildToolOptions.PrintHelp(result);
-                
+
                 string errors = string.Empty;
                 foreach (Error error in result.Errors)
                 {
@@ -29,17 +29,17 @@ public static class Program
                         errors += $"{tokenError.Tag}: {tokenError.Token} \n";
                     }
                 }
-                
+
                 throw new Exception($"Invalid arguments. Errors: {errors}");
             }
-        
+
             BuildToolOptions = result.Value;
-            
+
             if (!BuildToolAction.InitializeAction())
             {
                 throw new Exception("Failed to initialize action.");
             }
-            
+
             Console.WriteLine($"UnrealSharpBuildTool executed {BuildToolOptions.Action.ToString()} action successfully.");
         }
         catch (Exception exception)
@@ -47,20 +47,20 @@ public static class Program
             Console.WriteLine("An error occurred: " + exception.Message + Environment.NewLine + exception.StackTrace);
             return 1;
         }
-        
+
         return 0;
     }
-    
+
     public static string TryGetArgument(string argument)
     {
         return BuildToolOptions.TryGetArgument(argument);
     }
-    
+
     public static bool HasArgument(string argument)
     {
         return BuildToolOptions.HasArgument(argument);
     }
-    
+
     public static string GetSolutionFile()
     {
         return Path.Combine(GetScriptFolder(), BuildToolOptions.ProjectName + ".sln");
@@ -70,7 +70,7 @@ public static class Program
     {
         return Path.Combine(BuildToolOptions.ProjectDirectory, BuildToolOptions.ProjectName + ".uproject");
     }
-    
+
     public static string GetBuildConfiguration()
     {
         string buildConfig = TryGetArgument("BuildConfig");
@@ -80,14 +80,14 @@ public static class Program
         }
         return buildConfig;
     }
-    
+
     public static BuildConfig GetBuildConfig()
     {
         string buildConfig = GetBuildConfiguration();
         Enum.TryParse(buildConfig, out BuildConfig config);
         return config;
     }
-    
+
     public static string GetBuildConfiguration(BuildConfig buildConfig)
     {
         return buildConfig switch
@@ -98,24 +98,24 @@ public static class Program
             _ => "Release"
         };
     }
-    
+
     public static string GetScriptFolder()
     {
         return Path.Combine(BuildToolOptions.ProjectDirectory, "Script");
     }
-    
+
     public static string GetProjectDirectory()
     {
         return BuildToolOptions.ProjectDirectory;
     }
-    
+
     public static string FixPath(string path)
     {
         if (OperatingSystem.IsWindows())
         {
             return path.Replace('/', '\\');
         }
-        
+
         return path;
     }
 
@@ -123,14 +123,14 @@ public static class Program
     {
         return "Managed" + BuildToolOptions.ProjectName;
     }
-    
+
     public static string GetOutputPath(string rootDir = "")
     {
         if (string.IsNullOrEmpty(rootDir))
         {
             rootDir = BuildToolOptions.ProjectDirectory;
         }
-        
+
         return Path.Combine(rootDir, "Binaries", "Managed");
     }
 
@@ -143,14 +143,14 @@ public static class Program
     {
         return Path.Combine(BuildToolOptions.PluginDirectory, "Binaries", "Managed");
     }
-    
+
     public static string GetVersion()
     {
         Version currentVersion = Environment.Version;
         string currentVersionStr = $"{currentVersion.Major}.{currentVersion.Minor}";
         return "net" + currentVersionStr;
     }
-    
+
     public static void CreateOrUpdateLaunchSettings(string launchSettingsPath)
     {
         Root root = new Root();
@@ -165,20 +165,20 @@ public static class Program
             executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Mac", "UnrealEditor");
         }
         string commandLineArgs = Program.FixPath(Program.GetUProjectFilePath());
-        
+
         // Create a new profile if it doesn't exist
         if (root.Profiles == null)
         {
             root.Profiles = new Profiles();
         }
-            
+
         root.Profiles.ProfileName = new Profile
         {
             CommandName = "Executable",
             ExecutablePath = executablePath,
             CommandLineArgs = $"\"{commandLineArgs}\"",
         };
-        
+
         string newJsonString = JsonConvert.SerializeObject(root, Newtonsoft.Json.Formatting.Indented);
         StreamWriter writer = File.CreateText(launchSettingsPath);
         writer.Write(newJsonString);
@@ -194,18 +194,18 @@ public static class Program
         allProjectFiles.AddRange(fsprojFiles.Where(IsWeavableProject));
         return allProjectFiles;
     }
-    
+
     private static bool IsWeavableProject(FileInfo projectFile)
     {
         // We need to be able to filter out certain non-production projects.
-        // The main target of this is source generators and analyzers which users 
+        // The main target of this is source generators and analyzers which users
         // may want to leverage as part of their solution and can't be weaved because
         // they have to use netstandard2.0.
         XDocument doc = XDocument.Load(projectFile.FullName);
         return !doc.Descendants()
             .Where(element => element.Name.LocalName == "PropertyGroup")
             .SelectMany(element => element.Elements())
-            .Any(element => element.Name.LocalName == "IsRoslynComponent" && 
+            .Any(element => element.Name.LocalName == "ExcludeFromWeaver" &&
                             element.Value.Equals("true", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -278,7 +278,7 @@ bool FCSProcHelper::IsProjectReloadable(FStringView ProjectPath)
     {
         if (Node->GetTag() == TEXT("PropertyGroup"))
         {
-            if (const FXmlNode* RoslynComponentNode = Node->FindChildNode(TEXT("IsRoslynComponent"));
+            if (const FXmlNode* RoslynComponentNode = Node->FindChildNode(TEXT("ExcludeFromWeaver"));
                 RoslynComponentNode &&
                 RoslynComponentNode->GetContent().Equals(TEXT("true"), ESearchCase::IgnoreCase))
             {

--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -1,5 +1,8 @@
 ﻿#include "CSProcHelper.h"
 #include "UnrealSharpProcHelper.h"
+#include "XmlFile.h"
+#include "XmlNode.h"
+#include "XmlNode.h"
 #include "Misc/App.h"
 #include "Misc/Paths.h"
 #include "Interfaces/IPluginManager.h"
@@ -42,7 +45,7 @@ bool FCSProcHelper::InvokeCommand(const FString& ProgramPath, const FString& Arg
 	{
 		Output += FPlatformProcess::ReadPipe(ReadPipe);
 	}
-	
+
 	FPlatformProcess::GetProcReturnCode(ProcHandle, &OutReturnCode);
 	FPlatformProcess::CloseProc(ProcHandle);
 	FPlatformProcess::ClosePipe(ReadPipe, WritePipe);
@@ -183,7 +186,7 @@ FString FCSProcHelper::GetUnrealSharpMetadataPath()
 void FCSProcHelper::GetProjectNamesByLoadOrder(TArray<FString>& UserProjectNames, const bool bIncludeProjectGlue)
 {
 	const FString ProjectMetadataPath = GetUnrealSharpMetadataPath();
-	
+
 	if (!FPaths::FileExists(ProjectMetadataPath))
 	{
 		// Can be null at the start of the project.
@@ -207,12 +210,12 @@ void FCSProcHelper::GetProjectNamesByLoadOrder(TArray<FString>& UserProjectNames
 	for (const TSharedPtr<FJsonValue>& OrderEntry : JsonObject->GetArrayField(TEXT("AssemblyLoadingOrder")))
 	{
 		FString ProjectName = OrderEntry->AsString();
-		
+
 		if (!bIncludeProjectGlue && ProjectName == TEXT("ProjectGlue"))
 		{
 			continue;
 		}
-		
+
 		UserProjectNames.Add(OrderEntry->AsString());
 	}
 }
@@ -221,7 +224,7 @@ void FCSProcHelper::GetProjectNamesByLoadOrder(TArray<FString>& UserProjectNames
 void FCSProcHelper::GetAssemblyPathsByLoadOrder(TArray<FString>& AssemblyPaths, const bool bIncludeProjectGlue)
 {
 	FString AbsoluteFolderPath = GetUserAssemblyDirectory();
-	
+
 	TArray<FString> ProjectNames;
 	GetProjectNamesByLoadOrder(ProjectNames, bIncludeProjectGlue);
 
@@ -242,21 +245,49 @@ void FCSProcHelper::GetAllProjectPaths(TArray<FString>& ProjectPaths, bool bIncl
 		false,
 		false);
 
-	if (bIncludeProjectGlue)
-	{
-		return;
-	}
-	
 	for (int32 i = ProjectPaths.Num() - 1; i >= 0; i--)
 	{
-		if (!ProjectPaths[i].EndsWith("ProjectGlue.csproj"))
+		if (IsProjectReloadable(ProjectPaths[i]) && (bIncludeProjectGlue || !ProjectPaths[i].EndsWith("ProjectGlue.csproj")))
 		{
 			continue;
 		}
 
 		ProjectPaths.RemoveAt(i);
-		return;
 	}
+}
+
+bool FCSProcHelper::IsProjectReloadable(FStringView ProjectPath)
+{
+    FXmlFile ProjectFile(ProjectPath.GetData());
+    if (!ProjectFile.IsValid())
+    {
+        UE_LOG(LogUnrealSharpProcHelper, Warning, TEXT("Failed to parse project file as XML: %s"),
+            ProjectPath.GetData());
+        return true;
+    }
+
+    const FXmlNode* RootNode = ProjectFile.GetRootNode();
+    if (!RootNode)
+    {
+        return true;
+    }
+
+    // Look through all PropertyGroup elements
+    for (const TArray<FXmlNode*>& ProjectNodes = RootNode->GetChildrenNodes();
+        const FXmlNode* Node : ProjectNodes)
+    {
+        if (Node->GetTag() == TEXT("PropertyGroup"))
+        {
+            if (const FXmlNode* RoslynComponentNode = Node->FindChildNode(TEXT("IsRoslynComponent"));
+                RoslynComponentNode &&
+                RoslynComponentNode->GetContent().Equals(TEXT("true"), ESearchCase::IgnoreCase))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
 }
 
 FString FCSProcHelper::GetUnrealSharpBuildToolPath()

--- a/Source/UnrealSharpProcHelper/CSProcHelper.h
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.h
@@ -25,16 +25,16 @@ enum class EDotNetBuildConfiguration : uint64
 class UNREALSHARPPROCHELPER_API FCSProcHelper final
 {
 public:
-	
+
 	static bool InvokeCommand(const FString& ProgramPath, const FString& Arguments, int32& OutReturnCode, FString& Output, const FString* InWorkingDirectory = nullptr);
 	static bool InvokeUnrealSharpBuildTool(const FString& BuildAction, const TMap<FString, FString>& AdditionalArguments = TMap<FString, FString>());
-	
+
 	static FString GetRuntimeConfigPath();
-	
+
 	static FString GetPluginAssembliesPath();
-	
+
 	static FString GetUnrealSharpPluginsPath();
-	
+
 	static FString GetUnrealSharpBuildToolPath();
 
 	// Path to the directory where we store the user's assembly after it has been processed by the weaver.
@@ -51,6 +51,9 @@ public:
 
 	// Gets all the project paths in the /Scripts directory.
 	static void GetAllProjectPaths(TArray<FString>& ProjectPaths, bool bIncludeProjectGlue = false);
+
+    // Checks if the project at this path can actually be reloaded. This is mainly used to skip of Roslyn analyzers since we don't want to reload them.
+    static bool IsProjectReloadable(FStringView ProjectPath);
 
 	// Path to the .NET runtime root. Only really works in editor, since players don't have the .NET runtime.
 	static FString GetDotNetDirectory();
@@ -84,5 +87,5 @@ public:
 
 	// Path to the C# solution file.
 	static FString GetPathToSolution();
-	
+
 };

--- a/Source/UnrealSharpProcHelper/UnrealSharpProcHelper.Build.cs
+++ b/Source/UnrealSharpProcHelper/UnrealSharpProcHelper.Build.cs
@@ -19,12 +19,13 @@ public class UnrealSharpProcHelper : ModuleRules
                 "CoreUObject",
                 "Engine",
                 "Slate",
-                "SlateCore", 
+                "SlateCore",
                 "Projects",
-                "Json"
+                "Json",
+                "XmlParser",
             }
         );
-        
+
         PublicDefinitions.Add("SkipGlueGeneration");
     }
 }


### PR DESCRIPTION
Currently, if the project encounters an analyzer during the initial build or during hot reload of the plugin will display an error. This fixes it by ensuring any .csproj files in the project that have `IsRoslynComponent` set to `true` are ignored by the weaver and hot reloader as they are build-only artifacts.