### PR TITLE
Updated subsystems so there is a way to request dependencies in C#

### DIFF
--- a/Config/Default.UnrealSharpTypes.json
+++ b/Config/Default.UnrealSharpTypes.json
@@ -70,6 +70,10 @@
             {
                 "Name": "FRandomStream",
                 "ManagedType": "UnrealSharp.CoreUObject.FRandomStream"
+            },
+            {
+                "Name": "FSubsystemCollectionBaseRef",
+                "ManagedType": "UnrealSharp.UnrealSharpCore.FSubsystemCollectionBaseRef"
             }
         ],
         "NativelyTranslatableTypes": [

--- a/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/BlittableMarshaller.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/BlittableMarshaller.cs
@@ -2,8 +2,8 @@ using System.Runtime.CompilerServices;
 
 namespace UnrealSharp.Core.Marshallers;
 
-public static class BlittableMarshaller<T>
-{ 
+public static class BlittableMarshaller<T> where T : unmanaged, allows ref struct
+{
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ToNative(IntPtr nativeBuffer, int arrayIndex, T obj)
     {
@@ -12,7 +12,7 @@ public static class BlittableMarshaller<T>
             ToNative(nativeBuffer, arrayIndex, obj, sizeof(T));
         }
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ToNative(IntPtr nativeBuffer, int arrayIndex, T obj, int size)
     {
@@ -21,7 +21,7 @@ public static class BlittableMarshaller<T>
             *(T*)(nativeBuffer + arrayIndex * size) = obj;
         }
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T FromNative(IntPtr nativeBuffer, int arrayIndex)
     {
@@ -30,7 +30,7 @@ public static class BlittableMarshaller<T>
             return FromNative(nativeBuffer, arrayIndex, sizeof(T));
         }
     }
-    
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static T FromNative(IntPtr nativeBuffer, int arrayIndex, int size)
     {

--- a/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/MarshalledStruct.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/MarshalledStruct.cs
@@ -1,9 +1,9 @@
 ﻿namespace UnrealSharp;
 
-public interface MarshalledStruct<Self> where Self : MarshalledStruct<Self>
+public interface MarshalledStruct<Self> where Self : MarshalledStruct<Self>, allows ref struct
 {
     public static abstract IntPtr GetNativeClassPtr();
-    
+
     public static abstract int GetNativeDataSize();
 
     public static abstract Self FromNative(IntPtr buffer);

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/UnrealSharp/SubsystemCollectionBaseRef.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/UnrealSharp/SubsystemCollectionBaseRef.cs
@@ -10,7 +10,8 @@ public readonly ref partial struct FSubsystemCollectionBaseRef
 
     public T? InitializeDependency<T>(TSubclassOf<T> subsystemClass) where T : USubsystem
     {
-        IntPtr handle = FSubsystemCollectionBaseRefExporter.CallInitializeDependency(_collectionRef, subsystemClass.NativeClass);
+        IntPtr obj = FSubsystemCollectionBaseRefExporter.CallInitializeDependency(_collectionRef, subsystemClass.NativeClass);
+        IntPtr handle = FCSManagerExporter.CallFindManagedObject(obj);
         return GCHandleUtilities.GetObjectFromHandlePtr<T>(handle);
     }
 

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/UnrealSharp/SubsystemCollectionBaseRef.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/UnrealSharp/SubsystemCollectionBaseRef.cs
@@ -1,0 +1,31 @@
+﻿using UnrealSharp.Core;
+using UnrealSharp.Engine;
+using UnrealSharp.Interop;
+
+namespace UnrealSharp.UnrealSharpCore;
+
+public readonly ref partial struct FSubsystemCollectionBaseRef
+{
+    private readonly IntPtr _collectionRef;
+
+    public T? InitializeDependency<T>(TSubclassOf<T> subsystemClass) where T : USubsystem
+    {
+        IntPtr handle = FSubsystemCollectionBaseRefExporter.CallInitializeDependency(_collectionRef, subsystemClass.NativeClass);
+        return GCHandleUtilities.GetObjectFromHandlePtr<T>(handle);
+    }
+
+    public T? InitializeDependency<T>() where T : USubsystem
+    {
+        return InitializeDependency(new TSubclassOf<T>(typeof(T)));
+    }
+
+    public T InitializeRequiredSubsystem<T>(TSubclassOf<T> subsystemClass) where T : USubsystem
+    {
+        return InitializeDependency<T>(subsystemClass) ?? throw new InvalidOperationException($"Subsystem {typeof(T).Name} is not initialized.");
+    }
+
+    public T InitializeRequiredSubsystem<T>() where T : USubsystem
+    {
+        return InitializeRequiredSubsystem(new TSubclassOf<T>(typeof(T)));
+    }
+}

--- a/Managed/UnrealSharp/UnrealSharp/Interop/FSubsystemCollectionBaseRefExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/FSubsystemCollectionBaseRefExporter.cs
@@ -1,0 +1,9 @@
+﻿using UnrealSharp.Binds;
+
+namespace UnrealSharp.Interop;
+
+[NativeCallbacks]
+public static unsafe partial class FSubsystemCollectionBaseRefExporter
+{
+    public static delegate* unmanaged<IntPtr, IntPtr, IntPtr> InitializeDependency;
+}

--- a/Source/UnrealSharpCore/Export/FSubsystemCollectionBaseRefExporter.cpp
+++ b/Source/UnrealSharpCore/Export/FSubsystemCollectionBaseRefExporter.cpp
@@ -1,0 +1,9 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "FSubsystemCollectionBaseRefExporter.h"
+
+USubsystem* UFSubsystemCollectionBaseRefExporter::InitializeDependency(FSubsystemCollectionBase* Collection, UClass* SubsystemClass)
+{
+    return Collection->InitializeDependency(SubsystemClass);
+}

--- a/Source/UnrealSharpCore/Export/FSubsystemCollectionBaseRefExporter.h
+++ b/Source/UnrealSharpCore/Export/FSubsystemCollectionBaseRefExporter.h
@@ -1,0 +1,21 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CSBindsManager.h"
+#include "UObject/Object.h"
+#include "FSubsystemCollectionBaseRefExporter.generated.h"
+
+/**
+ *
+ */
+UCLASS()
+class UNREALSHARPCORE_API UFSubsystemCollectionBaseRefExporter : public UObject
+{
+    GENERATED_BODY()
+
+public:
+    UNREALSHARP_FUNCTION()
+    static USubsystem* InitializeDependency(FSubsystemCollectionBase* Collection, UClass* SubsystemClass);
+};

--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSEngineSubsystem.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSEngineSubsystem.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SubsystemCollectionBaseRef.h"
 #include "Subsystems/EngineSubsystem.h"
 #include "CSEngineSubsystem.generated.h"
 
@@ -12,26 +13,26 @@ class UCSEngineSubsystem : public UEngineSubsystem, public FTickableGameObject
 	GENERATED_BODY()
 
 	// USubsystem Begin
-	
+
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override
 	{
 		Super::Initialize(Collection);
-		K2_Initialize();
+		K2_Initialize(Collection);
 	}
-  
+
 	virtual void Deinitialize() override
 	{
 		Super::Deinitialize();
 		K2_Deinitialize();
 	}
-  
+
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override
 	{
 		if (!Super::ShouldCreateSubsystem(Outer))
 		{
 			return false;
 		}
-  
+
 		return K2_ShouldCreateSubsystem();
 	}
 
@@ -76,14 +77,14 @@ protected:
 
 	UFUNCTION(BlueprintNativeEvent, meta = (ScriptName = "ShouldCreateSubsystem"), Category = "Managed Subsystems")
 	bool K2_ShouldCreateSubsystem() const;
-  
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Initialize"), Category = "Managed Subsystems")
-	void K2_Initialize();
-  
+	void K2_Initialize(FSubsystemCollectionBaseRef Collection);
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Deinitialize"), Category = "Managed Subsystems")
 	void K2_Deinitialize();
 
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Tick"), Category = "Managed Subsystems")
-	void K2_Tick(float DeltaTime);	
+	void K2_Tick(float DeltaTime);
 
 };

--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSGameInstanceSubsystem.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSGameInstanceSubsystem.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SubsystemCollectionBaseRef.h"
 #include "Subsystems/GameInstanceSubsystem.h"
 #include "CSGameInstanceSubsystem.generated.h"
 
@@ -12,26 +13,26 @@ class UCSGameInstanceSubsystem : public UGameInstanceSubsystem, public FTickable
 	GENERATED_BODY()
 
 	// USubsystem Begin
-	
+
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override
 	{
 		Super::Initialize(Collection);
-		K2_Initialize();
+		K2_Initialize(Collection);
 	}
-  
+
 	virtual void Deinitialize() override
 	{
 		Super::Deinitialize();
 		K2_Deinitialize();
 	}
-  
+
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override
 	{
 		if (!Super::ShouldCreateSubsystem(Outer))
 		{
 			return false;
 		}
-  
+
 		return K2_ShouldCreateSubsystem();
 	}
 
@@ -82,13 +83,13 @@ protected:
 
 	UFUNCTION(BlueprintNativeEvent, meta = (ScriptName = "ShouldCreateSubsystem"), Category = "Managed Subsystems")
 	bool K2_ShouldCreateSubsystem() const;
-  
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Initialize"), Category = "Managed Subsystems")
-	void K2_Initialize();
-  
+	void K2_Initialize(FSubsystemCollectionBaseRef Collection);
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Deinitialize"), Category = "Managed Subsystems")
 	void K2_Deinitialize();
-	
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Tick"), Category = "Managed Subsystems")
 	void K2_Tick(float DeltaTime);
 };

--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSLocalPlayerSubsystem.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSLocalPlayerSubsystem.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "SubsystemCollectionBaseRef.h"
 #include "Subsystems/LocalPlayerSubsystem.h"
 #include "CSLocalPlayerSubsystem.generated.h"
 
@@ -12,26 +13,26 @@ class UCSLocalPlayerSubsystem : public ULocalPlayerSubsystem, public FTickableGa
 	GENERATED_BODY()
 
 	// USubsystem Begin
-	
+
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override
 	{
 		Super::Initialize(Collection);
-		K2_Initialize();
+		K2_Initialize(Collection);
 	}
-  
+
 	virtual void Deinitialize() override
 	{
 		Super::Deinitialize();
 		K2_Deinitialize();
 	}
-  
+
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override
 	{
 		if (!Super::ShouldCreateSubsystem(Outer))
 		{
 			return false;
 		}
-  
+
 		return K2_ShouldCreateSubsystem();
 	}
 
@@ -90,10 +91,10 @@ protected:
 
 	UFUNCTION(BlueprintNativeEvent, meta = (ScriptName = "ShouldCreateSubsystem"), Category = "Managed Subsystems")
 	bool K2_ShouldCreateSubsystem() const;
-  
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Initialize"), Category = "Managed Subsystems")
-	void K2_Initialize();
-  
+	void K2_Initialize(FSubsystemCollectionBaseRef Collection);
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Deinitialize"), Category = "Managed Subsystems")
 	void K2_Deinitialize();
 

--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSLocalPlayerSubsystem.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSLocalPlayerSubsystem.h
@@ -70,9 +70,6 @@ class UCSLocalPlayerSubsystem : public ULocalPlayerSubsystem, public FTickableGa
 
 	// End
 
-	UFUNCTION(meta = (ScriptMethod))
-	ULocalPlayer* K2_GetLocalPlayer() const;
-
 public:
 
 	UPROPERTY(EditAnywhere, Category = "Managed Subsystems")
@@ -100,4 +97,7 @@ protected:
 
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Tick"), Category = "Managed Subsystems")
 	void K2_Tick(float DeltaTime);
+
+	UFUNCTION(meta = (ScriptMethod))
+	ULocalPlayer* K2_GetLocalPlayer() const;
 };

--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.cpp
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.cpp
@@ -26,3 +26,8 @@ bool UCSWorldSubsystem::GetIsInitialized() const
 {
 	return IsInitialized();
 }
+
+bool UCSWorldSubsystem::K2_DoesSupportWorldType_Implementation(const ECSWorldType WorldType) const
+{
+    return true;
+}

--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.h
@@ -8,6 +8,35 @@
 #include "Subsystems/WorldSubsystem.h"
 #include "CSWorldSubsystem.generated.h"
 
+UENUM(BlueprintType)
+enum class ECSWorldType : uint8
+{
+    /** An untyped world, in most cases this will be the vestigial worlds of streamed in sub-levels */
+    None = EWorldType::None,
+
+    /** The game world */
+    Game = EWorldType::Game,
+
+    /** A world being edited in the editor */
+    Editor = EWorldType::Editor,
+
+    /** A Play In Editor world */
+    PIE = EWorldType::PIE,
+
+    /** A preview world for an editor tool */
+    EditorPreview = EWorldType::EditorPreview,
+
+    /** A preview world for a game */
+    GamePreview = EWorldType::GamePreview,
+
+    /** A minimal RPC world for a game */
+    GameRPC = EWorldType::GameRPC,
+
+    /** An editor world that was loaded but not currently being edited in the level editor */
+    Inactive = EWorldType::Inactive,
+};
+
+
 UCLASS(Blueprintable, BlueprintType, Abstract)
 class UCSWorldSubsystem : public UTickableWorldSubsystem
 #if ENGINE_MINOR_VERSION >= 5
@@ -41,6 +70,16 @@ class UCSWorldSubsystem : public UTickableWorldSubsystem
 		}
 
 		return K2_ShouldCreateSubsystem();
