### PR TITLE
Various fixes to code generation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,5 +14,6 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="4.13.0" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.Build.Locator" Version="1.9.1" />
+    <PackageVersion Include="PolySharp" Version="1.15.0" />
   </ItemGroup>
 </Project>

--- a/Managed/UnrealSharp/UnrealSharp.Core/Interop/FOptionalPropertyExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/Interop/FOptionalPropertyExporter.cs
@@ -15,4 +15,5 @@ public static unsafe partial class FOptionalPropertyExporter
     public static delegate* unmanaged<IntPtr, IntPtr, IntPtr> GetValuePointerForReadOrReplace;
     public static delegate* unmanaged<IntPtr, IntPtr, IntPtr> GetValuePointerForReadOrReplaceIfSet;
     public static delegate* unmanaged<IntPtr, int> CalcSize;
+    public static delegate* unmanaged<IntPtr, IntPtr, void> DestructInstance;
 }

--- a/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/OptionMarshaller.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/OptionMarshaller.cs
@@ -8,27 +8,26 @@ public class OptionMarshaller<T>(IntPtr nativeProperty, MarshallingDelegates<T>.
 {
     public void ToNative(IntPtr nativeBuffer, int arrayIndex, Option<T> obj)
     {
-        unsafe
+        if (obj.IsSome)
         {
-            if (obj.IsSome)
-            {
-                var result = FOptionalPropertyExporter.CallMarkSetAndGetInitializedValuePointerToReplace(nativeProperty, nativeBuffer);
-                toNative(result, 0, obj.ValueUnsafe());
-            }
-            else
-            {
-                FOptionalPropertyExporter.MarkUnset(nativeProperty, nativeBuffer);
-            }
+            var result = FOptionalPropertyExporter.CallMarkSetAndGetInitializedValuePointerToReplace(nativeProperty, nativeBuffer);
+            toNative(result, 0, obj.ValueUnsafe());
+        }
+        else
+        {
+            FOptionalPropertyExporter.CallMarkUnset(nativeProperty, nativeBuffer);
         }
     }
 
     public Option<T> FromNative(IntPtr nativeBuffer, int arrayIndex)
     {
-        unsafe
-        {
-            if (!FOptionalPropertyExporter.CallIsSet(nativeProperty, nativeBuffer).ToManagedBool()) return Option<T>.None;
-            var result = FOptionalPropertyExporter.GetValuePointerForRead(nativeProperty, nativeBuffer);
-            return fromNative(result, 0);
-        }
+        if (!FOptionalPropertyExporter.CallIsSet(nativeProperty, nativeBuffer).ToManagedBool()) return Option<T>.None;
+        var result = FOptionalPropertyExporter.CallGetValuePointerForRead(nativeProperty, nativeBuffer);
+        return fromNative(result, 0);
+    }
+    
+    public void DestructInstance(IntPtr nativeBuffer, int arrayIndex)
+    {
+        FOptionalPropertyExporter.CallDestructInstance(nativeProperty, nativeBuffer);
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AsyncWrapperGenerator.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AsyncWrapperGenerator.cs
@@ -349,7 +349,7 @@ public class AsyncWrapperGenerator : IIncrementalGenerator
 
         var metadataAttributes = methodDeclaration.AttributeLists
             .SelectMany(a => a.Attributes)
-            .Where(a => a.Name.ToString() == "UMetaData");
+            .Where(a => a.Name.ToString() == "UMetaData" || a.GetFullNamespace() == "UnrealSharp.Attributes.MetaData");
 
         Dictionary<string, string> metadata = new();
         foreach (var metadataAttribute in metadataAttributes)

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AsyncWrapperGenerator.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/AsyncWrapperGenerator.cs
@@ -75,8 +75,15 @@ public class AsyncWrapperGenerator : IIncrementalGenerator
                 namespaces.UnionWith(nts.TypeArguments.Select(t => t.ContainingNamespace.ToDisplayString()));
             }
 
-            namespaces.Add(typeSymbol.ContainingNamespace.ToDisplayString());
-        }
+                namespaces.Add(typeSymbol.ContainingNamespace.ToDisplayString());
+                
+                namespaces.UnionWith(parameter.AttributeLists.SelectMany(a => a.Attributes)
+                    .Select(a => model.GetTypeInfo(a).Type)
+                    .Where(type => type is not null)
+                    .Where(type => type!.ContainingNamespace is not null)
+                    .Select(type => type!.ContainingNamespace.ToDisplayString()));
+
+            }
 
         var returnTypeName = asyncMethodInfo.ReturnType.GetAnnotatedTypeName(model);
         var actionClassName = $"{asyncMethodInfo.ParentClass.Identifier.Text}{method.Identifier.Text}Action";

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/CodeSuppressors/UPropertyReferenceTypeSuppressor.cs
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/CodeSuppressors/UPropertyReferenceTypeSuppressor.cs
@@ -7,14 +7,14 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace UnrealSharp.SourceGenerators.CodeSuppressors;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class DefaultComponentSuppressor : DiagnosticSuppressor
+public class UPropertyReferenceTypeSuppressor : DiagnosticSuppressor
 {
-    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => ImmutableArray.Create(DefaultComponentNullableRule);
+    public override ImmutableArray<SuppressionDescriptor> SupportedSuppressions => [DefaultComponentNullableRule];
     
     private static readonly SuppressionDescriptor DefaultComponentNullableRule = new(
-        "DefaultComponentNullableSuppressorId",
+        "NullableUPropertySuppressorId",
         "CS8618",
-        "Default component automatically instantiated."
+        "UProperties on UClasses are automatically instantiated."
     );
     
     public override void ReportSuppressions(SuppressionAnalysisContext context)
@@ -48,7 +48,7 @@ public class DefaultComponentSuppressor : DiagnosticSuppressor
         var symbol = semanticModel.GetDeclaredSymbol(propertyNode, cancellationToken);
         if (symbol is not IPropertySymbol propertySymbol) return false;
         
-        return AnalyzerStatics.TryGetAttribute(propertySymbol, AnalyzerStatics.UPropertyAttribute, out var propertyAttribute) && 
-               AnalyzerStatics.IsDefaultComponent(propertyAttribute);
+        return AnalyzerStatics.TryGetAttribute(propertySymbol, AnalyzerStatics.UPropertyAttribute, out _) && 
+               AnalyzerStatics.HasAttribute(propertySymbol.ContainingType, AnalyzerStatics.UClassAttribute);
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp.SourceGenerators/UnrealSharp.SourceGenerators.csproj
+++ b/Managed/UnrealSharp/UnrealSharp.SourceGenerators/UnrealSharp.SourceGenerators.csproj
@@ -13,6 +13,10 @@
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" PrivateAssets="all" />
         <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" PrivateAssets="all" />
+        <PackageReference Include="PolySharp">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
     </ItemGroup>
     
 </Project>

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/MetaTags.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/MetaTags.cs
@@ -696,6 +696,14 @@ public sealed class NoGetterAttribute : Attribute { }
 public sealed class BindWidgetAttribute : Attribute { }
 
 /// <summary>
+/// [BindWidgetOptional]
+/// Used for UWidget properties. Indicates that the property should be bound to a widget in the Blueprint Editor.
+//  Will not cause an error if not found.
+/// </summary>
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+public sealed class BindWidgetOptionalAttribute : Attribute { }
+
+/// <summary>
 /// [BindWidgetAnim]
 /// Used for binding widget animations to a property
 /// </summary>

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
@@ -66,6 +66,16 @@ public partial class UObject
         }
     }
 
