### PR TITLE
Added logic to allow an engine modules to be extracted out info a plugin

### DIFF
--- a/Source/UnrealSharpManagedGlue/Program.cs
+++ b/Source/UnrealSharpManagedGlue/Program.cs
@@ -111,6 +111,8 @@ public static class Program
         bool hasProjectGlue = false;
         foreach (ProjectDirInfo pluginDir in PluginUtilities.PluginInfo.Values)
         {
+            if (pluginDir.IsPartOfEngine) continue;
+            
             if (pluginDir.IsUProject)
             {
                 hasProjectGlue = true;

--- a/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
@@ -29,6 +29,8 @@ public readonly struct ProjectDirInfo
 
     public bool IsUProject => _projectDirectory.EndsWith(".uproject", StringComparison.OrdinalIgnoreCase);
     
+    public bool IsPartOfEngine => _projectName == "Engine";
+    
     public string GlueProjectDirectory => Path.Combine(ScriptDirectory, GlueProjectName);
     public string GlueProjectDirectory_LEGACY => Path.Combine(ScriptDirectory, GlueProjectName_LEGACY);
     
@@ -104,11 +106,11 @@ public static class FileExporter
             throw new InvalidOperationException("Package is null");
         }
 
-        string rootPath = package.IsPartOfEngine() ? Program.EngineGluePath : GetLocalGluePath(package);
+        string rootPath = GetGluePath(package);
         return Path.Combine(rootPath, package.GetShortName());
     }
 
