### PR TITLE
Include-references needs to be done after the project directories to avoid generation errors

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateSolution.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateSolution.cs
@@ -68,13 +68,14 @@ public class GenerateSolution : BuildToolAction
                     using BuildToolProcess addProjectToSln = new BuildToolProcess();
                     addProjectToSln.StartInfo.ArgumentList.Add("sln");
                     addProjectToSln.StartInfo.ArgumentList.Add("add");
-                    addProjectToSln.StartInfo.ArgumentList.Add("--include-references");
-                    addProjectToSln.StartInfo.ArgumentList.Add("false");
-
+					
                     foreach (string relativePath in projects)
                     {
                         addProjectToSln.StartInfo.ArgumentList.Add(relativePath);
                     }
+					
+					addProjectToSln.StartInfo.ArgumentList.Add("--include-references");
+                    addProjectToSln.StartInfo.ArgumentList.Add("false");
 
                     addProjectToSln.StartInfo.ArgumentList.Add("-s");
                     addProjectToSln.StartInfo.ArgumentList.Add(projects.Key);


### PR DESCRIPTION
--include-references needs to be done after the project directories you are adding otherwise it throws the error Could not find project or directory `--include-references`. Does this change depend on the dotnet version though? Do we need a version check here or is this safe?

The following error is thrown in its current state
System.Exception: BuildTool process failed with exit code 1:
Could not find project or directory `--include-references`.
Could not find project or directory `false`.

Which results in people reporting 
Attempt 3/10: error while adding projects to sln: BuildTool process failed with exit code 1:
Could not find project or directory `--include-references`.
Could not find project or directory `false`.

dotnet --info
.NET SDK:
 Version:           9.0.306
 Commit:            cc9947ca66