+    public bool IsA<T>(TSubclassOf<T> classType) where T : UObject
+    {
+        return UObjectExporter.CallIsA(NativeObject, classType.NativeClass).ToManagedBool();
+    }
+
+    public bool IsA(UClass classType)
+    {
+        return UObjectExporter.CallIsA(NativeObject, classType.NativeObject).ToManagedBool();
+    }
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/Managed/UnrealSharp/UnrealSharp/Interop/FNameExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/FNameExporter.cs
@@ -7,6 +7,6 @@ namespace UnrealSharp.Interop;
 public static unsafe partial class FNameExporter
 {
     public static delegate* unmanaged<FName, ref UnmanagedArray, void> NameToString;
-    public static delegate* unmanaged<ref FName, char*, void> StringToName;
+    public static delegate* unmanaged<ref FName, char*, int, void> StringToName;
     public static delegate* unmanaged<FName, NativeBool> IsValid;
 }

--- a/Managed/UnrealSharp/UnrealSharp/Interop/FTextExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/FTextExporter.cs
@@ -6,7 +6,9 @@ namespace UnrealSharp.Interop;
 public static unsafe partial class FTextExporter
 {
     public static delegate* unmanaged<ref FTextData, char*> ToString;
+    public static delegate* unmanaged<ref FTextData, out char*, out int, void> ToStringView;
     public static delegate* unmanaged<ref FTextData, string, void> FromString;
+    public static delegate* unmanaged<ref FTextData, char*, int, void> FromStringView;
     public static delegate* unmanaged<ref FTextData, FName, void> FromName;
     public static delegate* unmanaged<ref FTextData, void> CreateEmptyText;
 }

--- a/Managed/UnrealSharp/UnrealSharp/Interop/UObjectExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/UObjectExporter.cs
@@ -15,5 +15,6 @@ public static unsafe partial class UObjectExporter
     public static delegate* unmanaged<IntPtr, IntPtr, IntPtr, IntPtr, void> InvokeNativeNetFunction;
     public static delegate* unmanaged<IntPtr, NativeBool> NativeIsValid;
     public static delegate* unmanaged<IntPtr, IntPtr> GetWorld_Internal;
+    public static delegate* unmanaged<IntPtr, IntPtr, NativeBool> IsA;
     public static delegate* unmanaged<IntPtr, int> GetUniqueID;
 }

--- a/Managed/UnrealSharp/UnrealSharp/Name.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Name.cs
@@ -26,7 +26,18 @@ public struct FName : IEquatable<FName>, IComparable<FName>
         {
             fixed (char* stringPtr = name)
             {
-                FNameExporter.CallStringToName(ref this, stringPtr);
+                FNameExporter.CallStringToName(ref this, stringPtr, name.Length);
+            }
+        }
+    }
+    
+    public FName(ReadOnlySpan<char> name)
+    {
+        unsafe
+        {
+            fixed (char* stringPtr = name)
+            {
+                FNameExporter.CallStringToName(ref this, stringPtr, name.Length);
             }
         }
     }

