### PR TITLE
Make delegate trimming and AOT safe

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Array.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Array.cs
@@ -127,7 +127,7 @@ public class TArray<T> : UnrealArrayBase<T>, IList<T>, IReadOnlyList<T>
         int numElements = Count;
         for (int i = 0; i < numElements; ++i)
         {
-            if (this[i].Equals(item))
+            if (EqualityComparer<T>.Default.Equals(this[i], item))
             {
                 return i;
             }

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/MetaTags.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/MetaTags.cs
@@ -535,7 +535,7 @@ public sealed class ClampMaxAttribute(string ClampMax) : Attribute { }
 /// [UIMin]
 /// Used for float and integer properties. Specifies the lowest that the value slider should represent.
 /// </summary>
-/// <param name="ClampMin">N</param>
+/// <param name="UIMin">N</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class UIMinAttribute(string UIMin) : Attribute { }
 
@@ -543,7 +543,7 @@ public sealed class UIMinAttribute(string UIMin) : Attribute { }
 /// [UIMax]
 /// Used for float and integer properties. Specifies the highest that the value slider should represent.
 /// </summary>
-/// <param name="ClampMax">N</param>
+/// <param name="UIMax">N</param>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
 public sealed class UIMaxAttribute(string UIMax) : Attribute { }
 

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/UDelegateAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/UDelegateAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnrealSharp.Attributes;
+
+[AttributeUsage(AttributeTargets.Delegate)]
+public abstract class UDelegateAttribute : Attribute
+{
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
+    public Type? WrapperType { get; set; }
+}

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/UMultiDelegateAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/UMultiDelegateAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace UnrealSharp.Attributes;
 
 [AttributeUsage(AttributeTargets.Delegate)]
-public class UMultiDelegateAttribute : Attribute;
+public class UMultiDelegateAttribute : UDelegateAttribute;

--- a/Managed/UnrealSharp/UnrealSharp/Attributes/USingleDelegateAttribute.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Attributes/USingleDelegateAttribute.cs
@@ -1,4 +1,4 @@
 ﻿namespace UnrealSharp.Attributes;
 
 [AttributeUsage(AttributeTargets.Delegate)]
-public class USingleDelegateAttribute : Attribute;
+public class USingleDelegateAttribute : UDelegateAttribute;

--- a/Managed/UnrealSharp/UnrealSharp/DelegateBase.cs
+++ b/Managed/UnrealSharp/UnrealSharp/DelegateBase.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using UnrealSharp.Attributes;
 using UnrealSharp.Core.Attributes;
 using UnrealSharp.CoreUObject;
@@ -82,24 +84,24 @@ public class SingleDelegateMarshaller<T> where T : Delegate
 
 public abstract class TDelegateBase<T> where T : Delegate
 {
+    [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
     private static readonly Type Wrapper;
     public readonly DelegateBase<T> InnerDelegate;
 
     internal TDelegateBase()
     {
-        InnerDelegate = (DelegateBase<T>) Activator.CreateInstance(Wrapper);
+        InnerDelegate = (DelegateBase<T>) Activator.CreateInstance(Wrapper)!;
     }
 
     static TDelegateBase()
     {
-        Type delegateType = typeof(T);
-        string wrapperName = $"U{delegateType.Name}";
-        string fullName = $"{delegateType.Namespace}.{wrapperName}";
-        
-        Wrapper = delegateType.Assembly.GetType(fullName);
-        if (Wrapper == null)
+        if (typeof(T).GetCustomAttribute<UDelegateAttribute>(true)?.WrapperType is Type wrapperType)
         {
-            throw new TypeLoadException($"Could not find wrapper type '{fullName}' for '{typeof(T).FullName}'");
+            Wrapper = wrapperType;
+        }
+        else
+        {
+            throw new TypeLoadException($"Could not find wrapper type '{typeof(T).FullName}'");
         }
     }
     

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/Object.cs
@@ -652,21 +652,8 @@ internal static class ReflectionHelper
     // Get the name without the U/A/F/E prefix.
     internal static string GetEngineName(this Type type)
     {
-        Attribute? generatedTypeAttribute = type.GetCustomAttribute<GeneratedTypeAttribute>();
-
-        if (generatedTypeAttribute is null)
-        {
-            return type.Name;
-        }
-
-        FieldInfo? field = generatedTypeAttribute.GetType().GetField("EngineName");
-
-        if (field == null)
-        {
-            throw new InvalidOperationException($"The EngineName field was not found in the {nameof(GeneratedTypeAttribute)}.");
-        }
-
-        return (string) field.GetValue(generatedTypeAttribute)!;
+        var generatedTypeAttribute = type.GetCustomAttribute<GeneratedTypeAttribute>();
+        return generatedTypeAttribute is null ? type.Name : generatedTypeAttribute.EngineName;
     }
 
     internal static IntPtr TryGetNativeClass(this Type type)

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/ScriptInterface.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/ScriptInterface.cs
@@ -49,7 +49,7 @@ public static class ScriptInterfaceExtensions
         }
             
         var wrapperHandle = FCSManagerExporter.CallFindOrCreateManagedInterfaceWrapper(uobject.NativeObject, nativeClass);
-		if(wrapperHandle == IntPtr.Zero)
+        if(wrapperHandle == IntPtr.Zero)
         {
             return null;
         }
@@ -63,7 +63,7 @@ public static class ScriptInterfaceExtensions
         {
             return typedWrapper;
         }
-			
+            
         return null;
     }
 
@@ -121,7 +121,7 @@ public static class ScriptInterfaceExtensions
 
 
 
-public static class ScriptInterfaceMarshaller<T> where T : class
+public static class ScriptInterfaceMarshaller<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods)] T> where T : class
 {
     public static void ToNative(IntPtr nativeBuffer, int arrayIndex, T obj)
     {

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/ScriptInterface.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/CoreUObject/ScriptInterface.cs
@@ -13,7 +13,7 @@ internal struct FScriptInterface
         ObjectPointer = objectPointer;
         InterfacePointer = interfacePointer;
     }
-    
+
     internal IntPtr ObjectPointer;
     internal IntPtr InterfacePointer;
 }
