### PR TITLE
Fix package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0" />
-    <PackageVersion Include="Microsoft.CSharp" Version="4.13.0" />
+    <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I accidently made a typo where the version of `Microsoft.CSharp` should be 4.7.0, instead of 4.13.0.
Also move `Directory.Package.props` to the parent directory so that it also applies to projects under `Source.`