--- a/Managed/UnrealSharp/UnrealSharp/SoftClass.cs
+++ b/Managed/UnrealSharp/UnrealSharp/SoftClass.cs
@@ -79,7 +79,7 @@ public struct TSoftClassPtr<T> where T : UObject
     {
         if (typeof(T).IsAssignableFrom(typeof(T2)) || typeof(T2).IsAssignableFrom(typeof(T)))
         {
-            return new TSoftClassPtr<T2>(Class);
+            return Class.Valid ? new TSoftClassPtr<T2>(Class) : new TSoftClassPtr<T2>(SoftObjectPtr.Data);
         }
 
         throw new Exception($"Cannot cast {typeof(T).Name} to {typeof(T2).Name}");

--- a/Managed/UnrealSharp/UnrealSharp/Text.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Text.cs
@@ -30,6 +30,17 @@ public class FText
     {
         FTextExporter.CallFromString(ref Data, text);
     }
+
+    public FText(ReadOnlySpan<char> text)
+    {
+        unsafe
+        {
+            fixed (char* textPtr = text)
+            {
+                FTextExporter.CallFromStringView(ref Data, textPtr, text.Length);
+            }
+        }
+    }
     
     public FText(FName name) : this(name.ToString())
     {
@@ -79,6 +90,20 @@ public class FText
             return new string(FTextExporter.CallToString(ref Data));
         }
     }
+
+    public ReadOnlySpan<char> AsReadOnlySpan()
+    {
+        if (Empty)
+        {
+            return ReadOnlySpan<char>.Empty;
+        }
+
+        unsafe
+        {
+            FTextExporter.CallToStringView(ref Data, out char* textPtr, out int length);
+            return new ReadOnlySpan<char>(textPtr, length);
+        }
+    }
     
     public static implicit operator FText(string value)
     {
@@ -88,6 +113,11 @@ public class FText
     public static implicit operator string(FText value)
     {
         return value.ToString();
+    }
+    
+    public static implicit operator ReadOnlySpan<char>(FText value)
+    {
+        return value.AsReadOnlySpan();
     }
     
     public static bool operator ==(FText a, FText b)

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/ClassMetaData.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/MetaData/ClassMetaData.cs
@@ -120,7 +120,7 @@ public class ClassMetaData : TypeReferenceMetadata
 
             if (FunctionMetaData.IsAsyncUFunction(method))
             {
-                FunctionProcessor.RewriteMethodAsAsyncUFunctionImplementation(method);
+                method.CustomAttributes.Clear();
                 continue;
             }
             

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
@@ -92,6 +92,13 @@ public class NativeDataContainerType : NativeDataType
             
             fieldAttributes |= FieldAttributes.Static;
         }
+        else if (outer is FieldDefinition)
+        {
+            TypeReference genericCopyMarshallerTypeRef = MarshallerAssembly.FindType(GetCopyContainerMarshallerName(), MarshallerNamespace)!;
+            _containerMarshallerType = genericCopyMarshallerTypeRef.Resolve().MakeGenericInstanceType(ContainerMarshallerTypeParameters).ImportType();
+            
+            fieldAttributes |= FieldAttributes.Static;
+        }
         else
         {
             TypeReference genericCopyMarshallerTypeRef = MarshallerAssembly.FindType(GetContainerMarshallerName(), MarshallerNamespace)!;

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/FunctionProcessor.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/TypeProcessors/FunctionProcessor.cs
@@ -419,12 +419,6 @@ public static class FunctionProcessor
         methodDef.OptimizeMethod();
     }
 
-    public static void RewriteMethodAsAsyncUFunctionImplementation(MethodDefinition methodDefinition)
-    {
-        methodDefinition.CustomAttributes.Clear();
-        methodDefinition.Name = $"{methodDefinition.Name}_Implementation";
-    }
-
     public static MethodDefinition CreateMethod(TypeDefinition declaringType, string name, MethodAttributes attributes, TypeReference? returnType = null, TypeReference[]? parameters = null)
     {
         MethodDefinition def = new MethodDefinition(name, attributes, returnType ?? WeaverImporter.Instance.VoidTypeRef);

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Utilities/TypeDefinitionUtilities.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Utilities/TypeDefinitionUtilities.cs
@@ -606,7 +606,7 @@ public static class TypeDefinitionUtilities
                     return typeDef.IsUnmanagedType() ? new NativeDataUnmanagedType(typeDef, arrayDim) : new NativeDataManagedObjectType(typeRef, arrayDim);
                 }
                 
-                return typeDef.GetBlittableType() != null ? new NativeDataBlittableStructType(typeDef, arrayDim) : new NativeDataStructType(typeDef, typeDef.GetMarshallerClassName(), arrayDim);
+                return typeDef.GetBlittableType() != null ? new NativeDataBlittableStructType(typeDef, arrayDim) : new NativeDataStructType(typeDef, "StructMarshaller`1", arrayDim);
         }
     }
     

--- a/Source/UnrealSharpAsync/Private/CSAsyncActionBase.cpp
+++ b/Source/UnrealSharpAsync/Private/CSAsyncActionBase.cpp
@@ -14,12 +14,17 @@ void UCSAsyncActionBase::Destroy()
 
 void UCSAsyncActionBase::InvokeManagedCallback(bool bDispose)
 {
-	ManagedCallback.Invoke(this, bDispose);
+	InvokeManagedCallback(this, bDispose);
+}
 
-	if (bDispose)
-	{
-		Destroy();
-	}
+void UCSAsyncActionBase::InvokeManagedCallback(UObject* WorldContextObject, bool bDispose)
+{
+    ManagedCallback.Invoke(WorldContextObject, bDispose);
+
+    if (bDispose)
+    {
+        Destroy();
+    }
 }
 
 void UCSAsyncActionBase::InitializeManagedCallback(FGCHandleIntPtr Callback)

