### PR TITLE
Project Glue Rework

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildWeave.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/BuildWeave.cs
@@ -8,16 +8,18 @@ public class BuildWeave : BuildToolAction
         WeaveProject weaveProject = new WeaveProject();
         return buildSolution.RunAction() && weaveProject.RunAction() && AddLaunchSettings();
     }
+    
     bool AddLaunchSettings()
     {
         List<FileInfo> allProjectFiles = Program.GetAllProjectFiles(new DirectoryInfo(Program.GetProjectDirectory()));
 
         foreach (FileInfo projectFile in allProjectFiles)
         {
-            if (projectFile.Directory!.Name == "ProjectGlue")
+            if (projectFile.Directory!.Name.EndsWith(".Glue"))
             {
                 continue;
             }
+            
             string csProjectPath = Path.Combine(Program.GetScriptFolder(), projectFile.Directory.Name);
             string propertiesDirectoryPath = Path.Combine(csProjectPath, "Properties");
             string launchSettingsPath = Path.Combine(propertiesDirectoryPath, "launchSettings.json");

--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateProject.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateProject.cs
@@ -29,6 +29,8 @@ public class GenerateProject : BuildToolAction
         string folder = Program.TryGetArgument("NewProjectFolder");
         _projectRoot = Program.TryGetArgument("ProjectRoot");
         
+        string slnPathg = Program.GetSolutionFile();
+        
         if (!ContainsUPluginOrUProjectFile(_projectRoot))
         {
             throw new InvalidOperationException("Project folder must contain a .uplugin or .uproject file.");
@@ -79,14 +81,11 @@ public class GenerateProject : BuildToolAction
             File.Delete(myClassFile);
         }
 
-        if (!Program.HasArgument("SkipSolutionGeneration"))
+        string slnPath = Program.GetSolutionFile();
+        if (!File.Exists(slnPath))
         {
-            string slnPath = Program.GetSolutionFile();
-            if (!File.Exists(slnPath))
-            {
-                GenerateSolution generateSolution = new GenerateSolution();
-                generateSolution.RunAction();
-            }
+            GenerateSolution generateSolution = new GenerateSolution();
+            generateSolution.RunAction();
         }
 
         if (Program.HasArgument("SkipUSharpProjSetup"))
@@ -249,9 +248,8 @@ public class GenerateProject : BuildToolAction
     private void AppendGeneratedCode(XmlDocument doc, XmlElement itemGroup)
     {
         string providedGlueName = Program.TryGetArgument("GlueProjectName");
-        string glueProjectName = string.IsNullOrEmpty(providedGlueName) ? "ProjectGlue" : providedGlueName;
         string scriptFolder = string.IsNullOrEmpty(_projectRoot) ? Program.GetScriptFolder() : Path.Combine(_projectRoot, "Script");
-        string generatedGluePath = Path.Combine(scriptFolder, glueProjectName, $"{glueProjectName}.csproj");
+        string generatedGluePath = Path.Combine(scriptFolder, providedGlueName, $"{providedGlueName}.csproj");
         AddDependency(doc, itemGroup, generatedGluePath);
     }
 

--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Program.cs
@@ -167,13 +167,13 @@ public static class Program
         string executablePath = string.Empty;
         if (OperatingSystem.IsWindows())
         {
-            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Win64", "UnrealEditor.exe");
+            executablePath = Path.Combine(BuildToolOptions.EngineDirectory, "Binaries", "Win64", "UnrealEditor.exe");
         }
         else if (OperatingSystem.IsMacOS())
         {
-            executablePath = Path.Combine(Program.BuildToolOptions.EngineDirectory, "Binaries", "Mac", "UnrealEditor");
+            executablePath = Path.Combine(BuildToolOptions.EngineDirectory, "Binaries", "Mac", "UnrealEditor");
         }
-        string commandLineArgs = Program.FixPath(Program.GetUProjectFilePath());
+        string commandLineArgs = FixPath(GetUProjectFilePath());
 
         // Create a new profile if it doesn't exist
         if (root.Profiles == null)
@@ -188,7 +188,7 @@ public static class Program
             CommandLineArgs = $"\"{commandLineArgs}\"",
         };
 
-        string newJsonString = JsonConvert.SerializeObject(root, Newtonsoft.Json.Formatting.Indented);
+        string newJsonString = JsonConvert.SerializeObject(root, Formatting.Indented);
         StreamWriter writer = File.CreateText(launchSettingsPath);
         writer.Write(newJsonString);
         writer.Close();

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -63,7 +63,22 @@ public static class Program
             resolver.AddSearchDirectory(directory);
             searchPaths.Add(directory);
         }
