### PR TITLE
Fix generation for cases where property getter & setter differ in their types.

### DIFF
--- a/Source/UnrealSharpManagedGlue/Exporters/GetterSetterFunctionExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/GetterSetterFunctionExporter.cs
@@ -56,6 +56,12 @@ public class GetterSetterFunctionExporter : FunctionExporter
                 ? $"({ReturnValueTranslator!.GetManagedType(_propertyGetterSetter)})" : string.Empty;
             builder.AppendLine($"return {castOperation}returnValue;");
         }
+        else if (_function.ReturnProperty != null)
+        {
+            // Types differ (e.g., getter returns FText, property bound as string). Still return and rely on
+            // available implicit/user-defined conversions on the managed types (FText -> string, etc.).
+            builder.AppendLine("return returnValue;");
+        }
         
         if (string.IsNullOrEmpty(_outParameterName))
         {


### PR DESCRIPTION

- Property pairing was dependent on accessor discovery order. When the setter was encountered first, the property type came from the setter parameter, and the getter wrapper omitted a return if the return type differed — generating invalid code (empty getter).
- Prefer the getter’s value type (return or out) as the canonical property type and bind both getter and setter exporters to it. Always emit a return in getter wrappers (implicit conversions handle mismatches like FText->string).

Fix for #459