--- a/Source/UnrealSharpAsync/Public/CSAsyncActionBase.h
+++ b/Source/UnrealSharpAsync/Public/CSAsyncActionBase.h
@@ -20,6 +20,7 @@ protected:
 	friend class UUCSAsyncBaseExporter;
 
 	void InvokeManagedCallback(bool bDispose = true);
+    void InvokeManagedCallback(UObject* WorldContextObject, bool bDispose = true);
 	void InitializeManagedCallback(FGCHandleIntPtr Callback);
 	
 	FCSManagedDelegate ManagedCallback;

--- a/Source/UnrealSharpCore/Export/FNameExporter.cpp
+++ b/Source/UnrealSharpCore/Export/FNameExporter.cpp
@@ -5,9 +5,9 @@ void UFNameExporter::NameToString(FName Name, FString* OutString)
 	Name.ToString(*OutString);
 }
 
-void UFNameExporter::StringToName(FName* Name, const UTF16CHAR* String)
+void UFNameExporter::StringToName(FName* Name, const UTF16CHAR* String, int32 Length)
 {
-	*Name = FName(String);
+	*Name = FName(TStringView(String, Length));
 }
 
 bool UFNameExporter::IsValid(FName Name)

--- a/Source/UnrealSharpCore/Export/FNameExporter.h
+++ b/Source/UnrealSharpCore/Export/FNameExporter.h
@@ -15,7 +15,7 @@ public:
 	static void NameToString(FName Name, FString* OutString);
 
 	UNREALSHARP_FUNCTION()
-	static void StringToName(FName* Name, const UTF16CHAR* String);
+	static void StringToName(FName* Name, const UTF16CHAR* String, int32 Length);
 	
 	UNREALSHARP_FUNCTION()
 	static bool IsValid(FName Name);

--- a/Source/UnrealSharpCore/Export/FOptionalPropertyExporter.cpp
+++ b/Source/UnrealSharpCore/Export/FOptionalPropertyExporter.cpp
@@ -1,52 +1,52 @@
 ﻿#include "FOptionalPropertyExporter.h"
 #include "UObject/PropertyOptional.h"
 
-bool UFOptionalPropertyExporter::IsSet(FOptionalProperty* OptionalProperty, const void* ScriptValue)
+bool UFOptionalPropertyExporter::IsSet(const FOptionalProperty* OptionalProperty, const void* ScriptValue)
 {
 	return OptionalProperty->IsSet(ScriptValue);
 }
 
-void* UFOptionalPropertyExporter::MarkSetAndGetInitializedValuePointerToReplace(FOptionalProperty* OptionalProperty, void* Data)
+void* UFOptionalPropertyExporter::MarkSetAndGetInitializedValuePointerToReplace(const FOptionalProperty* OptionalProperty, void* Data)
 {
 	return OptionalProperty->MarkSetAndGetInitializedValuePointerToReplace(Data);
 }
 
-void UFOptionalPropertyExporter::MarkUnset(FOptionalProperty* OptionalProperty, void* Data)
+void UFOptionalPropertyExporter::MarkUnset(const FOptionalProperty* OptionalProperty, void* Data)
 {
 	return OptionalProperty->MarkUnset(Data);
 }
 
-const void* UFOptionalPropertyExporter::GetValuePointerForRead(FOptionalProperty* OptionalProperty, const void* Data)
+const void* UFOptionalPropertyExporter::GetValuePointerForRead(const FOptionalProperty* OptionalProperty, const void* Data)
 {
 	return OptionalProperty->GetValuePointerForRead(Data);
 }
 
-void* UFOptionalPropertyExporter::GetValuePointerForReplace(FOptionalProperty* OptionalProperty, void* Data)
+void* UFOptionalPropertyExporter::GetValuePointerForReplace(const FOptionalProperty* OptionalProperty, void* Data)
 {
 	return OptionalProperty->GetValuePointerForReplace(Data);
 }
 
-const void* UFOptionalPropertyExporter::GetValuePointerForReadIfSet(FOptionalProperty* OptionalProperty, const void* Data)
+const void* UFOptionalPropertyExporter::GetValuePointerForReadIfSet(const FOptionalProperty* OptionalProperty, const void* Data)
 {
 	return OptionalProperty->GetValuePointerForReadIfSet(Data);
 }
 
-void* UFOptionalPropertyExporter::GetValuePointerForReplaceIfSet(FOptionalProperty* OptionalProperty, void* Data)
+void* UFOptionalPropertyExporter::GetValuePointerForReplaceIfSet(const FOptionalProperty* OptionalProperty, void* Data)
 {
 	return OptionalProperty->GetValuePointerForReplaceIfSet(Data);
 }
 
-void* UFOptionalPropertyExporter::GetValuePointerForReadOrReplace(FOptionalProperty* OptionalProperty, void* Data)
+void* UFOptionalPropertyExporter::GetValuePointerForReadOrReplace(const FOptionalProperty* OptionalProperty, void* Data)
 {
 	return OptionalProperty->GetValuePointerForReadOrReplace(Data);
 }
 
-void* UFOptionalPropertyExporter::GetValuePointerForReadOrReplaceIfSet(FOptionalProperty* OptionalProperty, void* Data)
+void* UFOptionalPropertyExporter::GetValuePointerForReadOrReplaceIfSet(const FOptionalProperty* OptionalProperty, void* Data)
 {
 	return OptionalProperty->GetValuePointerForReadOrReplaceIfSet(Data);
 }
 
