### PR TITLE
Ensure parameter name is unique

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/ClassMetaData.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/ClassMetaData.cs
@@ -105,6 +105,19 @@ public class ClassMetaData : TypeReferenceMetadata
         {
             MethodDefinition method = _classDefinition.Methods[i];
 
+            if (method.HasParameters)
+            {
+                var paramNameSet = new HashSet<string>();
+                var uniqueNum = 0;
+                foreach (var param in method.Parameters)
+                {
+                    if (!paramNameSet.Add(param.Name))
+                    {
+                        param.Name = $"{param.Name}_{uniqueNum++}";
+                    }
+                }
+            }
+
             if (FunctionMetaData.IsAsyncUFunction(method))
             {
                 FunctionProcessor.RewriteMethodAsAsyncUFunctionImplementation(method);


### PR DESCRIPTION
A lambda allows using discard `_` as its parameter name so that if a lambda has multiple parameters named `_`, it will end up a method that has duplicated parameter names. For exmaple,

```cs
[UFunction](_, _, _, _) => Foo();
```

This will confuse the weaver and cause the weaver to generate duplicated fields and properties, so that `GetPropertyOffsetFromName` can return an incorrect offset with given name `_`, and crashes the game.

Fix this issue by ensuring parameter name is always unique: adding a number suffix if there's any duplication.