### PR TITLE
Enable UObjects to have get only properties

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/PropertyProcessor.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/PropertyProcessor.cs
@@ -41,8 +41,10 @@ public static class PropertyProcessor
             if (prop.MemberRef.Resolve() is PropertyDefinition propertyRef)
             {
                 prop.PropertyDataType.WriteGetter(type, propertyRef.GetMethod, loadBuffer, nativePropertyField);
-                prop.PropertyDataType.WriteSetter(type, propertyRef.SetMethod, loadBuffer, nativePropertyField);
-
+                if (propertyRef.SetMethod is not null) {
+                  prop.PropertyDataType.WriteSetter(type, propertyRef.SetMethod, loadBuffer, nativePropertyField);
+                }
+                
                 string backingFieldName = RemovePropertyBackingField(type, prop);
                 removedBackingFields.Add(backingFieldName, (prop, propertyRef, offsetField, nativePropertyField));
             }


### PR DESCRIPTION
Right now, the weaver crashes if a UObject property does not have a setter defined. However, a user may want to communicate that a property is only retrievable in C#, and is set by the editor or during construction. This PR rectifies that by skipping over set method generation for properties that lack a pre-defined set method.