+	}
+
+    virtual bool DoesSupportWorldType(const EWorldType::Type WorldType) const override
+	{
+	    if (!Super::DoesSupportWorldType(WorldType))
+	    {
+	        return false;
+	    }
+
+	    return K2_DoesSupportWorldType(static_cast<ECSWorldType>(WorldType));
 	}
 
 	virtual void BeginDestroy() override;
@@ -115,6 +154,9 @@ protected:
 
 	UFUNCTION(BlueprintNativeEvent, meta = (ScriptName = "ShouldCreateSubsystem"), Category = "Managed Subsystems")
 	bool K2_ShouldCreateSubsystem() const;
+
+    UFUNCTION(BlueprintNativeEvent, meta = (ScriptName = "DoesSupportWorldType"), Category = "Managed Subsystems")
+    bool K2_DoesSupportWorldType(const ECSWorldType WorldType) const;
 
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Initialize"), Category = "Managed Subsystems")
 	void K2_Initialize(FSubsystemCollectionBaseRef Collection);

--- a/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/CSWorldSubsystem.h
@@ -4,6 +4,7 @@
 #if ENGINE_MINOR_VERSION >= 5
 #include "Streaming/StreamingWorldSubsystemInterface.h"
 #endif
+#include "SubsystemCollectionBaseRef.h"
 #include "Subsystems/WorldSubsystem.h"
 #include "CSWorldSubsystem.generated.h"
 
