### PR TITLE
Ensure trace channel names starting with digits are prefixed with '_' to prevent invalid C# identifier generation

### DIFF
--- a/Source/UnrealSharpRuntimeGlue/Private/DefaultGenerators/CSTraceTypeQueryGlueGenerator.cpp
+++ b/Source/UnrealSharpRuntimeGlue/Private/DefaultGenerators/CSTraceTypeQueryGlueGenerator.cpp
@@ -49,6 +49,12 @@ void UCSTraceTypeQueryGlueGenerator::ProcessTraceTypeQuery()
 
 		FString ChannelName = TraceTypeQueryEnum->GetMetaData(TEXT("ScriptName"), i);
 		ChannelName.RemoveFromStart(TEXT("ECC_"));
+
+		if (ChannelName.Len() > 0 && FChar::IsDigit(ChannelName[0]))
+		{
+			ChannelName = TEXT("_") + ChannelName;
+		}
+
 		ScriptBuilder.AppendLine(FString::Printf(TEXT("%s = %d,"), *ChannelName, i));
 	}
 


### PR DESCRIPTION
A fix for invalid C# glue generation resulting from a trace name starting with a digit.

https://discord.com/channels/1153570806417342466/1299809051965657208/threads/1420602750688952361