-    public static string GetLocalGluePath(UhtPackage package)
+    public static string GetGluePath(UhtPackage package)
     {
         ProjectDirInfo projectDirInfo = package.FindOrAddProjectInfo();
         return projectDirInfo.GlueProjectDirectory;

--- a/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
@@ -16,11 +16,11 @@ public static class PluginUtilities
 
     static PluginUtilities()
     {
-        var projectDirectory = Program.Factory.Session.ProjectDirectory;
-        var pluginDirectory = Path.Combine(projectDirectory!, "Plugins");
-        var pluginDirInfo = new DirectoryInfo(pluginDirectory);
+        string? projectDirectory = Program.Factory.Session.ProjectDirectory;
+        string pluginDirectory = Path.Combine(projectDirectory!, "Plugins");
+        DirectoryInfo pluginDirInfo = new DirectoryInfo(pluginDirectory);
         
-        var files = pluginDirInfo.GetFiles("*.uplugin", SearchOption.AllDirectories)
+        IEnumerable<(string DirectoryName, string FullName)> files = pluginDirInfo.GetFiles("*.uplugin", SearchOption.AllDirectories)
             .Select(x => x.DirectoryName!)
             .Select(x => (DirectoryName: x, ConfigPath: Path.Combine(x, "Config")))
             .Select(x => (x.DirectoryName, ConfigDir: new DirectoryInfo(x.ConfigPath)))
@@ -29,13 +29,13 @@ public static class PluginUtilities
                 (x, y) => (x.DirectoryName, FileInfo: y))
             .Select(x => (x.DirectoryName, x.FileInfo.FullName));
         
-        foreach (var (pluginDir, pluginFile) in files)
+        foreach ((string pluginDir, string pluginFile) in files)
         {
-            using var fileStream = File.OpenRead(pluginFile);
+            using FileStream fileStream = File.OpenRead(pluginFile);
             try
             {
-                var manifest = JsonSerializer.Deserialize<List<string>>(fileStream);
-                foreach (var module in manifest!)
+                List<string>? manifest = JsonSerializer.Deserialize<List<string>>(fileStream);
+                foreach (string module in manifest!)
                 {
                     ExtractedEngineModules.Add($"/Script/{module}", pluginDir);
                 }
@@ -58,7 +58,7 @@ public static class PluginUtilities
         HashSet<string> dependencies = [];
         if (package.IsPartOfEngine())
         {
-            if (ExtractedEngineModules.TryGetValue(package.SourceName, out var pluginPath))
+            if (ExtractedEngineModules.TryGetValue(package.SourceName, out string? pluginPath))
             {
                 DirectoryInfo pluginDir = new(pluginPath);
                 info = new ProjectDirInfo(pluginDir.Name, pluginPath, dependencies);
@@ -116,7 +116,7 @@ public static class PluginUtilities
 
                     if (refPackage.IsPartOfEngine())
                     {
-                        if (!ExtractedEngineModules.TryGetValue(refPackage.SourceName, out var pluginPath))
+                        if (!ExtractedEngineModules.TryGetValue(refPackage.SourceName, out string? pluginPath))
                         {
                             continue;
                         }

--- a/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/PluginUtilities.cs
@@ -2,13 +2,50 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using EpicGames.UHT.Types;
+using UnrealSharpScriptGenerator.Model;
 
 namespace UnrealSharpScriptGenerator.Utilities;
 
 public static class PluginUtilities
 {
     public static readonly Dictionary<UhtPackage, ProjectDirInfo> PluginInfo = new();
+    
+    private static readonly Dictionary<string, string> ExtractedEngineModules = new();
+
+    static PluginUtilities()
+    {
+        var projectDirectory = Program.Factory.Session.ProjectDirectory;
+        var pluginDirectory = Path.Combine(projectDirectory!, "Plugins");
+        var pluginDirInfo = new DirectoryInfo(pluginDirectory);
+        
+        var files = pluginDirInfo.GetFiles("*.uplugin", SearchOption.AllDirectories)
+            .Select(x => x.DirectoryName!)
+            .Select(x => (DirectoryName: x, ConfigPath: Path.Combine(x, "Config")))
+            .Select(x => (x.DirectoryName, ConfigDir: new DirectoryInfo(x.ConfigPath)))
+            .Where(x => x.ConfigDir.Exists)
+            .SelectMany(x => x.ConfigDir.GetFiles("*.ExtractedModules.json", SearchOption.AllDirectories),
+                (x, y) => (x.DirectoryName, FileInfo: y))
+            .Select(x => (x.DirectoryName, x.FileInfo.FullName));
+        
+        foreach (var (pluginDir, pluginFile) in files)
+        {
+            using var fileStream = File.OpenRead(pluginFile);
+            try
+            {
+                var manifest = JsonSerializer.Deserialize<List<string>>(fileStream);
+                foreach (var module in manifest!)
+                {
+                    ExtractedEngineModules.Add($"/Script/{module}", pluginDir);
+                }
+            }
+            catch (JsonException e)
+            {
+                Console.WriteLine($"Error reading {pluginFile}: {e.Message}");
+            }
+        }
+    }
 
     public static ProjectDirInfo FindOrAddProjectInfo(this UhtPackage package)
     {
@@ -16,32 +53,51 @@ public static class PluginUtilities
         {
             return plugin;
         }
-        
-        string baseDirectory = package.GetModule().BaseDirectory;
-        DirectoryInfo? currentDirectory = new DirectoryInfo(baseDirectory);
 
-        FileInfo? projectFile = null;
-        while (currentDirectory is not null)
+        ProjectDirInfo info;
+        HashSet<string> dependencies = [];
+        if (package.IsPartOfEngine())
         {
-            FileInfo[] foundFiles = currentDirectory.GetFiles("*.*", SearchOption.TopDirectoryOnly);
-            projectFile = foundFiles.FirstOrDefault(f => f.Extension.Equals(".uplugin", StringComparison.OrdinalIgnoreCase) || 
-                                                         f.Extension.Equals(".uproject", StringComparison.OrdinalIgnoreCase));
-            
-            if (projectFile is not null)
+            if (ExtractedEngineModules.TryGetValue(package.SourceName, out var pluginPath))
             {
-                break;
+                DirectoryInfo pluginDir = new(pluginPath);
+                info = new ProjectDirInfo(pluginDir.Name, pluginPath, dependencies);
+            }
+            else
+            {
+                info = new ProjectDirInfo("Engine", Program.EngineGluePath, dependencies); 
+            }
+        }
+        else
+        {
+
+            string baseDirectory = package.GetModule().BaseDirectory;
+            DirectoryInfo? currentDirectory = new DirectoryInfo(baseDirectory);
+
+            FileInfo? projectFile = null;
+            while (currentDirectory is not null)
+            {
+                FileInfo[] foundFiles = currentDirectory.GetFiles("*.*", SearchOption.TopDirectoryOnly);
+                projectFile = foundFiles.FirstOrDefault(f =>
+                    f.Extension.Equals(".uplugin", StringComparison.OrdinalIgnoreCase) ||
+                    f.Extension.Equals(".uproject", StringComparison.OrdinalIgnoreCase));
+
+                if (projectFile is not null)
+                {
+                    break;
+                }
+
+                currentDirectory = currentDirectory.Parent;
             }
 
-            currentDirectory = currentDirectory.Parent;
+            if (projectFile is null)
+            {
+                throw new InvalidOperationException(
+                    $"Could not find .uplugin or .uproject file for package {package.SourceName} in {baseDirectory}");
+            }
+            info = new ProjectDirInfo(Path.GetFileNameWithoutExtension(projectFile.Name), currentDirectory!.FullName, dependencies);
         }
-        
-        if (projectFile is null)
-        {
-            throw new InvalidOperationException($"Could not find .uplugin or .uproject file for package {package.SourceName} in {baseDirectory}");
-        }
-        
-        HashSet<string> dependencies = new HashSet<string>();
-        ProjectDirInfo info = new ProjectDirInfo(Path.GetFileNameWithoutExtension(projectFile.Name), currentDirectory!.FullName, dependencies);
+
         PluginInfo.Add(package, info);
         
         foreach (UhtHeaderFile header in package.GetHeaderFiles())
@@ -53,10 +109,26 @@ public static class PluginUtilities
             {
                 foreach (UhtPackage refPackage in refHeader.GetPackages())
                 {
-                    if (refPackage.IsPartOfEngine() || refPackage == package)
+                    if (refPackage == package)
                     {
                         continue;
                     }
+
+                    if (refPackage.IsPartOfEngine())
+                    {
+                        if (!ExtractedEngineModules.TryGetValue(refPackage.SourceName, out var pluginPath))
+                        {
+                            continue;
+                        }
+
+                        if (info.IsPartOfEngine)
+                        {
+                            DirectoryInfo pluginDir = new(pluginPath);
+                            info = new ProjectDirInfo(pluginDir.Name, pluginPath, dependencies);
+                            PluginInfo[package] = info;
+                        }
+                    }
+                    
                     
                     ProjectDirInfo projectInfo = refPackage.FindOrAddProjectInfo();
                     if (info.GlueCsProjPath == projectInfo.GlueCsProjPath)


### PR DESCRIPTION
This PR is a fairly straightforward. It allows for users to extract specific engine modules out into their own plugins for glue generation. This might come in handy for extending plugins that are not enabled by default (i.e. GAS). This will also help users who need to integrate with FAB plugins as well.