### PR TITLE
Fixed a bug where ExcludeFromWeaver was not respected during Hot Reload

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Core/UnmanagedCallbacks.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/UnmanagedCallbacks.cs
@@ -196,9 +196,13 @@ public static class UnmanagedCallbacks
     public static void FreeHandle(IntPtr handle)
     {
         GCHandle foundHandle = GCHandle.FromIntPtr(handle);
-        if (foundHandle.IsAllocated)
+        if (!foundHandle.IsAllocated) return;
+        
+        if (foundHandle.Target is IDisposable disposable)
         {
-            foundHandle.Free();
+            disposable.Dispose();
         }
+            
+        foundHandle.Free();
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp.Editor/UnrealSharpEditorModule.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Editor/UnrealSharpEditorModule.cs
@@ -128,7 +128,8 @@ public static class ManagedUnrealSharpEditorCallbacks
     static unsafe void Weave(char* outputPath, string buildConfiguration)
     {
         List<string> assemblyPaths = new();
-        foreach (Project? projectFile in ProjectCollection.LoadedProjects)
+        foreach (Project? projectFile in ProjectCollection.LoadedProjects
+                     .Where(p => p.GetPropertyValue("ExcludeFromWeaver") != "true"))
         {
             string projectName = Path.GetFileNameWithoutExtension(projectFile.FullPath);
             string assemblyPath = Path.Combine(projectFile.DirectoryPath, "bin",


### PR DESCRIPTION
Fixed an issue where the weaver would try to reload ExcludeFromWeaver projects during hot reload. This will prevent an issue where you get a popup saying "Can't locate assembly" when hot reload occurs.