### PR TITLE
Include CSMetaDataUtils.h

### DIFF
--- a/Source/UnrealSharpCore/TypeGenerator/Register/TypeInfo/CSTypeInfo.h
+++ b/Source/UnrealSharpCore/TypeGenerator/Register/TypeInfo/CSTypeInfo.h
@@ -1,5 +1,9 @@
 ﻿#pragma once
 
+#if WITH_EDITOR
+#include "UnrealSharpCore/TypeGenerator/Register/CSMetaDataUtils.h"
+#endif
+
 struct FCSAssembly;
 
 enum ETypeState : uint8


### PR DESCRIPTION
Otherwise it would result in a build error complaining about `FCSMetaDataUtils` not found.