@@ -16,13 +17,13 @@ class UCSWorldSubsystem : public UTickableWorldSubsystem
 	GENERATED_BODY()
 
 	// USubsystem Begin
-	
+
 	virtual void Initialize(FSubsystemCollectionBase& Collection) override
 	{
 		Super::Initialize(Collection);
-		K2_Initialize();
+		K2_Initialize(Collection);
 	}
-  
+
 	virtual void Deinitialize() override
 	{
 		if (IsInitialized())
@@ -31,34 +32,34 @@ class UCSWorldSubsystem : public UTickableWorldSubsystem
 			K2_Deinitialize();
 		}
 	}
-  
+
 	virtual bool ShouldCreateSubsystem(UObject* Outer) const override
 	{
 		if (!Super::ShouldCreateSubsystem(Outer))
 		{
 			return false;
 		}
-  
+
 		return K2_ShouldCreateSubsystem();
 	}
 
 	virtual void BeginDestroy() override;
 
 	// End
-	
+
 	// UWorldSubsystem begin
 	virtual void PostInitialize() override
 	{
 		Super::PostInitialize();
 		K2_PostInitialize();
 	}
-	
+
 	virtual void OnWorldBeginPlay(UWorld& InWorld) override
 	{
 		Super::OnWorldBeginPlay(InWorld);
 		K2_OnWorldBeginPlay();
 	}