@@ -21,10 +21,10 @@ internal struct FScriptInterface
 public interface IScriptInterface
 {
     public UObject Object { get; }
-    
+
 }
 
-public static class ScriptInterfaceExtensions 
+public static class ScriptInterfaceExtensions
 {
     /// <summary>
     /// Attempt to cast a UObject to an interface.
@@ -47,9 +47,9 @@ public static class ScriptInterfaceExtensions
         {
             return null;
         }
-            
+
         var wrapperHandle = FCSManagerExporter.CallFindOrCreateManagedInterfaceWrapper(uobject.NativeObject, nativeClass);
-        if(wrapperHandle == IntPtr.Zero)
+        if (wrapperHandle == IntPtr.Zero)
         {
             return null;
         }
@@ -63,7 +63,7 @@ public static class ScriptInterfaceExtensions
         {
             return typedWrapper;
         }
-            
+
         return null;
     }
 
@@ -81,10 +81,10 @@ public static class ScriptInterfaceExtensions
         {
             return null;
         }
-        
+
         return uobject.AsInterface<T>() ?? throw new InvalidCastException($"Cannot cast {uobject.GetType()} to {typeof(T)}");
     }
-    
+
     /// <summary>
     /// Attempt to convert an interface object to a UObject.
     /// </summary>
@@ -114,7 +114,7 @@ public static class ScriptInterfaceExtensions
         {
             return null;
         }
-        
+
         return scriptInterface.AsUObject() ?? throw new InvalidCastException($"Cannot cast {scriptInterface.GetType()} to UObject");
     }
 }
@@ -133,7 +133,7 @@ public static class ScriptInterfaceMarshaller<[DynamicallyAccessedMembers(Dynami
             scriptInterface->InterfacePointer = objectPointer;
         }
     }
