### PR TITLE
Support initialize readonly TArray, TSet and TMap

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Array.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Array.cs
@@ -160,8 +160,13 @@ public class TArray<T> : UnrealArrayBase<T>, IList<T>, IReadOnlyList<T>
 public class ArrayMarshaller<T>(IntPtr nativeProperty, MarshallingDelegates<T>.ToNative toNative, MarshallingDelegates<T>.FromNative fromNative)
 {
     private TArray<T>? _arrayWrapper;
-    
+
     public void ToNative(IntPtr nativeBuffer, int arrayIndex, IList<T> obj)
+    {
+        ToNative(nativeBuffer, obj);
+    }
+
+    public void ToNative(IntPtr nativeBuffer, IList<T> obj)
     {
         unsafe
         {

--- a/Managed/UnrealSharp/UnrealSharp/MapBase.cs
+++ b/Managed/UnrealSharp/UnrealSharp/MapBase.cs
@@ -475,9 +475,19 @@ public class MapReadOnlyMarshaller<TKey, TValue>
         return _readOnlyMapWrapper;
     }
 
-    public void ToNative(IntPtr nativeBuffer, int arrayIndex, IntPtr prop, IReadOnlyDictionary<TKey, TValue> value)
+    public TMap<TKey, TValue> MakeWrapper(IntPtr nativeBuffer)
     {
-        throw new NotImplementedException("Read-only TMap cannot write to native memory.");
+        return new TMap<TKey, TValue>(_nativeProperty, nativeBuffer, _keyFromNative, _keyToNative, _valueFromNative, _valueToNative);
+    }
+
+    public void ToNative(IntPtr nativeBuffer, int arrayIndex, IReadOnlyDictionary<TKey, TValue> value)
+    {
+        TMap<TKey, TValue> wrapper = MakeWrapper(nativeBuffer);
+
+        foreach (KeyValuePair<TKey, TValue> pair in value)
+        {
+            wrapper.Add(pair.Key, pair.Value);
+        }
     }
 }
 

--- a/Managed/UnrealSharp/UnrealSharp/SetReadOnly.cs
+++ b/Managed/UnrealSharp/UnrealSharp/SetReadOnly.cs
@@ -43,14 +43,18 @@ public class TSetReadOnly<T> : TSetBase<T>, IReadOnlySet<T>
 public class SetReadOnlyMarshaller<T>
 {
     readonly NativeProperty _property;
+    private readonly FScriptSetHelper _helper;
     readonly MarshallingDelegates<T>.FromNative _elementFromNative;
+    readonly MarshallingDelegates<T>.ToNative _elementToNative;
     private TSetReadOnly<T>? _readonlySetWrapper;
 
     public SetReadOnlyMarshaller(IntPtr setProperty,
         MarshallingDelegates<T>.ToNative toNative, MarshallingDelegates<T>.FromNative fromNative)
     {
         _property = new NativeProperty(setProperty);
+        _helper = new FScriptSetHelper(_property);
         _elementFromNative = fromNative;
+        _elementToNative = toNative;
     }
 
     public TSetReadOnly<T> FromNative(IntPtr nativeBuffer, int arrayIndex)
@@ -70,6 +74,6 @@ public class SetReadOnlyMarshaller<T>
 
     public void ToNative(IntPtr nativeBuffer, int arrayIndex, IntPtr prop, IReadOnlyCollection<T> value)
     {
-        throw new NotImplementedException("Read-only TSet cannot write to native memory.");
+        SetMarshaller<T>.ToNativeInternal(nativeBuffer, arrayIndex, value, _helper, _elementToNative);
     }
 }

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/ContainerPropertyTranslator.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/ContainerPropertyTranslator.cs
@@ -23,7 +23,7 @@ public class ContainerPropertyTranslator : PropertyTranslator
     public readonly string InterfaceName;
 
     public override bool IsBlittable => false;
-    public override bool SupportsSetter => false;
+    public override bool SupportsSetter => true;
     public override bool CacheProperty => true;
 
     public override bool CanExport(UhtProperty property)
@@ -58,6 +58,18 @@ public class ContainerPropertyTranslator : PropertyTranslator
 
         builder.AppendLine($"{propertyManagedName}_Marshaller ??= new {wrapperType}({propertyManagedName}_NativeProperty, {marshallingDelegates});");
         builder.AppendLine($"return {propertyManagedName}_Marshaller.FromNative(IntPtr.Add(NativeObject, {propertyManagedName}_Offset), 0);");
+    }
+
+    public override void ExportPropertySetter(GeneratorStringBuilder builder, UhtProperty property, string propertyManagedName)
+    {
+        UhtContainerBaseProperty containerProperty = (UhtContainerBaseProperty)property;
+        PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
+
+        string wrapperType = GetWrapperType(property);
+        string marshallingDelegates = translator.ExportMarshallerDelegates(containerProperty.ValueProperty);
+
+        builder.AppendLine($"{propertyManagedName}_Marshaller ??= new {wrapperType}({propertyManagedName}_NativeProperty, {marshallingDelegates});");
+        builder.AppendLine($"{propertyManagedName}_Marshaller.ToNative(IntPtr.Add(NativeObject, {propertyManagedName}_Offset), value);");
     }
 
     public override void ExportPropertyVariables(GeneratorStringBuilder builder, UhtProperty property, string propertyEngineName)

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslator.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslator.cs
@@ -357,10 +357,10 @@ public abstract class PropertyTranslator
         
         bool isReadWrite = property.IsReadWrite();
         bool isEditDefaultsOnly = property.IsEditDefaultsOnly();
-        
+
         Action? exportSetterAction = SupportsSetter && (isReadWrite || isEditDefaultsOnly) ? ExportSetter : null;
         string setterOperation = isEditDefaultsOnly && !isReadWrite ? "init" : "set";
-        
+
         ExportProperty_Internal(builder, property, property.GetPropertyName(), ExportBackingFields, null, ExportGetter, exportSetterAction, setterOperation); 
     }
     


### PR DESCRIPTION
Generates `{ get; init; }` instead of `{ get; }` to allow readonly collections being initialized in constructors.

Fixes #469 