-int32 UFOptionalPropertyExporter::CalcSize(FOptionalProperty* OptionalProperty)
+int32 UFOptionalPropertyExporter::CalcSize(const FOptionalProperty* OptionalProperty)
 {
 #if ENGINE_MINOR_VERSION >= 5
 	// Do we really need this? StaticLink should do this.
@@ -54,4 +54,9 @@ int32 UFOptionalPropertyExporter::CalcSize(FOptionalProperty* OptionalProperty)
 #else
 	return OptionalProperty->GetSize();
 #endif
+}
+
+void UFOptionalPropertyExporter::DestructInstance(const FOptionalProperty* OptionalProperty, void* Data)
+{
+    OptionalProperty->DestroyValueInternal(Data);
 }

--- a/Source/UnrealSharpCore/Export/FOptionalPropertyExporter.h
+++ b/Source/UnrealSharpCore/Export/FOptionalPropertyExporter.h
@@ -13,32 +13,35 @@ class UNREALSHARPCORE_API UFOptionalPropertyExporter : public UObject
 public:
 
 	UNREALSHARP_FUNCTION()
-	static bool IsSet(FOptionalProperty* OptionalProperty, const void* ScriptValue);
+	static bool IsSet(const FOptionalProperty* OptionalProperty, const void* ScriptValue);
 
 	UNREALSHARP_FUNCTION()
-	static void* MarkSetAndGetInitializedValuePointerToReplace(FOptionalProperty* OptionalProperty, void* Data);
+	static void* MarkSetAndGetInitializedValuePointerToReplace(const FOptionalProperty* OptionalProperty, void* Data);
 
 	UNREALSHARP_FUNCTION()
-	static void MarkUnset(FOptionalProperty* OptionalProperty, void* Data);
+	static void MarkUnset(const FOptionalProperty* OptionalProperty, void* Data);
 
 	UNREALSHARP_FUNCTION()
-	static const void* GetValuePointerForRead(FOptionalProperty* OptionalProperty, const void* Data);
+	static const void* GetValuePointerForRead(const FOptionalProperty* OptionalProperty, const void* Data);
 
 	UNREALSHARP_FUNCTION()
-	static void* GetValuePointerForReplace(FOptionalProperty* OptionalProperty, void* Data);
+	static void* GetValuePointerForReplace(const FOptionalProperty* OptionalProperty, void* Data);
 
 	UNREALSHARP_FUNCTION()
-	static const void* GetValuePointerForReadIfSet(FOptionalProperty* OptionalProperty, const void* Data);
+	static const void* GetValuePointerForReadIfSet(const FOptionalProperty* OptionalProperty, const void* Data);
 
 	UNREALSHARP_FUNCTION()
-	static void* GetValuePointerForReplaceIfSet(FOptionalProperty* OptionalProperty, void* Data);
+	static void* GetValuePointerForReplaceIfSet(const FOptionalProperty* OptionalProperty, void* Data);
 	
 	UNREALSHARP_FUNCTION()
-	static void* GetValuePointerForReadOrReplace(FOptionalProperty* OptionalProperty, void* Data);
+	static void* GetValuePointerForReadOrReplace(const FOptionalProperty* OptionalProperty, void* Data);
 
 	UNREALSHARP_FUNCTION()
-	static void* GetValuePointerForReadOrReplaceIfSet(FOptionalProperty* OptionalProperty, void* Data);
+	static void* GetValuePointerForReadOrReplaceIfSet(const FOptionalProperty* OptionalProperty, void* Data);
 
 	UNREALSHARP_FUNCTION()
-	static int32 CalcSize(FOptionalProperty* OptionalProperty);
+	static int32 CalcSize(const FOptionalProperty* OptionalProperty);
+
+    UNREALSHARP_FUNCTION()
+    static void DestructInstance(const FOptionalProperty* OptionalProperty, void* Data);
 };

--- a/Source/UnrealSharpCore/Export/FTextExporter.cpp
+++ b/Source/UnrealSharpCore/Export/FTextExporter.cpp
@@ -10,6 +10,20 @@ const TCHAR* UFTextExporter::ToString(FText* Text)
 	return *Text->ToString();
 }
 
+void UFTextExporter::ToStringView(FText* Text, const TCHAR*& OutString, int32& OutLength)
+{
+    if (!Text)
+    {
+        OutString = nullptr;
+        OutLength = 0;
+        return;
+    }
+
+    const FString& AsString = Text->ToString();
+    OutString = *AsString;
+    OutLength = AsString.Len();
+}
+
 void UFTextExporter::FromString(FText* Text, const char* String)
 {
 	if (!Text)
@@ -18,6 +32,16 @@ void UFTextExporter::FromString(FText* Text, const char* String)
 	}
 
 	*Text = Text->FromString(String);
+}
+
+void UFTextExporter::FromStringView(FText* Text, const TCHAR* String, int32 Length)
+{
+    if (!Text)
+    {
+        return;
+    }
+
+    *Text = Text->FromStringView(FStringView(String, Length));
 }
 
 void UFTextExporter::FromName(FText* Text, FName Name)

--- a/Source/UnrealSharpCore/Export/FTextExporter.h
+++ b/Source/UnrealSharpCore/Export/FTextExporter.h
@@ -11,9 +11,15 @@ class UNREALSHARPCORE_API UFTextExporter : public UObject
 public:
 	UNREALSHARP_FUNCTION()
 	static const TCHAR* ToString(FText* Text);
