### PR TITLE
Fix Relative Paths causing hostfxr_initialize_for_dotnet_command_line to fail

### DIFF
--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -139,7 +139,7 @@ FString FCSProcHelper::GetRuntimeConfigPath()
 
 FString FCSProcHelper::GetUserAssemblyDirectory()
 {
-	return FPaths::Combine(FPaths::ProjectDir(), "Binaries", "Managed");
+	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), "Binaries", "Managed"));
 }
 
 FString FCSProcHelper::GetUnrealSharpMetadataPath()


### PR DESCRIPTION
This PR fixes an issue where hostfxr_initialize_for_dotnet_command_line was called with an incorrect path.

Fixes issue: 
[2025.08.02-10.27.37:091][  0]LogWindows: Error: Fatal error: [File:C:\Cropout\Plugins\UnrealSharp\Source\UnrealSharpCore\CSManager.cpp] [Line: 192] 
[2025.08.02-10.27.37:091][  0]LogWindows: Error: Failed to initialize Runtime Host. Check logs for more details.
