### PR TITLE
Added a new event for when an assembly is unloaded

### DIFF
--- a/Source/UnrealSharpCore/CSAssembly.cpp
+++ b/Source/UnrealSharpCore/CSAssembly.cpp
@@ -220,6 +220,7 @@ bool UCSAssembly::UnloadAssembly()
 	ManagedAssemblyHandle->Dispose(ManagedAssemblyHandle->GetHandle());
 	ManagedAssemblyHandle.Reset();
 
+    UCSManager::Get().OnManagedAssemblyUnloadedEvent().Broadcast(AssemblyName);
 	return UCSManager::Get().GetManagedPluginsCallbacks().UnloadPlugin(*AssemblyPath);
 }
 


### PR DESCRIPTION
Adds a new event dispatcher to listen for when an assembly is unloaded so any native code that is holding onto managed handles has an opportunity to drop those handles.