+
+    UNREALSHARP_FUNCTION()
+    static void ToStringView(FText* Text, const TCHAR*& OutString, int32& OutLength);
 	
 	UNREALSHARP_FUNCTION()
 	static void FromString(FText* Text, const char* String);
+    
+    UNREALSHARP_FUNCTION()
+    static void FromStringView(FText* Text, const TCHAR* String, int32 Length);
 
 	UNREALSHARP_FUNCTION()
 	static void FromName(FText* Text, FName Name);

--- a/Source/UnrealSharpCore/Export/UObjectExporter.cpp
+++ b/Source/UnrealSharpCore/Export/UObjectExporter.cpp
@@ -128,6 +128,11 @@ void* UUObjectExporter::GetWorld_Internal(UObject* Object)
 	return UCSManager::Get().FindManagedObject(World);
 }
 
+bool UUObjectExporter::IsA(const UObject* Object, UClass* Class)
+{
+    return Object->IsA(Class);
+}
+
 uint32 UUObjectExporter::GetUniqueID(UObject* Object)
 {
 	return Object->GetUniqueID();

--- a/Source/UnrealSharpCore/Export/UObjectExporter.h
+++ b/Source/UnrealSharpCore/Export/UObjectExporter.h
@@ -40,6 +40,9 @@ public:
 	UNREALSHARP_FUNCTION()
 	static void* GetWorld_Internal(UObject* Object);
 
+    UNREALSHARP_FUNCTION()
+    static bool IsA(const UObject* Object, UClass* Class);
+
 	UNREALSHARP_FUNCTION()
 	static uint32 GetUniqueID(UObject* Object);
 

--- a/Source/UnrealSharpCore/Extensions/BlueprintActions/CSCancellableAsyncAction.cpp
+++ b/Source/UnrealSharpCore/Extensions/BlueprintActions/CSCancellableAsyncAction.cpp
@@ -3,11 +3,19 @@
 void UCSCancellableAsyncAction::Activate()
 {
 	ReceiveActivate();
+	
+#if WITH_EDITOR
+    FEditorDelegates::PrePIEEnded.AddWeakLambda(this, [this](bool)
+    {
+        Cancel();
+        FEditorDelegates::PrePIEEnded.RemoveAll(this);
+    });
+#endif
 }
 
 void UCSCancellableAsyncAction::Cancel()
 {
-	if (HasAnyFlags(RF_ClassDefaultObject | RF_ArchetypeObject) || !IsValid(this))
+	if (HasAnyFlags(RF_ClassDefaultObject | RF_ArchetypeObject) || !IsValid(this) || IsUnreachable())
 	{
 		return;
 	}

--- a/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction.h
+++ b/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction.h
@@ -27,6 +27,7 @@ public:
 	}
 
 	static void InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL);
+	static void InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL, UObject* WorldContextObject);
 private:
 	TSharedPtr<FGCHandle> MethodHandle = nullptr;
 };

