### PR TITLE
Fix C#-defined structs not using copy marshallers for collections

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/MapBase.cs
+++ b/Managed/UnrealSharp/UnrealSharp/MapBase.cs
@@ -425,7 +425,8 @@ public class MapMarshaller<TKey, TValue> where TKey : notnull
     public void ToNative(IntPtr nativeBuffer, int arrayIndex, IDictionary<TKey, TValue> value)
     {
         TMap<TKey, TValue> wrapper = MakeWrapper(nativeBuffer);
-        
+
+        wrapper.Clear();
         foreach (KeyValuePair<TKey, TValue> pair in value)
         {
             wrapper.Add(pair.Key, pair.Value);
@@ -484,6 +485,7 @@ public class MapReadOnlyMarshaller<TKey, TValue> where TKey : notnull
     {
         TMap<TKey, TValue> wrapper = MakeWrapper(nativeBuffer);
 
+        wrapper.Clear();
         foreach (KeyValuePair<TKey, TValue> pair in value)
         {
             wrapper.Add(pair.Key, pair.Value);

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/NativeTypes/NativeDataContainerType.cs
@@ -78,11 +78,28 @@ public class NativeDataContainerType : NativeDataType
 
         // Instantiate generics for the direct access and copying marshallers.
         string prefix = propertyMetadata.Name + "_";
-        
-        FieldAttributes fieldAttributes = FieldAttributes.Private;
+        bool shouldUseCopyMarshaller;
+
         if (outer is MethodDefinition method)
         {
+            // The property is a parameter to a method, use copy marshaller
             prefix = method.Name + "_" + prefix;
+            shouldUseCopyMarshaller = true;
+        }
+        else if (typeDefinition.IsValueType)
+        {
+            // The property belongs to a struct, use copy marshaller
+            shouldUseCopyMarshaller = true;
+        }
+        else
+        {
+            // The property belongs to a class, use regular marshaller
+            shouldUseCopyMarshaller = false;
+        }
+
+        FieldAttributes fieldAttributes = FieldAttributes.Private;
+        if (shouldUseCopyMarshaller)
+        {
             TypeReference genericCopyMarshallerTypeRef = MarshallerAssembly.FindType(GetCopyContainerMarshallerName(), MarshallerNamespace)!;
             
             _containerMarshallerType = genericCopyMarshallerTypeRef.Resolve().MakeGenericInstanceType(ContainerMarshallerTypeParameters).ImportType();
@@ -94,8 +111,8 @@ public class NativeDataContainerType : NativeDataType
         }
         else
         {
-            TypeReference genericCopyMarshallerTypeRef = MarshallerAssembly.FindType(GetContainerMarshallerName(), MarshallerNamespace)!;
-            _containerMarshallerType = genericCopyMarshallerTypeRef.Resolve().MakeGenericInstanceType(ContainerMarshallerTypeParameters).ImportType();
+            TypeReference genericMarshallerTypeRef = MarshallerAssembly.FindType(GetContainerMarshallerName(), MarshallerNamespace)!;
+            _containerMarshallerType = genericMarshallerTypeRef.Resolve().MakeGenericInstanceType(ContainerMarshallerTypeParameters).ImportType();
 
             if (propertyMetadata.MemberRef is PropertyDefinition propertyDefinition && !AllowsSetter)
             {


### PR DESCRIPTION
Collection members in structs should be marshalled using copy-semantics, as the C# representation of collections are reference types and so may live on past the scope of the uproperty that holds the struct. The glue generator gets this right, however the weaver does not. This fixes the weaver to use copy marshallers for structs.

 Example:
```CSharp
[UStruct]
public struct FMyMap
{
    [UProperty]
    public IDictionary<int, int> Map;
}

...

// In some UClass
[UProperty]
public FMyMap MyMap { get; set; }

...

MyMap = new() { Map = new Dictionary<int, int>() { { 1, 2 } } };
MyMap = new() { Map = new Dictionary<int, int>() { { 2, 3 } } };

// MyMap should contain only [2, 3] but instead contains both [1, 2] and [2, 3]
```

Also, marshalling a map into a uproperty was not clearing the underlying map, resulting in the map being merged instead of overwritten. This fixes that by adding a clear before the copy. The only thing a bit weird here is if you set a property to itself, which will clear it instead of noop-ing, e.g.

```CSharp
[UProperty]
public TMap<int, int> MyMap { get; set; }

...

MyMap.Add(1, 2);
MyMap = MyMap; // Clears it
```

This is kind of a weird thing to do, and I'm not sure if having a setter on a TMap property even makes sense, but maybe we should handle it?