-	
+
 	virtual void OnWorldComponentsUpdated(UWorld& World) override
 	{
 		Super::OnWorldComponentsUpdated(World);
@@ -88,9 +89,9 @@ class UCSWorldSubsystem : public UTickableWorldSubsystem
 		Super::Tick(DeltaTime);
 		K2_Tick(DeltaTime);
 	}
-	
+
 	// End
-	
+
 	/** Returns true if Initialize has been called but Deinitialize has not */
 	UFUNCTION(meta = (ScriptMethod))
 	bool GetIsInitialized() const;
@@ -99,7 +100,7 @@ protected:
 
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "PostInitialize"), Category = "Managed Subsystems")
 	void K2_PostInitialize();
-	
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Tick"), Category = "Managed Subsystems")
 	void K2_Tick(float DeltaTime);
 
@@ -114,11 +115,11 @@ protected:
 
 	UFUNCTION(BlueprintNativeEvent, meta = (ScriptName = "ShouldCreateSubsystem"), Category = "Managed Subsystems")
 	bool K2_ShouldCreateSubsystem() const;
-  
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Initialize"), Category = "Managed Subsystems")
-	void K2_Initialize();
-  
+	void K2_Initialize(FSubsystemCollectionBaseRef Collection);
+
 	UFUNCTION(BlueprintImplementableEvent, meta = (ScriptName = "Deinitialize"), Category = "Managed Subsystems")
 	void K2_Deinitialize();