-
+        
+        List<AssemblyDefinition> bindingsAssemblies = new List<AssemblyDefinition>(WeaverOptions.AssemblyPaths.Count());
+        foreach (string assemblyPath in WeaverOptions.AssemblyPaths)
+        {
+            string assemblyFileName = Path.GetFileNameWithoutExtension(assemblyPath);
+            AssemblyDefinition assembly = resolver.Resolve(new AssemblyNameReference(assemblyFileName, null));
+            
+            if (assembly == null)
+            {
+                throw new FileNotFoundException($"Could not find assembly: {assemblyFileName}");
+            }
+            
+            bindingsAssemblies.Add(assembly);
+        }
+        
+        WeaverImporter.Instance.AllProjectAssemblies = bindingsAssemblies;
         WeaverImporter.Instance.AssemblyResolver = resolver;
     }
 
@@ -107,7 +122,7 @@ public static class Program
 
         foreach (AssemblyDefinition assembly in assemblies)
         {
-            if (assembly.Name.FullName == WeaverImporter.Instance.ProjectGlueAssembly.FullName || assembly.Name.Name.EndsWith("PluginGlue"))
+            if (assembly.Name.Name.EndsWith(".Glue"))
             {
                 continue;
             }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Utilities/AssemblyUtilities.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Utilities/AssemblyUtilities.cs
@@ -48,12 +48,9 @@ public static class AssemblyUtilities
     
     public static void ForEachAssembly(Func<AssemblyDefinition, bool> action)
     {
-        List<AssemblyDefinition> assemblies = [WeaverImporter.Instance.UnrealSharpAssembly, 
-            WeaverImporter.Instance.UnrealSharpCoreAssembly, 
-            WeaverImporter.Instance.UserAssembly, 
-            WeaverImporter.Instance.ProjectGlueAssembly];
-        
+        List<AssemblyDefinition> assemblies = [WeaverImporter.Instance.UnrealSharpAssembly, WeaverImporter.Instance.UnrealSharpCoreAssembly];
         assemblies.AddRange(WeaverImporter.Instance.WeavedAssemblies);
+        assemblies.AddRange(WeaverImporter.Instance.AllProjectAssemblies);
         
         foreach (AssemblyDefinition assembly in assemblies)
         {

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverImporter.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/WeaverImporter.cs
@@ -43,7 +43,7 @@ public class WeaverImporter
     
     public AssemblyDefinition UnrealSharpAssembly => FindAssembly(UnrealSharpNamespace);
     public AssemblyDefinition UnrealSharpCoreAssembly => FindAssembly(UnrealSharpNamespace + ".Core");
-    public AssemblyDefinition ProjectGlueAssembly => FindAssembly("ProjectGlue");
+    public List<AssemblyDefinition> AllProjectAssemblies = [];
     
     public MethodReference NativeObjectGetter = null!;
     public TypeDefinition IntPtrType = null!;

--- a/Source/UnrealSharpEditor/Plugins/CSPluginTemplateDescription.cpp
+++ b/Source/UnrealSharpEditor/Plugins/CSPluginTemplateDescription.cpp
@@ -11,12 +11,12 @@ void FCSPluginTemplateDescription::OnPluginCreated(const TSharedPtr<IPlugin> New
     const FString ProjectPath = NewPlugin->GetBaseDir() / "Script";
     const FString GlueProjectName = FString::Printf(TEXT("%s.Glue"), *NewPlugin->GetName());
 
-    if (bRequiresPluginGlue)
+    if (bRequiresGlue)
     {
         CreateCodeModule(GlueProjectName, ProjectPath, GlueProjectName, NewPlugin->GetBaseDir(), false);
     }
     
-    CreateCodeModule(ModuleName, ProjectPath, GlueProjectName, NewPlugin->GetBaseDir(), bRequiresPluginGlue);
+    CreateCodeModule(ModuleName, ProjectPath, GlueProjectName, NewPlugin->GetBaseDir(), bRequiresGlue);
 }
 
 void FCSPluginTemplateDescription::CreateCodeModule(const FString& ModuleName, const FString& ProjectPath,

--- a/Source/UnrealSharpEditor/Plugins/CSPluginTemplateDescription.cpp
+++ b/Source/UnrealSharpEditor/Plugins/CSPluginTemplateDescription.cpp
@@ -9,7 +9,7 @@ void FCSPluginTemplateDescription::OnPluginCreated(const TSharedPtr<IPlugin> New
 
     const FString ModuleName = FString::Printf(TEXT("Managed%s"), *NewPlugin->GetName());
     const FString ProjectPath = NewPlugin->GetBaseDir() / "Script";
-    const FString GlueProjectName = FString::Printf(TEXT("%s.PluginGlue"), *NewPlugin->GetName());
+    const FString GlueProjectName = FString::Printf(TEXT("%s.Glue"), *NewPlugin->GetName());
 
     if (bRequiresPluginGlue)
     {

--- a/Source/UnrealSharpEditor/Plugins/CSPluginTemplateDescription.h
+++ b/Source/UnrealSharpEditor/Plugins/CSPluginTemplateDescription.h
@@ -13,8 +13,8 @@ class UNREALSHARPEDITOR_API FCSPluginTemplateDescription final : public FPluginT
 public:
     FCSPluginTemplateDescription(FText InName, FText InDescription, FString InOnDiskPath, const bool InCanContainContent,
         const EHostType::Type InModuleDescriptorType, const ELoadingPhase::Type InLoadingPhase = ELoadingPhase::Default,
-        const bool InSupportsContentOnlyProjects = true, const bool InRequiresPluginGlue = true) : FPluginTemplateDescription(MoveTemp(InName), MoveTemp(InDescription),
-            MoveTemp(InOnDiskPath), InCanContainContent, InModuleDescriptorType, InLoadingPhase, InSupportsContentOnlyProjects), bRequiresPluginGlue(InRequiresPluginGlue)
+        const bool InSupportsContentOnlyProjects = true, const bool InRequiresGlue = true) : FPluginTemplateDescription(MoveTemp(InName), MoveTemp(InDescription),
+            MoveTemp(InOnDiskPath), InCanContainContent, InModuleDescriptorType, InLoadingPhase, InSupportsContentOnlyProjects), bRequiresGlue(InRequiresGlue)
     {
     }
 
@@ -23,5 +23,5 @@ public:
 private:
     static void CreateCodeModule(const FString& ModuleName, const FString& ProjectPath, const FString& GlueProjectName, const FString& PluginPath, bool bIncludeGlueProject);
 
-    bool bRequiresPluginGlue;
+    bool bRequiresGlue;
 };

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -128,7 +128,7 @@ void FUnrealSharpEditorModule::OnCSharpCodeModified(const TArray<FFileChangeData
 		FPaths::NormalizeFilename(NormalizedFileName);
 
 		// Skip ProjectGlue files
-		if (NormalizedFileName.Contains(TEXT("ProjectGlue")) || NormalizedFileName.Contains("PluginGlue"))
+		if (NormalizedFileName.Contains("Glue"))
 		{
 			continue;
 		}

--- a/Source/UnrealSharpManagedGlue/CSharpExporter.cs
+++ b/Source/UnrealSharpManagedGlue/CSharpExporter.cs
@@ -82,7 +82,7 @@ public static class CSharpExporter
 
     static void DeserializeModuleData()
     {
-        if (!Directory.Exists(Program.EngineGluePath) || !Directory.Exists(Program.ProjectGluePath))
+        if (!Directory.Exists(Program.EngineGluePath))
         {
             return;
         }
@@ -119,7 +119,7 @@ public static class CSharpExporter
         string timestampFilePath = Path.Combine(generatedCodeDirectory, "Timestamp");
         string typeInfoFilePath = Path.Combine(generatedCodeDirectory, SpecialtypesJson);
 
-        if (!File.Exists(timestampFilePath) || !File.Exists(typeInfoFilePath) || !Directory.Exists(Program.EngineGluePath) || !Directory.Exists(Program.ProjectGluePath))
+        if (!File.Exists(timestampFilePath) || !File.Exists(typeInfoFilePath) || !Directory.Exists(Program.EngineGluePath))
         {
             return true;
         }
@@ -175,7 +175,7 @@ public static class CSharpExporter
 
         if (!package.IsPartOfEngine())
         {
-            package.GetPackageDependencies();
+            package.FindOrAddProjectInfo();
         }
 
         string packageName = package.GetShortName();

--- a/Source/UnrealSharpManagedGlue/Properties/launchSettings.json
+++ b/Source/UnrealSharpManagedGlue/Properties/launchSettings.json
@@ -1,9 +1,0 @@
-﻿{
-  "profiles": {
-    "UBT": {
-      "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\Epic Games\\UE_5.6\\Engine\\Binaries\\DotNET\\UnrealBuildTool\\UnrealBuildTool.exe",
-      "commandLineArgs": "-Mode=UnrealHeaderTool \"-Target=TurnBasedFrameworkEditor Win64 Development -Project=\\\"D:\\dev\\TurnBasedFramework\\TurnBasedFramework.uproject\\\"\""
-    }
-  }
-}

--- a/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
@@ -133,6 +133,7 @@ public static class FileExporter
         foreach (ProjectDirInfo pluginDirectory in Program.PluginDirs)
         {
             CleanGeneratedFolder(pluginDirectory.GlueProjectDirectory);
+            CleanGeneratedFolder(pluginDirectory.GlueProjectDirectory_LEGACY);
         }
     }
     

--- a/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
@@ -1,23 +1,36 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.IO;
-using System.Linq;
 using System.Threading;
 using EpicGames.UHT.Types;
 
 namespace UnrealSharpScriptGenerator.Utilities;
 
-public record struct PluginDirInfo(string PluginName, string PluginDirectory)
+public readonly struct ProjectDirInfo
 {
-    public string PluginScriptDir = Path.Combine(PluginDirectory, "Script");
-    public string GlueProjectDir => Path.Combine(PluginScriptDir, GlueProjectName);
+    private readonly string _projectName;
+    private readonly string _projectDirectory;
+    public HashSet<string>? Dependencies { get; }
 
-    public string GlueProjectName => $"{PluginName}.PluginGlue";
-
+    public ProjectDirInfo(string projectName, string projectDirectory, HashSet<string>? dependencies = null)
+    {
+        _projectName = projectName;
+        _projectDirectory = projectDirectory;
+        Dependencies = dependencies;
+    }
+    
+    public string GlueProjectName => $"{_projectName}.Glue";
+    public string GlueProjectName_LEGACY => $"{_projectName}.PluginGlue";
     public string GlueProjectFile => $"{GlueProjectName}.csproj";
-
-    public string GlueProjectPath => Path.Combine(GlueProjectDir, GlueProjectFile);
+    
+    public string ScriptDirectory => Path.Combine(_projectDirectory, "Script");
+    
+    public string GlueCsProjPath => Path.Combine(GlueProjectDirectory, GlueProjectFile);
+    
+    public string GlueProjectDirectory => Path.Combine(ScriptDirectory, GlueProjectName);
+    public string GlueProjectDirectory_LEGACY => Path.Combine(ScriptDirectory, GlueProjectName_LEGACY);
+    
+    public string ProjectRoot => _projectDirectory;
 }
 
 public static class FileExporter
@@ -95,37 +108,34 @@ public static class FileExporter
 
     public static string GetLocalGluePath(UhtPackage package)
     {
-        if (!package.IsPlugin())
-        {
-            return Program.ProjectGluePath;
-        }
-
-        var (pluginName, pluginDirectory) = package.GetPluginDirectory();
-        return Path.Combine(pluginDirectory, "Script", $"{pluginName}.PluginGlue");
+        ProjectDirInfo projectDirInfo = package.FindOrAddProjectInfo();
+        return projectDirInfo.GlueProjectDirectory;
     }
 
     public static void CleanOldExportedFiles()
     {
         Console.WriteLine("Cleaning up old generated C# glue files...");
         CleanFilesInDirectories(Program.EngineGluePath);
-        CleanFilesInDirectories(Program.ProjectGluePath, true);
-        foreach (var pluginDirectory in Program.PluginDirs)
+        CleanFilesInDirectories(Program.ProjectGluePath_LEGACY, true);
+        
+        foreach (ProjectDirInfo pluginDirectory in Program.PluginDirs)
         {
-            CleanFilesInDirectories(pluginDirectory.GlueProjectDir, true);
+            CleanFilesInDirectories(pluginDirectory.GlueProjectDirectory, true);
+            CleanFilesInDirectories(pluginDirectory.GlueProjectDirectory_LEGACY, true);
         }
     }
 
     public static void CleanModuleFolders()
     {
         CleanGeneratedFolder(Program.EngineGluePath);
-        CleanGeneratedFolder(Program.ProjectGluePath);
-        foreach (var pluginDirectory in Program.PluginDirs)
+        CleanGeneratedFolder(Program.ProjectGluePath_LEGACY);
+        
+        foreach (ProjectDirInfo pluginDirectory in Program.PluginDirs)
         {
-            CleanGeneratedFolder(pluginDirectory.GlueProjectDir);
+            CleanGeneratedFolder(pluginDirectory.GlueProjectDirectory);
         }
     }
-
-
+    
     public static void CleanGeneratedFolder(string path)
     {
         if (!Directory.Exists(path))

--- a/Source/UnrealSharpManagedGlue/Utilities/PackageUtilities.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/PackageUtilities.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using EpicGames.Core;
 using EpicGames.UHT.Types;
 

--- a/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
@@ -8,72 +8,62 @@ namespace UnrealSharpScriptGenerator.Utilities;
 
 public static class PluginUtilities
 {
-    private const string ProjectGlueName = "<ProjectGlue>";
-    private static readonly Dictionary<string, PluginDirInfo> PluginDirs = new();
-    private static readonly Dictionary<string, HashSet<string>> PluginDependencies = new();
+    public static readonly Dictionary<UhtPackage, ProjectDirInfo> PluginInfo = new();
 
-    public static HashSet<string> GetPackageDependencies(this UhtPackage package)
+    public static ProjectDirInfo FindOrAddProjectInfo(this UhtPackage package)
     {
-        var pluginName = package.IsPlugin() ? package.GetPluginDirectory().PluginName : ProjectGlueName;
-        if (PluginDependencies.TryGetValue(pluginName, out HashSet<string>? dependencies))
+        if (PluginInfo.TryGetValue(package, out ProjectDirInfo plugin))
         {
-            return dependencies;
+            return plugin;
         }
+        
+        string baseDirectory = package.GetModule().BaseDirectory;
+        DirectoryInfo? currentDirectory = new DirectoryInfo(baseDirectory);
 
-        dependencies = package.GetHeaderFiles()
-                .SelectMany(x => x.ReferencedHeadersLocked)
-                .SelectMany(x => x.GetPackages())
-                .Where(x => !x.IsPartOfEngine())
-                .Where(x => x.IsPlugin())
-                .Select(x => x.GetPluginDirectory())
-                .Select(x => x.PluginName)
-                .Where(x => x != pluginName)
-                .ToHashSet();
-        PluginDependencies.Add(pluginName, dependencies);
-        return dependencies;
-    }
-
-    public static PluginDirInfo GetPluginDirectory(this UhtPackage package)
-    {
-        if (PluginDirs.TryGetValue(package.SourceName, out var pluginDirectory))
-        {
-            return pluginDirectory;
-        }
-
-        var currentDirectory = new DirectoryInfo(package.GetModule().BaseDirectory);
+        FileInfo? projectFile = null;
         while (currentDirectory is not null)
         {
-            var pluginFile = currentDirectory.GetFiles("*.uplugin", SearchOption.TopDirectoryOnly)
-                    .SingleOrDefault();
-            if (pluginFile is not null)
+            FileInfo[] foundFiles = currentDirectory.GetFiles("*.*", SearchOption.TopDirectoryOnly);
+            projectFile = foundFiles.FirstOrDefault(f => f.Extension.Equals(".uplugin", StringComparison.OrdinalIgnoreCase) || 
+                                                         f.Extension.Equals(".uproject", StringComparison.OrdinalIgnoreCase));
+            
+            if (projectFile is not null)
             {
-
-                var info = new PluginDirInfo(Path.GetFileNameWithoutExtension(pluginFile.Name),
-                        currentDirectory.FullName);
-                PluginDirs.Add(package.SourceName, info);
-                return info;
+                break;
             }
 
             currentDirectory = currentDirectory.Parent;
         }
-
-        throw new InvalidOperationException($"Could not find plugin directory for {package.SourceName}");
-    }
-
-    public static IEnumerable<string> GetPluginDependencyPaths(string pluginName)
-    {
-        if (!PluginDependencies.TryGetValue(pluginName, out HashSet<string>? dependencies))
+        
+        if (projectFile is null)
         {
-            return [];
+            throw new InvalidOperationException($"Could not find .uplugin or .uproject file for package {package.SourceName} in {baseDirectory}");
         }
-
-        return dependencies
-                .Select(x => PluginDirs[x])
-                .Select(x => x.GlueProjectPath);
-    }
-
-    public static IEnumerable<string> GetProjectDependencyPaths()
-    {
-        return GetPluginDependencyPaths(ProjectGlueName);
+        
+        HashSet<string> dependencies = new HashSet<string>();
+        foreach (UhtHeaderFile header in package.GetHeaderFiles())
+        {
+            HashSet<UhtHeaderFile> referencedHeaders = header.References.ReferencedHeaders;
+            referencedHeaders.UnionWith(header.ReferencedHeadersNoLock);
+            
+            foreach (UhtHeaderFile refHeader in referencedHeaders)
+            {
+                foreach (UhtPackage refPackage in refHeader.GetPackages())
+                {
+                    if (refPackage.IsPartOfEngine() || refPackage == package)
+                    {
+                        continue;
+                    }
+                    
+                    ProjectDirInfo projectInfo = refPackage.FindOrAddProjectInfo();
+                    dependencies.Add(projectInfo.GlueCsProjPath);
+                }
+            }
+        }
+        
+        ProjectDirInfo info = new ProjectDirInfo(Path.GetFileNameWithoutExtension(projectFile.Name), currentDirectory!.FullName, dependencies);
+        PluginInfo.Add(package, info);
+        
+        return info;
     }
 }

--- a/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
@@ -9,7 +9,6 @@ namespace UnrealSharpScriptGenerator.Utilities;
 public static class PluginUtilities
 {
     public static readonly Dictionary<UhtPackage, ProjectDirInfo> PluginInfo = new();
-    public static readonly Dictionary<string, HashSet<string>> ProjectDependencies = new();
 
     public static ProjectDirInfo FindOrAddProjectInfo(this UhtPackage package)
     {

--- a/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
@@ -9,6 +9,7 @@ namespace UnrealSharpScriptGenerator.Utilities;
 public static class PluginUtilities
 {
     public static readonly Dictionary<UhtPackage, ProjectDirInfo> PluginInfo = new();
+    public static readonly Dictionary<string, HashSet<string>> ProjectDependencies = new();
 
     public static ProjectDirInfo FindOrAddProjectInfo(this UhtPackage package)
     {
@@ -41,6 +42,9 @@ public static class PluginUtilities
         }
         
         HashSet<string> dependencies = new HashSet<string>();
+        ProjectDirInfo info = new ProjectDirInfo(Path.GetFileNameWithoutExtension(projectFile.Name), currentDirectory!.FullName, dependencies);
+        PluginInfo.Add(package, info);
+        
         foreach (UhtHeaderFile header in package.GetHeaderFiles())
         {
             HashSet<UhtHeaderFile> referencedHeaders = header.References.ReferencedHeaders;
@@ -56,13 +60,15 @@ public static class PluginUtilities
                     }
                     
                     ProjectDirInfo projectInfo = refPackage.FindOrAddProjectInfo();
+                    if (info.GlueCsProjPath == projectInfo.GlueCsProjPath)
+                    {
+                        continue;
+                    }
+                    
                     dependencies.Add(projectInfo.GlueCsProjPath);
                 }
             }
         }
-        
-        ProjectDirInfo info = new ProjectDirInfo(Path.GetFileNameWithoutExtension(projectFile.Name), currentDirectory!.FullName, dependencies);
-        PluginInfo.Add(package, info);
         
         return info;
     }

--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -175,7 +175,7 @@ void FCSProcHelper::GetProjectNamesByLoadOrder(TArray<FString>& UserProjectNames
 	{
 		FString ProjectName = OrderEntry->AsString();
 
-		if (!bIncludeProjectGlue && (ProjectName == TEXT("ProjectGlue") || ProjectName.EndsWith(TEXT("PluginGlue"))))
+		if (!bIncludeProjectGlue && ProjectName.EndsWith(TEXT(".Glue")))
 		{
 			continue;
 		}
@@ -225,7 +225,7 @@ void FCSProcHelper::GetAllProjectPaths(TArray<FString>& ProjectPaths, bool bIncl
 
 	for (int32 i = ProjectPaths.Num() - 1; i >= 0; i--)
 	{
-		if (bIncludeProjectGlue || (!ProjectPaths[i].EndsWith("ProjectGlue.csproj") && !ProjectPaths[i].EndsWith("PluginGlue.csproj")))
+		if (bIncludeProjectGlue || !ProjectPaths[i].EndsWith("Glue.csproj"))
 		{
 			continue;
 		}
@@ -351,7 +351,7 @@ const FString& FCSProcHelper::GetPluginsDirectory()
 
 const FString& FCSProcHelper::GetProjectGlueFolderPath()
 {
-	static FString ProjectGlueFolderPath = GetScriptFolderDirectory() / "ProjectGlue";
+	static FString ProjectGlueFolderPath = GetScriptFolderDirectory() / FApp::GetProjectName() + TEXT(".Glue");
 	return ProjectGlueFolderPath;
 }
 


### PR DESCRIPTION
All glue projects are just now called `PluginName/ProjectName.Glue.csproj` instead of `.PluginGlue.csproj` for plugins and `ProjectGlue.csproj` for the project's glue

References to old `ProjectGlue.csproj` can be removed and instead reference `ProjectName.Glue.csproj`. This project will only appear if you have any C++ code in your game project.