### PR TITLE
Updated assembly loading to load from the actual path rather than a stream

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoadContext.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoadContext.cs
@@ -58,21 +58,8 @@ public class PluginLoadContext : AssemblyLoadContext
         {
             return null;
         }
-
-        using FileStream assemblyFile = File.Open(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-        string pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
-
-        Assembly? loadedAssembly;
-        if (!File.Exists(pdbPath))
-        {
-            loadedAssembly = LoadFromStream(assemblyFile);
-        }
-        else
-        {
-            using var pdbFile = File.Open(pdbPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            loadedAssembly = LoadFromStream(assemblyFile, pdbFile);
-        }
         
+        Assembly loadedAssembly = LoadFromAssemblyPath(assemblyPath);
         LoadedAssemblies[assemblyName.Name] = new WeakReference<Assembly>(loadedAssembly);
         return loadedAssembly;
     }

--- a/Source/UnrealSharpCore/CSAssembly.cpp
+++ b/Source/UnrealSharpCore/CSAssembly.cpp
@@ -220,6 +220,7 @@ bool UCSAssembly::UnloadAssembly()
 	ManagedAssemblyHandle->Dispose(ManagedAssemblyHandle->GetHandle());
 	ManagedAssemblyHandle.Reset();
 
+    UCSManager::Get().OnManagedAssemblyUnloadedEvent().Broadcast(AssemblyName);
 	return UCSManager::Get().GetManagedPluginsCallbacks().UnloadPlugin(*AssemblyPath);
 }
 

--- a/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/UnrealSharpEditor.cpp
@@ -258,11 +258,11 @@ void FUnrealSharpEditorModule::StartHotReload(bool bRebuild, bool bPromptPlayerW
     TArray<FString> AssemblyPaths;
     FileManager.FindFiles(AssemblyPaths, *IntermediatePath, TEXT(""));
 
-    for (const FString& AssemblyPath : AssemblyPaths)
+    for (const FString& AssemblyName : AssemblyPaths)
     {
-        FString AssemblyName = FPaths::GetBaseFilename(AssemblyPath);
+        FString AssemblyPath = IntermediatePath / AssemblyName;
         FString OutputAssemblyPath = OutputPath / AssemblyName;
-        FileManager.Copy(*AssemblyPath, *OutputAssemblyPath, true);
+        FileManager.Copy(*OutputAssemblyPath, *AssemblyPath, true);
     }
 
 	// Load all assemblies again in the correct order.

--- a/Source/UnrealSharpProcHelper/CSProcHelper.cpp
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.cpp
@@ -142,6 +142,11 @@ FString FCSProcHelper::GetUserAssemblyDirectory()
 	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), "Binaries", "Managed"));
 }
 
+FString FCSProcHelper::GetHotReloadStagingDirectory()
+{
+    return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectDir(), "Intermediate", "Managed", "HotReload"));
+}
+
 FString FCSProcHelper::GetUnrealSharpMetadataPath()
 {
 	return FPaths::Combine(GetUserAssemblyDirectory(), "UnrealSharp.assemblyloadorder.json");

--- a/Source/UnrealSharpProcHelper/CSProcHelper.h
+++ b/Source/UnrealSharpProcHelper/CSProcHelper.h
@@ -40,6 +40,9 @@ public:
 	// Path to the directory where we store the user's assembly after it has been processed by the weaver.
 	static FString GetUserAssemblyDirectory();
 
+    // Path to the directory where we place binaries that have been processed by the weaver during hot reload
+    static FString GetHotReloadStagingDirectory();
+
 	// Path to file with UnrealSharp metadata
 	static FString GetUnrealSharpMetadataPath();
 


### PR DESCRIPTION
This PR makes changes to how assembly loading is done:

1. Assembly loading is now done from a path instead of from a stream
2. The IL Weaver output during hot reload is placed in an intermediate directory and then copied over after unloading

This also adds a new delegate for responding to when an assembly is unloaded for native code.