-	
+
 };

--- a/Source/UnrealSharpCore/Extensions/Subsystems/SubsystemCollectionBaseRef.h
+++ b/Source/UnrealSharpCore/Extensions/Subsystems/SubsystemCollectionBaseRef.h
@@ -1,0 +1,18 @@
+﻿// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SubsystemCollectionBaseRef.generated.h"
+
+USTRUCT(BlueprintType)
+struct FSubsystemCollectionBaseRef
+{
+    GENERATED_BODY()
+
+    FSubsystemCollectionBaseRef() = default;
+    explicit(false) FSubsystemCollectionBaseRef(FSubsystemCollectionBase &Base) : Base(&Base) {}
+
+private:
+    FSubsystemCollectionBase *Base;
+};

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.Build.cs
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.Build.cs
@@ -21,29 +21,29 @@ public class UnrealSharpEditor : ModuleRules
                 "Engine",
                 "Slate",
                 "SlateCore",
-                "EditorSubsystem", 
+                "EditorSubsystem",
                 "UnrealSharpCore",
-                "UnrealEd", 
+                "UnrealEd",
                 "UnrealSharpProcHelper",
                 "BlueprintGraph",
                 "ToolMenus",
                 "EditorFramework",
                 "InputCore",
-                "AppFramework", 
-                "EditorStyle", 
+                "AppFramework",
+                "EditorStyle",
                 "Projects",
                 "GameplayTags",
                 "DeveloperSettings",
                 "UnrealSharpBlueprint",
                 "Kismet",
-                "KismetCompiler", 
+                "KismetCompiler",
                 "BlueprintEditorLibrary",
                 "SubobjectDataInterface",
-                "AssetTools", 
+                "AssetTools",
                 "UnrealSharpRuntimeGlue",
             }
         );
-        
+
         PublicDefinitions.Add("SkipGlueGeneration");
     }
 }

--- a/Source/UnrealSharpRuntimeGlue/UnrealSharpRuntimeGlue.Build.cs
+++ b/Source/UnrealSharpRuntimeGlue/UnrealSharpRuntimeGlue.Build.cs
@@ -20,13 +20,13 @@ public class UnrealSharpRuntimeGlue : ModuleRules
                 "Engine",
                 "Slate",
                 "UnrealSharpProcHelper",
-                "SlateCore", 
+                "SlateCore",
                 "DeveloperSettings",
                 "UnrealEd",
                 "GameplayTags"
             }
         );
-        
+
         PublicDefinitions.Add("SkipGlueGeneration");
     }
 }


### PR DESCRIPTION
In C++ subystems are able to declare dependencies through the `InitializeDependency` method on `FSubsystemCollectionBase`, however since this type is not exposed to Blueprints there is no way to handle this same thing in C#. To rectify this, I created `FSubsystemCollectionBaseRef` as a wrapper struct that holds a pointer to the underlying `FSubsystemCollectionBase` object. This is then reflected in C# by the type having a single property of type IntPtr and being marked as Blittable. The struct is also defined as a readonly ref struct to ensure that it cannot escape the context of the initialize method that called it. Additional support code was also modified to add `allows ref struct` so that this struct can be defined this way. 

The struct has two distinct method overload sets. `InitializeDependency` and `InitializeRequiredDependency`, with the former having the capacity to return null and the latter throwing an `InvalidOperationException` if it cannot find a dependency object.

The usage would look something like this:
```C#
[UClass]
public class MySubsystem : UCSGameInstanceSubsystem 
{
    [UProperty]
    private UDependentSubsystem Dependency { get; set; }

    protected override void Initialize(FSubsystemCollectionBaseRef collection)
    {
        Dependency = collection.InitializeRequiredDependency<UDependentSubsystem>();
    }
}
```