--- a/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Functions/CSFunction_Params.cpp
@@ -74,6 +74,9 @@ void UCSFunction_Params::InvokeManagedMethod_Params(UObject* ObjectToInvokeOn, F
 	
 	for (FOutParmRec* OutParameter = OutParameters; OutParameter != nullptr; OutParameter = OutParameter->NextOutParm)
 	{
+	    // The return value should already have been set
+	    if (OutParameter->Property->HasAnyPropertyFlags(CPF_ReturnParm)) continue;
+	    
 		const uint8* ValueAddress = ArgumentBuffer + OutParameter->Property->GetOffset_ForUFunction();
 		OutParameter->Property->CopyCompleteValue(OutParameter->PropAddr, ValueAddress);
 	}

--- a/Source/UnrealSharpCore/TypeGenerator/Properties/PropertyGeneratorManager.cpp
+++ b/Source/UnrealSharpCore/TypeGenerator/Properties/PropertyGeneratorManager.cpp
@@ -5,6 +5,9 @@
 #include "TypeGenerator/Register/MetaData/CSPropertyMetaData.h"
 #include <UObject/PropertyOptional.h>
 
+#include "TypeGenerator/CSClass.h"
+#include "TypeGenerator/CSSkeletonClass.h"
+
 static TTuple<UFunction*, UFunction*> GetGetterAndSetterMethods(UField* Outer, const FCSPropertyMetaData& PropertyMetaData)
 {
 	UClass* Class = Cast<UClass>(Outer);
@@ -13,6 +16,15 @@ static TTuple<UFunction*, UFunction*> GetGetterAndSetterMethods(UField* Outer, c
 	{
 		return {nullptr, nullptr};
 	}
+
+#if WITH_EDITOR
+    // Redirect to the generated class if we're trying to bind a function in a skeleton class.
+    // Since NativeFunctionLookupTable is not copied over when duplicating for reinstancing due to not being a UPROPERTY.
+    if (UCSSkeletonClass* OwnerClass = Cast<UCSSkeletonClass>(Outer); OwnerClass != nullptr)
+    {
+        Class = OwnerClass->GetGeneratedClass();
+    }
+#endif
 
 	return
 	{

--- a/Source/UnrealSharpManagedGlue/Exporters/ExtensionsClassExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/ExtensionsClassExporter.cs
@@ -44,6 +44,7 @@ public static class ExtensionsClassExporter
         {
             FunctionExporter exporter = new FunctionExporter(extensionMethod);
             exporter.Initialize(OverloadMode.AllowOverloads, EFunctionProtectionMode.UseUFunctionProtection, EBlueprintVisibility.Call);
+            exporter.ExportExtensionMethodOverloads(stringBuilder);
             exporter.ExportExtensionMethod(stringBuilder);
         }
         

--- a/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
@@ -264,7 +264,7 @@ public class FunctionExporter
             else
             {
                 string cppDefaultValue = translator.GetCppDefaultValue(Function, parameter);
-                bool isGenericClassParam = _hasGenericTypeSupport && parameter.IsGenericType() && parameter is UhtClassProperty;
+                bool isGenericClassParam = _hasGenericTypeSupport && parameter.IsGenericType() && !parameter.HasAnyFlags(EPropertyFlags.OutParm) && parameter is UhtClassProperty;
 
                 if (cppDefaultValue == "()" && parameter is UhtStructProperty structProperty)
                 {

--- a/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
@@ -703,7 +703,11 @@ public class FunctionExporter
 
             if (genericTypes.Count > 0)
             {
-                builder.AppendLine($"{Modifiers}{returnType} {_functionName}<{genericTypeString}>(this {overload.ParamStringApiWithDefaults})");
+                PropertyTranslator translator = _parameterTranslators[0];
+                string paramType = _classBeingExtended != null
+                    ? _classBeingExtended.GetFullManagedName()
+                    : translator.GetManagedType(_selfParameter!);
+                builder.AppendLine($"{Modifiers}{returnType} {_functionName}<{genericTypeString}>(this {paramType} {_selfParameter!.GetParameterName()}, {overload.ParamStringApiWithDefaults})");
                 builder.Indent();
                 foreach (var (genericType, constraint) in genericTypes.Zip(genericConstraints))
                     builder.AppendLine($"where {genericType} : {constraint}");

--- a/Source/UnrealSharpManagedGlue/Exporters/GetterSetterFunctionExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/GetterSetterFunctionExporter.cs
@@ -50,7 +50,7 @@ public class GetterSetterFunctionExporter : FunctionExporter
 
     protected override void ExportReturnStatement(GeneratorStringBuilder builder)
     {
-        if (_function.ReturnProperty != null && _function.ReturnProperty.IsSameType(_propertyGetterSetter))
+        if (Function.ReturnProperty != null && Function.ReturnProperty.IsSameType(_propertyGetterSetter))
         {
             string castOperation = _propertyGetterSetter.HasAllFlags(EPropertyFlags.BlueprintReadOnly) 
                 ? $"({ReturnValueTranslator!.GetManagedType(_propertyGetterSetter)})" : string.Empty;

--- a/Source/UnrealSharpManagedGlue/Exporters/InterfaceExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/InterfaceExporter.cs
@@ -38,13 +38,14 @@ public static class InterfaceExporter
         List<UhtFunction> exportedFunctions = new();
         List<UhtFunction> exportedOverrides = new();
         Dictionary<string, GetterSetterPair> exportedGetterSetters = new();
+        Dictionary<string, GetterSetterPair> getSetOverrides = new();
 
         if (interfaceObj.AlternateObject is UhtClass alternateObject)
         {
-            ScriptGeneratorUtilities.GetExportedFunctions(alternateObject, exportedFunctions, exportedOverrides, exportedGetterSetters);
+            ScriptGeneratorUtilities.GetExportedFunctions(alternateObject, exportedFunctions, exportedOverrides, exportedGetterSetters, getSetOverrides);
         }
         
-        ScriptGeneratorUtilities.GetExportedFunctions(interfaceObj, exportedFunctions, exportedOverrides, exportedGetterSetters);
+        ScriptGeneratorUtilities.GetExportedFunctions(interfaceObj, exportedFunctions, exportedOverrides, exportedGetterSetters, getSetOverrides);
         
         ExportInterfaceProperties(stringBuilder, exportedGetterSetters);
         ExportInterfaceFunctions(stringBuilder, exportedFunctions);
@@ -71,7 +72,7 @@ public static class InterfaceExporter
             exportedOverrides, 
             false, interfaceName + "Wrapper");
         
-        ClassExporter.ExportCustomProperties(stringBuilder, exportedGetterSetters);
+        ClassExporter.ExportCustomProperties(stringBuilder, exportedGetterSetters, [], []);
         ExportWrapperFunctions(stringBuilder, exportedFunctions);
         ExportWrapperFunctions(stringBuilder, exportedOverrides);
         
@@ -115,7 +116,7 @@ public static class InterfaceExporter
             stringBuilder.AppendTooltip(firstProperty);
         
             string managedType = translator.GetManagedType(firstProperty);
-            stringBuilder.AppendLine($"{protection}{managedType} {propertyName}");
+            stringBuilder.AppendLine($"{managedType} {propertyName}");
             stringBuilder.OpenBrace();
 
             if (getterSetterPair.Getter is not null)

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/ContainerPropertyTranslator.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/ContainerPropertyTranslator.cs
@@ -79,7 +79,7 @@ public class ContainerPropertyTranslator : PropertyTranslator
         if (property.IsGenericType()) return;
 
         string wrapperType = GetWrapperType(property);
-        if (property.IsOuter<UhtScriptStruct>())
+        if (property.IsOuter<UhtScriptStruct>() || property.HasAnyNativeGetterSetter())
         {
             builder.AppendLine($"static {wrapperType} {propertyEngineName}_Marshaller = null;");
         }
@@ -216,13 +216,14 @@ public class ContainerPropertyTranslator : PropertyTranslator
     {
         bool isStructProperty = property.IsOuter<UhtScriptStruct>();
         bool isParameter = property.IsOuter<UhtFunction>();
+        bool isNativeGetterSetter = property.HasAnyNativeGetterSetter();
         UhtContainerBaseProperty containerProperty = (UhtContainerBaseProperty) property;
         PropertyTranslator translator = PropertyTranslatorManager.GetTranslator(containerProperty.ValueProperty)!;
 
         string innerManagedType = property.IsGenericType() ?
             "DOT" : translator.GetManagedType(containerProperty.ValueProperty);
 
-        string containerType = isStructProperty || isParameter ? CopyMarshallerName : property.PropertyFlags.HasAnyFlags(EPropertyFlags.BlueprintReadOnly) ? ReadOnlyMarshallerName : MarshallerName;
+        string containerType = isStructProperty || isParameter || isNativeGetterSetter ? CopyMarshallerName : property.PropertyFlags.HasAnyFlags(EPropertyFlags.BlueprintReadOnly) ? ReadOnlyMarshallerName : MarshallerName;
         return $"{containerType}<{innerManagedType}>";
     }
 

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/OptionalPropertyTranslator.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/OptionalPropertyTranslator.cs
@@ -20,14 +20,7 @@ public class OptionalPropertyTranslator : PropertyTranslator
         if (property.IsGenericType()) return;
 
         string wrapperType = GetMarshaller(property);
-        if (property.IsOuter<UhtScriptStruct>())
-        {
-            builder.AppendLine($"static {wrapperType} {propertyEngineName}_Marshaller = null;");
-        }
-        else
-        {
-            builder.AppendLine($"{wrapperType} {propertyEngineName}_Marshaller = null;");
-        }
+        builder.AppendLine($"static {wrapperType} {propertyEngineName}_Marshaller = null;");
     }
     
     public override void ExportPropertyGetter(GeneratorStringBuilder builder, UhtProperty property, string propertyManagedName)

--- a/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslator.cs
+++ b/Source/UnrealSharpManagedGlue/PropertyTranslators/PropertyTranslator.cs
@@ -289,7 +289,7 @@ public abstract class PropertyTranslator
             builder.BeginUnsafeBlock();
             builder.AppendStackAllocProperty($"{property.SourceName}_Size", property.GetNativePropertyName());
             builder.AppendLine($"FPropertyExporter.CallGetValue_InContainer({property.GetNativePropertyName()}, NativeObject, paramsBuffer);");
-            ExportFromNative(builder, property, property.SourceName, $"{GetManagedType(property)} newValue =", "paramsBuffer", "0", false, false);
+            ExportFromNative(builder, property, property.SourceName, $"{GetManagedType(property)} newValue =", "paramsBuffer", "0", true, false);
             builder.AppendLine("return newValue;");
             builder.EndUnsafeBlock();
         }
@@ -310,6 +310,7 @@ public abstract class PropertyTranslator
             builder.AppendStackAllocProperty($"{property.SourceName}_Size", property.GetNativePropertyName());
             ExportToNative(builder, property, property.SourceName, "paramsBuffer", "0", "value");
             builder.AppendLine($"FPropertyExporter.CallSetValue_InContainer({property.GetNativePropertyName()}, NativeObject, paramsBuffer);"); 
+            ExportCleanupMarshallingBuffer(builder, property, property.SourceName);
             builder.EndUnsafeBlock();
         }
         

--- a/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/FileExporter.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using EpicGames.UHT.Types;
 
@@ -95,6 +96,11 @@ public static class FileExporter
         string directory = GetDirectoryPath(type.Package);
         string filePath = GetFilePath(type.EngineName, directory);
         UnchangedFiles.Add(filePath);
+
+        if (type is UhtStruct uhtStruct && uhtStruct.Functions.Any(f => f.HasMetadata("ExtensionMethod")))
+        {
+            UnchangedFiles.Add(GetFilePath($"{type.EngineName}_Extensions", directory));
+        }
     }
 
     public static string GetDirectoryPath(UhtPackage package)


### PR DESCRIPTION
This PR includes a number of fixes/improvements for the UBT, weaver, and source generators that improve the developer experience dramatically.

That list includes:

- Fixes involving generic parameters in generated glue code, including extension methods, and when a dynamic output param is an out parameter instead of a return value. Also, ensures any of the _Extension files are also added to the list of unchanged files during glue generation. 
- Improvements to diagnostic suppression of nullable UProperties to help reduce some false-positive warnings about uninitialized properties
- Fixes to async UFunctions, including fixing issues where the methods are uncallable across the assembly boundary, as well as adding support for ValueTask.
- Added support for the IsA method on TSubclassOf
- Added some Span support for FText and FName to allow for some optimizations
- Added the BindWidgetOptional attribute
- Added fixes for native getters and setters on properties, including a fix to not call invalid UFunctions on skeleton classes that was causing a crash
- Fixed some issues with interfaces with get/set methods that conflict with UProperties on native classes, done through explicit interface implementations
- Fixed some issues with the selection of marshallers selecting the wrong marshaller when there is a name conflict, by simply using StructMarshaller for everything now
- Fixed an issue with the return value being overwritten/ignored when UFunctions return to C++.