### PR TITLE
Prevent "Handle is not initialized" error when UObject lacks interface implementation

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/ScriptInterface.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/ScriptInterface.cs
@@ -49,6 +49,10 @@ public static class ScriptInterfaceExtensions
         }
             
         var wrapperHandle = FCSManagerExporter.CallFindOrCreateManagedInterfaceWrapper(uobject.NativeObject, nativeClass);
+		if(wrapperHandle == IntPtr.Zero)
+        {
+            return null;
+        }
         GCHandle wrapperGcHandle = GCHandle.FromIntPtr(wrapperHandle);
         if (!wrapperGcHandle.IsAllocated)
         {


### PR DESCRIPTION
This update adds a guard clause to prevent a runtime error when AsInterface is called on a UObject that does not implement the expected interface. Previously, wrapperHandle could return an invalid handle (IntPtr.Zero), leading to a "Handle is not initialized" exception.


<img width="1222" height="67" alt="image" src="https://github.com/user-attachments/assets/f7d59c0e-50da-4d8e-9468-b0a4c9b61842" />
