### PR TITLE
Refactor directory traversal logic to locate project root from plugin path

### DIFF
--- a/Source/UnrealSharpManagedGlue/Program.cs
+++ b/Source/UnrealSharpManagedGlue/Program.cs
@@ -84,9 +84,21 @@ public static class Program
     {
         PluginDirectory = ScriptGeneratorUtilities.TryGetPluginDefine("PLUGIN_PATH");
 
-        DirectoryInfo unrealSharpDirectory = Directory.GetParent(PluginDirectory)!.Parent!;
-        ScriptFolder = Path.Combine(unrealSharpDirectory.FullName, "Script");
-        PluginsPath = Path.Combine(unrealSharpDirectory.FullName, "Plugins");
+        DirectoryInfo projectDirectory = Directory.GetParent(PluginDirectory)!;
+		// Traverse up the directory tree until we find the "Plugins" directory
+		while (projectDirectory.Name != "Plugins")
+		{
+			if (projectDirectory.Parent == null)
+			{
+				throw new InvalidOperationException("Failed to locate project directory from plugin path.");
+			}
+			projectDirectory = projectDirectory.Parent;
+		}
+		// Now go up one more level to get to the project root
+		projectDirectory = projectDirectory.Parent!;
+
+		ScriptFolder = Path.Combine(projectDirectory.FullName, "Script");
+        PluginsPath = Path.Combine(projectDirectory.FullName, "Plugins");
         ProjectGluePath_LEGACY = Path.Combine(ScriptFolder, "ProjectGlue");
 
         EngineGluePath = ScriptGeneratorUtilities.TryGetPluginDefine("GENERATED_GLUE_PATH");

--- a/Source/UnrealSharpManagedGlue/Program.cs
+++ b/Source/UnrealSharpManagedGlue/Program.cs
@@ -84,21 +84,9 @@ public static class Program
     {
         PluginDirectory = ScriptGeneratorUtilities.TryGetPluginDefine("PLUGIN_PATH");
 
-        DirectoryInfo projectDirectory = Directory.GetParent(PluginDirectory)!;
-		// Traverse up the directory tree until we find the "Plugins" directory
-		while (projectDirectory.Name != "Plugins")
-		{
-			if (projectDirectory.Parent == null)
-			{
-				throw new InvalidOperationException("Failed to locate project directory from plugin path.");
-			}
-			projectDirectory = projectDirectory.Parent;
-		}
-		// Now go up one more level to get to the project root
-		projectDirectory = projectDirectory.Parent!;
-
-		ScriptFolder = Path.Combine(projectDirectory.FullName, "Script");
-        PluginsPath = Path.Combine(projectDirectory.FullName, "Plugins");
+        string projectDirectory = Factory.Session.ProjectDirectory!;
+		ScriptFolder = Path.Combine(projectDirectory, "Script");
+        PluginsPath = Path.Combine(projectDirectory, "Plugins");
         ProjectGluePath_LEGACY = Path.Combine(ScriptFolder, "ProjectGlue");
 
         EngineGluePath = ScriptGeneratorUtilities.TryGetPluginDefine("GENERATED_GLUE_PATH");


### PR DESCRIPTION
The current way of locating project directories assumes that plugins are placed in the Plugins directory. 
However, developers may need to further organize plugins using subdirectories. 
This PR changes the way project directories are located, looking upwards to the Plugins directory to support placing plugins in subdirectories.Refactor directory traversal logic to locate project root from plugin path.