### PR TITLE
Make UE collections implement the read-only versions of the interfaces

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Array.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Array.cs
@@ -11,7 +11,7 @@ namespace UnrealSharp;
 /// </summary>
 /// <typeparam name="T"> The type of elements in the array. </typeparam>
 [Binding]
-public class TArray<T> : UnrealArrayBase<T>, IList<T>
+public class TArray<T> : UnrealArrayBase<T>, IList<T>, IReadOnlyList<T>
 {
     /// <inheritdoc />
     public bool IsReadOnly => false;

--- a/Managed/UnrealSharp/UnrealSharp/Map.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Map.cs
@@ -5,7 +5,7 @@ using UnrealSharp.Core.Marshallers;
 namespace UnrealSharp;
 
 [Binding]
-public class TMap<TKey, TValue> : MapBase<TKey, TValue>, IDictionary<TKey, TValue>
+public class TMap<TKey, TValue> : MapBase<TKey, TValue>, IDictionary<TKey, TValue>, IReadOnlyDictionary<TKey, TValue>
 {
     public TMap(IntPtr mapProperty, IntPtr address,
         MarshallingDelegates<TKey>.FromNative keyFromNative, MarshallingDelegates<TKey>.ToNative keyToNative,
@@ -24,10 +24,14 @@ public class TMap<TKey, TValue> : MapBase<TKey, TValue>, IDictionary<TKey, TValu
     public bool IsReadOnly => false;
 
     public KeyEnumerator Keys => new(this);
-
+    
+    IEnumerable<TKey> IReadOnlyDictionary<TKey, TValue>.Keys => new KeyEnumerator(this);
+    
     ICollection<TKey> IDictionary<TKey, TValue>.Keys => new KeyEnumerator(this);
 
     public ValueCollection Values => new(this);
+    
+    IEnumerable<TValue> IReadOnlyDictionary<TKey, TValue>.Values => new ValueCollection(this);
 
     ICollection<TValue> IDictionary<TKey, TValue>.Values => new ValueCollection(this);
 

--- a/Managed/UnrealSharp/UnrealSharp/Set.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Set.cs
@@ -7,7 +7,7 @@ using UnrealSharp.Interop.Properties;
 namespace UnrealSharp;
 
 [Binding]
-public class TSet<T> : TSetBase<T>, ISet<T>
+public class TSet<T> : TSetBase<T>, ISet<T>, IReadOnlySet<T>
 {
     public TSet(IntPtr setProperty, IntPtr address,
         MarshallingDelegates<T>.FromNative fromNative, MarshallingDelegates<T>.ToNative toNative)


### PR DESCRIPTION
Currently, TArray, TSet, and TMap only implement the read/write interfaces for their collection types. However, if you look at the definitions for List, HashSet, and Dictionary, they also implement the read-only versions of those collections. This PR fixes that by ensuring the three collections also implement the read-only versions.