-    
+
     public static T? FromNative(IntPtr nativeBuffer, int arrayIndex)
     {
         unsafe

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/DataTable.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/DataTable.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using UnrealSharp.Attributes;
 using UnrealSharp.Interop;
 using UnrealSharp.UnrealSharpCore;
@@ -35,7 +36,7 @@ public partial class UDataTable
     /// <param name="rowName">The name of the row to find</param>
     /// <typeparam name="T">The type of the row to find</typeparam>
     /// <returns>The row if found, otherwise the default value of the type</returns>
-    public T FindRow<T>(FName rowName) where T : struct
+    public T FindRow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(FName rowName) where T : struct
     {
         Type type = typeof(T);
         
@@ -55,7 +56,7 @@ public partial class UDataTable
     /// <param name="value">The row if found, otherwise null</param>
     /// <typeparam name="T">The type of the row to find</typeparam>
     /// <returns>True if the row was found, otherwise false</returns>
-    public bool TryFindRow<T>(FName rowName, out T? value) where T : struct
+    public bool TryFindRow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(FName rowName, out T? value) where T : struct
     {
         value = null;
         Type type = typeof(T);
@@ -89,7 +90,7 @@ public partial class UDataTable
     /// Get the row names of the table.
     /// </summary>
     /// <returns>The row names of the table</returns>
-    public void ForEachRow<T>(Action<FName, T> action) where T : struct
+    public void ForEachRow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Action<FName, T> action) where T : struct
     {
         IList<FName> rowNames = GetRowNames();
         foreach (FName rowName in rowNames)
@@ -103,7 +104,7 @@ public partial class UDataTable
     /// </summary>
     /// <param name="action">The action to perform on each row</param>
     /// <typeparam name="T">The type of the row</typeparam>
-    public void ForEachRow<T>(Action<T> action) where T : struct
+    public void ForEachRow<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] T>(Action<T> action) where T : struct
     {
         IList<FName> rowNames = GetRowNames();
         foreach (FName rowName in rowNames)

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/MovementComponent.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/MovementComponent.cs
@@ -87,6 +87,7 @@ public partial class UMovementComponent : UActorComponent
     /// <remarks>The overload taking rotation as an FQuat is slightly faster than the version using FRotator (which will be converted to an FQuat)..</remarks>
     /// <param name="adjustment">The requested adjustment, usually from GetPenetrationAdjustment()</param>
     /// <param name="hit">The result of the failed move</param>
+    /// <param name="newRotation">The new rotation to apply</param>
     /// <returns>True if the adjustment was successful and the original move should be retried, or false if no repeated attempt should be made.</returns>
     public bool ResolvePenetration(FVector adjustment, FHitResult hit, FQuat newRotation)
     {
@@ -100,6 +101,7 @@ public partial class UMovementComponent : UActorComponent
     /// <remarks>The overload taking rotation as an FQuat is slightly faster than the version using FRotator (which will be converted to an FQuat)..</remarks>
     /// <param name="adjustment">The requested adjustment, usually from GetPenetrationAdjustment()</param>
     /// <param name="hit">The result of the failed move</param>
+    /// <param name="newRotation">The new rotation to apply</param>
     /// <returns>True if the adjustment was successful and the original move should be retried, or false if no repeated attempt should be made.</returns>
     public bool ResolvePenetration(FVector adjustment, FHitResult hit, FRotator newRotation)
     {

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/SystemLibrary.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/SystemLibrary.cs
@@ -13,7 +13,6 @@ public partial class SystemLibrary
     /// <param name="time"> The time in seconds before the function is called. </param>
     /// <param name="bLooping"> Whether the timer should loop. </param>
     /// <param name="initialStartDelay"> The initial delay before the timer starts. </param>
-    /// <param name="initialStartDelayVariance"> The variance in the initial delay. </param>
     /// <exception cref="ArgumentException"> Thrown if the target of the action is not an UObject. </exception>
     public static FTimerHandle SetTimer(Action action, float time, bool bLooping, float initialStartDelay = 0.000000f)
     {

--- a/Managed/UnrealSharp/UnrealSharp/Interop/UClassExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Interop/UClassExporter.cs
@@ -7,6 +7,6 @@ public static unsafe partial class UClassExporter
 {
     public static delegate* unmanaged<IntPtr, string, IntPtr> GetNativeFunctionFromClassAndName;
     public static delegate* unmanaged<IntPtr, string, IntPtr> GetNativeFunctionFromInstanceAndName;
-    public static delegate* unmanaged<string, string, string, IntPtr> GetDefaultFromName;
+    public static delegate* unmanaged<string, string?, string, IntPtr> GetDefaultFromName;
     public static delegate* unmanaged<IntPtr, IntPtr> GetDefaultFromInstance;
 }

--- a/Managed/UnrealSharp/UnrealSharp/MapBase.cs
+++ b/Managed/UnrealSharp/UnrealSharp/MapBase.cs
@@ -470,7 +470,7 @@ public class MapReadOnlyMarshaller<TKey, TValue> where TKey : notnull
         if (_readOnlyMapWrapper == null)
         {
             _readOnlyMapWrapper = new TMapReadOnly<TKey, TValue>(_nativeProperty, nativeBuffer +
-                (arrayIndex * Marshal.SizeOf(typeof(FScriptMap))), _keyFromNative, _keyToNative, _valueFromNative, _valueToNative);
+                (arrayIndex * Marshal.SizeOf<FScriptMap>()), _keyFromNative, _keyToNative, _valueFromNative, _valueToNative);
         }
         
         return _readOnlyMapWrapper;
@@ -548,7 +548,7 @@ public class MapCopyMarshaller<TKey, TValue> where TKey : notnull
         ref ScriptMapHelper helper, MarshallingDelegates<TKey>.ToNative keyToNative,
         MarshallingDelegates<TValue>.ToNative valueToNative)
     {
-        IntPtr scriptMapAddress = nativeBuffer + arrayIndex * Marshal.SizeOf(typeof(FScriptMap));
+        IntPtr scriptMapAddress = nativeBuffer + arrayIndex * Marshal.SizeOf<FScriptMap>();
         helper.MapAddress = scriptMapAddress;
 
         // Make sure any existing elements are properly destroyed

--- a/Managed/UnrealSharp/UnrealSharp/NativeArray.cs
+++ b/Managed/UnrealSharp/UnrealSharp/NativeArray.cs
@@ -99,7 +99,7 @@ public unsafe class TNativeArray<T> : IEnumerable<T> where T : INumber<T>
     /// <summary>
     /// Copy from a span to the array
     /// </summary>
-    /// <param name="span"> The array to copy the elements from. </param>
+    /// <param name="span"> The span to copy the elements from. </param>
     public void CopyFrom(ReadOnlySpan<T> span)
     {
         FArrayPropertyExporter.CallResizeArray(NativeUnrealProperty, NativeBuffer, span.Length);

--- a/Managed/UnrealSharp/UnrealSharp/NativeArray.cs
+++ b/Managed/UnrealSharp/UnrealSharp/NativeArray.cs
@@ -73,7 +73,7 @@ public unsafe class TNativeArray<T> : IEnumerable<T> where T : INumber<T>
     /// <summary>
     /// Copy the elements of the span to an array
     /// </summary>
-    /// <param name="array"> The array to copy the elements to. </param>
+    /// <param name="span"> The span to copy the elements to. </param>
     public void CopyTo(Span<T> span)
     {
         Span<T> source = new Span<T>(NativeArrayBuffer.ToPointer(), Length);
@@ -99,7 +99,7 @@ public unsafe class TNativeArray<T> : IEnumerable<T> where T : INumber<T>
     /// <summary>
     /// Copy from a span to the array
     /// </summary>
-    /// <param name="array"> The array to copy the elements from. </param>
+    /// <param name="span"> The array to copy the elements from. </param>
     public void CopyFrom(ReadOnlySpan<T> span)
     {
         FArrayPropertyExporter.CallResizeArray(NativeUnrealProperty, NativeBuffer, span.Length);
@@ -183,7 +183,7 @@ public class NativeArrayMarshaller<T>(IntPtr nativeProperty)
     {
         unsafe
         {
-            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf(typeof(UnmanagedArray)));
+            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf<UnmanagedArray>());
             FArrayPropertyExporter.CallInitializeArray(nativeProperty, mirror, obj.Length);
 
             Span<T> destination = new Span<T>(mirror->Data.ToPointer(), obj.Length);
@@ -216,7 +216,7 @@ public class NativeArrayCopyMarshaller<T>
     {
         unsafe
         {
-            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf(typeof(UnmanagedArray)));
+            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf<UnmanagedArray>());
             FArrayPropertyExporter.CallInitializeArray(_nativeProperty, mirror, obj.Length);
 
             Span<T> destination = new Span<T>(mirror->Data.ToPointer(), obj.Length);
@@ -244,7 +244,7 @@ public class NativeArrayCopyMarshaller<T>
     {
         unsafe
         {
-            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf(typeof(UnmanagedArray)));
+            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf<UnmanagedArray>());
             FArrayPropertyExporter.CallEmptyArray(_nativeProperty, mirror);
         }
     }

--- a/Managed/UnrealSharp/UnrealSharp/ScriptMapHelper.cs
+++ b/Managed/UnrealSharp/UnrealSharp/ScriptMapHelper.cs
@@ -90,7 +90,6 @@ internal unsafe struct ScriptMapHelper
     /// The map will be invalid until the next Rehash() call.
     /// </summary>
     /// <param name="index">The index of the element to remove.</param>
-    /// <param name="count"></param>
     public void RemoveAt(int index)
     {
         if (!IsValidIndex(index))

--- a/Managed/UnrealSharp/UnrealSharp/UnrealArray.cs
+++ b/Managed/UnrealSharp/UnrealSharp/UnrealArray.cs
@@ -154,7 +154,7 @@ public class ArrayCopyMarshaller<T>
     {
         unsafe
         {
-            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf(typeof(UnmanagedArray)));
+            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf<UnmanagedArray>());
             if (obj == null)
             {
                 FArrayPropertyExporter.CallEmptyArray(_nativeProperty, mirror);
@@ -191,7 +191,7 @@ public class ArrayCopyMarshaller<T>
     {
         unsafe
         {
-            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf(typeof(UnmanagedArray)));
+            UnmanagedArray* mirror = (UnmanagedArray*)(nativeBuffer + arrayIndex * Marshal.SizeOf<UnmanagedArray>());
             FArrayPropertyExporter.CallEmptyArray(_nativeProperty, mirror);
         }
     }

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Program.cs
@@ -355,6 +355,7 @@ public static class Program
             List<TypeDefinition> structs = [];
             List<TypeDefinition> enums = [];
             List<TypeDefinition> interfaces = [];
+            List<TypeDefinition> delegateDecls = [];
             List<TypeDefinition> multicastDelegates = [];
             List<TypeDefinition> delegates = [];
 
@@ -386,6 +387,10 @@ public static class Program
                         {
                             RegisterType(interfaces, type);
                         }
+                        else if (type.IsUSingleDelegate() || type.IsUMultiDelegate())
+                        {
+                            RegisterType(delegateDecls, type);
+                        }
                         else if (type.BaseType != null && type.BaseType.FullName.Contains("UnrealSharp.MulticastDelegate"))
                         {
                             RegisterType(multicastDelegates, type);
@@ -407,7 +412,7 @@ public static class Program
             UnrealInterfaceProcessor.ProcessInterfaces(interfaces, metadata);
             UnrealStructProcessor.ProcessStructs(structs, metadata, userAssembly);
             UnrealClassProcessor.ProcessClasses(classes, metadata);
-            UnrealDelegateProcessor.ProcessDelegates(delegates, multicastDelegates, userAssembly, metadata.DelegateMetaData);
+            UnrealDelegateProcessor.ProcessDelegates(delegateDecls, delegates, multicastDelegates, userAssembly, metadata.DelegateMetaData);
         }
         catch (Exception ex)
         {

--- a/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Utilities/TypeDefinitionUtilities.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpWeaver/Utilities/TypeDefinitionUtilities.cs
@@ -18,12 +18,14 @@ public static class TypeDefinitionUtilities
 {
     public static readonly string UClassCallbacks = "UClassExporter";
     public static readonly string UClassAttribute = "UClassAttribute";
-    
+    public static readonly string USingleDelegateAttribute = "USingleDelegateAttribute";
+    public static readonly string UMultiDelegateAttribute = "UMultiDelegateAttribute";
+
     public static readonly string UEnumAttribute = "UEnumAttribute";
     public static readonly string UStructAttribute = "UStructAttribute";
     public static readonly string UInterfaceAttribute = "UInterfaceAttribute";
     public static readonly string BlittableTypeAttribute = "BlittableTypeAttribute";
-    
+
     public static CustomAttribute? GetUClass(this IMemberDefinition definition)
     {
         return definition.CustomAttributes.FindAttributeByType(WeaverImporter.UnrealSharpAttributesNamespace, UClassAttribute);
@@ -33,7 +35,27 @@ public static class TypeDefinitionUtilities
     {
         return GetUClass(definition) != null;
     }
-    
+
+    public static CustomAttribute? GetUSingleDelegate(this IMemberDefinition definition)
+    {
+        return definition.CustomAttributes.FindAttributeByType(WeaverImporter.UnrealSharpAttributesNamespace, USingleDelegateAttribute);
+    }
+
+    public static bool IsUSingleDelegate(this IMemberDefinition definition)
+    {
+        return GetUSingleDelegate(definition) != null;
+    }
+
+    public static CustomAttribute? GetUMultiDelegate(this IMemberDefinition definition)
+    {
+        return definition.CustomAttributes.FindAttributeByType(WeaverImporter.UnrealSharpAttributesNamespace, UMultiDelegateAttribute);
+    }
+
+    public static bool IsUMultiDelegate(this IMemberDefinition definition)
+    {
+        return GetUMultiDelegate(definition) != null;
+    }
+
     public static bool IsUInterface(this TypeDefinition typeDefinition)
     {
         return GetUInterface(typeDefinition) != null;

--- a/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
@@ -630,7 +630,8 @@ public class FunctionExporter
         {
             attributeBuilder.AddAttribute("USingleDelegate");
         }
-        
+
+        attributeBuilder.AddAttributeProperty("WrapperType", $"typeof(U{delegateName})");
         attributeBuilder.Finish();
         builder.AppendLine(attributeBuilder.ToString());
         

--- a/Source/UnrealSharpManagedGlue/Utilities/AttributeBuilder.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/AttributeBuilder.cs
@@ -85,6 +85,23 @@ public class AttributeBuilder
         _state = AttributeState.InAttribute;
     }
 
+    public void AddAttributeProperty(string propertyName, string value)
+    {
+        switch (_state)
+        {
+            case AttributeState.InAttribute:
+                _stringBuilder.Append("(");
+                break;
+            case AttributeState.InAttributeParams:
+                _stringBuilder.Append(", ");
+                break;
+            default:
+                throw new InvalidOperationException("Invalid state");
+        }
+        _stringBuilder.Append($"{propertyName} = {value}");
+        _state = AttributeState.InAttributeParams;
+    }
+
     public void AddArgument(string arg)
     {
         switch (_state)


### PR DESCRIPTION
Instead of looking up the wrapper type by `U{name}`, emit an attribute and save the wrapper type into a `Type` property that is marked with `DynamicallyAccessedMemberTypesAttribute`, so that the wrapper type won't be trimmed by the trimmer or the AOT compiler:

```cs
[UMultiDelegate]
delegate void Foo();
```

becomes

```cs
[UMultiDelegate(WrapperType = typeof(UFoo))]
delegate void Foo();

class UFoo : ...
```

then the wrapper type can be obtained by `typeof(Foo).GetCustomAttribute<UDelegate>().WrapperType`.

This is also a performance improvement.

Also replacing some `Marshal.SizeOf(Type)` with `Marshal.SizeOf<T>()` to make it aot-compatible.

The others are some minor fixes to comments/nullable issues.