### PR TITLE
Various fixes and improvements

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Binds/BindsManager.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Binds/BindsManager.cs
@@ -1,38 +1,38 @@
-using System.Runtime.InteropServices;
-
-namespace UnrealSharp.Binds;
-
-[UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-internal delegate IntPtr GetBoundFunction(string outerName, string functionName, int functionSize);
+﻿namespace UnrealSharp.Binds;
 
 public static class NativeBinds
 {
-    private static GetBoundFunction? _getBoundFunction;
+    private unsafe static delegate* unmanaged[Cdecl]<char*, char*, int, IntPtr> _getBoundFunction = null;
 
-    public static void InitializeNativeBinds(IntPtr bindsCallbacks)
+    public unsafe static void InitializeNativeBinds(IntPtr bindsCallbacks)
     {
         if (_getBoundFunction != null)
         {
             throw new Exception("NativeBinds.InitializeNativeBinds called twice");
         }
-        
-        _getBoundFunction = Marshal.GetDelegateForFunctionPointer<GetBoundFunction>(bindsCallbacks);
+
+        _getBoundFunction = (delegate* unmanaged[Cdecl]<char*, char*, int, nint>)bindsCallbacks;
     }
-    
-    public static IntPtr TryGetBoundFunction(string outerName, string functionName, int functionSize)
+
+    public unsafe static IntPtr TryGetBoundFunction(string outerName, string functionName, int functionSize)
     {
         if (_getBoundFunction == null)
         {
             throw new Exception("NativeBinds not initialized");
         }
-        
-        IntPtr functionPtr = _getBoundFunction(outerName, functionName, functionSize);
-                
+
+        IntPtr functionPtr = IntPtr.Zero;
+        fixed (char* outerNamePtr = outerName)
+        fixed (char* functionNamePtr = functionName)
+        {
+            functionPtr = _getBoundFunction(outerNamePtr, functionNamePtr, functionSize);
+        }
+
         if (functionPtr == IntPtr.Zero)
         {
             throw new Exception($"Failed to find bound function {functionName} in {outerName}");
         }
-                
+
         return functionPtr;
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp.Binds/BindsManager.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Binds/BindsManager.cs
@@ -11,7 +11,7 @@ public static class NativeBinds
             throw new Exception("NativeBinds.InitializeNativeBinds called twice");
         }
 
-        _getBoundFunction = (delegate* unmanaged[Cdecl]<char*, char*, int, nint>)bindsCallbacks;
+        _getBoundFunction = (delegate* unmanaged[Cdecl]<char*, char*, int, IntPtr>)bindsCallbacks;
     }
 
     public unsafe static IntPtr TryGetBoundFunction(string outerName, string functionName, int functionSize)

--- a/Managed/UnrealSharp/UnrealSharp.Core/ManagedCallbacks.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/ManagedCallbacks.cs
@@ -5,7 +5,7 @@ namespace UnrealSharp.Core;
 [StructLayout(LayoutKind.Sequential)]
 public unsafe struct ManagedCallbacks
 {
-    public delegate* unmanaged<IntPtr, IntPtr, IntPtr> ScriptManagerBridge_CreateManagedObject;
+    public delegate* unmanaged<IntPtr, IntPtr, char**, IntPtr> ScriptManagerBridge_CreateManagedObject;
     public delegate* unmanaged<IntPtr, IntPtr, IntPtr, IntPtr, IntPtr, int> ScriptManagerBridge_InvokeManagedMethod;
     public delegate* unmanaged<IntPtr, void> ScriptManagerBridge_InvokeDelegate;
     public delegate* unmanaged<IntPtr, char*, IntPtr> ScriptManagerBridge_LookupManagedMethod;

--- a/Managed/UnrealSharp/UnrealSharp.Core/UnmanagedCallbacks.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/UnmanagedCallbacks.cs
@@ -8,7 +8,7 @@ namespace UnrealSharp.Core;
 public static class UnmanagedCallbacks
 {
     [UnmanagedCallersOnly]
-    public static IntPtr CreateNewManagedObject(IntPtr nativeObject, IntPtr typeHandlePtr)
+    public static unsafe IntPtr CreateNewManagedObject(IntPtr nativeObject, IntPtr typeHandlePtr, char** error)
     {
         try
         {
@@ -29,6 +29,7 @@ public static class UnmanagedCallbacks
         catch (Exception ex)
         {
             LogUnrealSharpCore.LogError($"Failed to create new managed object: {ex.Message}");
+            *error = (char*)Marshal.StringToHGlobalUni(ex.ToString());
         }
 
         return IntPtr.Zero;

--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/PackageProject.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/PackageProject.cs
@@ -16,6 +16,7 @@ public class PackageProject : BuildToolAction
         string rootProjectPath = Path.Combine(archiveDirectoryPath, Program.BuildToolOptions.ProjectName);
         string binariesPath = Program.GetOutputPath(rootProjectPath);
         string bindingsPath = Path.Combine(Program.BuildToolOptions.PluginDirectory, "Managed", "UnrealSharp");
+        string bindingsOutputPath = Path.Combine(Program.BuildToolOptions.PluginDirectory, "Intermediate", "Build", "Managed");
         
         Collection<string> extraArguments =
         [
@@ -23,7 +24,8 @@ public class PackageProject : BuildToolAction
             "--runtime",
             "win-x64",
 			"-p:DisableWithEditor=true",
-            $"-p:PublishDir=\"{binariesPath}\""
+            $"-p:PublishDir=\"{binariesPath}\"",
+            $"-p:OutputPath=\"{bindingsOutputPath}\"",
         ];
 
         BuildSolution buildBindings = new BuildSolution(bindingsPath, extraArguments, BuildConfig.Publish);

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using Mono.Cecil.Rocks;
@@ -164,7 +164,10 @@ public class NativeDataContainerType : NativeDataType
     public override void WriteSetter(TypeDefinition type, MethodDefinition setter, Instruction[] loadBufferPtr,
         FieldDefinition? fieldDefinition)
     {
-        
+        ILProcessor processor = BeginSimpleSetter(setter);
+        Instruction loadValue = processor.Create(OpCodes.Ldarg_1);
+        WriteMarshalToNative(processor, type, loadBufferPtr, processor.Create(OpCodes.Ldc_I4_0), loadValue);
+        setter.FinalizeMethod();
     }
 
     public override void WriteLoad(ILProcessor processor, TypeDefinition type, Instruction loadBufferInstruction,

--- a/Managed/global.json
+++ b/Managed/global.json
@@ -2,7 +2,7 @@
   "sdk": {
     "version": "9.0.100",
     "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "allowPrerelease": true
   }
 }
 

--- a/Source/UnrealSharpCore/CSAssembly.cpp
+++ b/Source/UnrealSharpCore/CSAssembly.cpp
@@ -340,13 +340,14 @@ TSharedPtr<FGCHandle> FCSAssembly::CreateManagedObject(const UObject* Object)
 	TSharedPtr<FCSClassInfo> ClassInfo = FindOrAddClassInfo(Class);
 	TSharedPtr<FGCHandle> TypeHandle = ClassInfo->GetManagedTypeHandle();
 
-	FGCHandle NewManagedObject = FCSManagedCallbacks::ManagedCallbacks.CreateNewManagedObject(Object, TypeHandle->GetPointer());
+	TCHAR* Error = nullptr;
+	FGCHandle NewManagedObject = FCSManagedCallbacks::ManagedCallbacks.CreateNewManagedObject(Object, TypeHandle->GetPointer(), &Error);
 	NewManagedObject.Type = GCHandleType::StrongHandle;
 
 	if (NewManagedObject.IsNull())
 	{
 		// This should never happen. Potential issues: IL errors, typehandle is invalid.
-		UE_LOGFMT(LogUnrealSharp, Fatal, "Failed to create managed counterpart for {0}", *Object->GetName());
+		UE_LOGFMT(LogUnrealSharp, Fatal, "Failed to create managed counterpart for {0}:\n{1}", *Object->GetName(), Error);
 		return nullptr;
 	}
 

--- a/Source/UnrealSharpCore/CSManagedCallbacksCache.h
+++ b/Source/UnrealSharpCore/CSManagedCallbacksCache.h
@@ -15,7 +15,7 @@ class UNREALSHARPCORE_API FCSManagedCallbacks
 
 	struct FManagedCallbacks
 	{
-		using ManagedCallbacks_CreateNewManagedObject = FGCHandleIntPtr(__stdcall*)(const void*, void*);
+		using ManagedCallbacks_CreateNewManagedObject = FGCHandleIntPtr(__stdcall*)(const void*, void*, TCHAR**);
 		using ManagedCallbacks_InvokeManagedEvent = int(__stdcall*)(void*, void*, void*, void*, void*);
 		using ManagedCallbacks_InvokeDelegate = int(__stdcall*)(FGCHandleIntPtr);
 		using ManagedCallbacks_LookupMethod = uint8*(__stdcall*)(void*, const TCHAR*);

--- a/Source/UnrealSharpUtilities/UnrealSharpUtils.cpp
+++ b/Source/UnrealSharpUtilities/UnrealSharpUtils.cpp
@@ -22,6 +22,7 @@ FName FCSUnrealSharpUtils::GetNativeFullName(const UField* Object)
 
 void FCSUnrealSharpUtils::PurgeMetaData(const UObject* Object)
 {
+#if WITH_METADATA
 	if (!IsValid(Object))
 	{
 		UE_LOGFMT(LogUnrealSharpUtilities, Error, "Tried to purge metadata of an invalid object");
@@ -37,6 +38,7 @@ void FCSUnrealSharpUtils::PurgeMetaData(const UObject* Object)
 	{
 		MetaData->Empty();
 	}
+#endif
 }
 
 FName FCSUnrealSharpUtils::GetModuleName(const UObject* Object)


### PR DESCRIPTION
- Add the exception message and stacktrace to the log when the managed counterpart was failed to create to improve the diagnosability when an exception was thrown from the constructor
- Replace `Marshal.GetDelegateForFunctionPointer` and `Marshal.GetFunctionPointerForDelegate` with function pointers to reduce the overhead
- Properly generates the setter, and skip the initialization for `ldnull` to avoid marshalling a null value for types like `TArray` and etc. A field with reference type should already have `null` as the initial value by default (a follow up to #512)
- Tweak the global.json to allow using a prerelease version of .NET SDK
- Only purge metadata when it's available to avoid build errors during packaging with Shipping configuration
- Override the `OutputPath` to use the intermediate path so that assemblies won't be locked by the unreal editor which can lead to failure to package the game