### PR TITLE
Fix garbled Chinese text when passing C# strings into Unreal

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Core/Interop/FStringExporter.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/Interop/FStringExporter.cs
@@ -6,4 +6,5 @@ namespace UnrealSharp.Core.Interop;
 public unsafe partial class FStringExporter
 {
     public static delegate* unmanaged<UnmanagedArray*, string, void> MarshalToNativeString;
+    public static delegate* unmanaged<UnmanagedArray*, char*, int, void> MarshalToNativeStringView;
 }

--- a/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/StringMarshaller.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/Marshallers/StringMarshaller.cs
@@ -15,7 +15,13 @@ public static class StringMarshaller
             }
             
             UnmanagedArray* unrealString = (UnmanagedArray*) (nativeBuffer + arrayIndex * sizeof(UnmanagedArray));
-            FStringExporter.CallMarshalToNativeString(unrealString, stringToMarshal);
+
+            // NOTE: do not pass a string directly to native (the runtime marshals it as ANSI and replaces non-ASCII with '?').
+            // Pin the UTF-16 buffer and let the UE side convert it to TCHAR/FString.
+            fixed (char* stringPtr = stringToMarshal)
+            {
+                FStringExporter.CallMarshalToNativeStringView(unrealString, stringPtr, stringToMarshal.Length);
+            }
         }
     }
     

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Core/Text.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Core/Text.cs
@@ -26,7 +26,21 @@ public class FText
     
     public FText(string text)
     {
-        FTextExporter.CallFromString(ref Data, text);
+        if (text == null)
+        {
+            FTextExporter.CallCreateEmptyText(ref Data);
+            return;
+        }
+
+        // NOTE: do not pass a string directly to native (the runtime marshals it as ANSI and replaces non-ASCII with '?').
+        // Pin the UTF-16 buffer and let the UE side build FText from a TCHAR view (pointer + length).
+        unsafe
+        {
+            fixed (char* textPtr = text)
+            {
+                FTextExporter.CallFromStringView(ref Data, textPtr, text.Length);
+            }
+        }
     }
 
     public FText(ReadOnlySpan<char> text)

--- a/Source/UnrealSharpCore/Private/Export/FTextExporter.cpp
+++ b/Source/UnrealSharpCore/Private/Export/FTextExporter.cpp
@@ -31,7 +31,16 @@ void UFTextExporter::FromString(FText* Text, const char* String)
 		return;
 	}
 
-	*Text = Text->FromString(String);
+	if (!String)
+	{
+		*Text = FText::GetEmpty();
+		return;
+	}
+
+	// Contract: this API receives a UTF-8 byte string and must decode it into TCHAR.
+	// NOTE: do NOT call this from C# by passing a string directly (the runtime will marshal it as ANSI and replace non-ASCII with '?').
+	// Prefer FromStringView (TCHAR* + length) by pinning the UTF-16 buffer on the managed side to avoid data loss.
+	*Text = FText::FromString(FString(UTF8_TO_TCHAR(String)));
 }
 
 void UFTextExporter::FromStringView(FText* Text, const TCHAR* String, int32 Length)

--- a/Source/UnrealSharpCore/Public/Export/FStringExporter.h
+++ b/Source/UnrealSharpCore/Public/Export/FStringExporter.h
@@ -1,6 +1,7 @@
 ﻿#pragma once
 
 #include "CoreMinimal.h"
+#include "Containers/StringConv.h"
 #include "CSBindsManager.h"
 #include "FStringExporter.generated.h"
 
@@ -12,6 +13,39 @@ public:
 	UNREALSHARP_FUNCTION()
 	static void MarshalToNativeString(FString* NativeString, const char* ManagedString)
 	{
-		*NativeString = ManagedString;
+		if (!NativeString)
+		{
+			return;
+		}
+
+		if (!ManagedString)
+		{
+			*NativeString = FString();
+			return;
+		}
+
+		// Contract: this API receives a UTF-8 byte string and must decode it into TCHAR.
+		// NOTE: do NOT call this from C# by passing a string directly (the runtime will marshal it as ANSI and replace non-ASCII with '?').
+		// Prefer MarshalToNativeStringView (UTF-16 pointer + length) to avoid data loss.
+		*NativeString = UTF8_TO_TCHAR(ManagedString);
+	}
+
+	UNREALSHARP_FUNCTION()
+	static void MarshalToNativeStringView(FString* NativeString, const UTF16CHAR* ManagedString, int32 Length)
+	{
+		if (!NativeString)
+		{
+			return;
+		}
+
+		if (!ManagedString || Length <= 0)
+		{
+			*NativeString = FString();
+			return;
+		}
+
+		// C# strings are UTF-16 (char*). Use a length-based view (no null-termination dependency) and convert to TCHAR correctly.
+		const auto Converted = StringCast<TCHAR>(ManagedString, Length);
+		*NativeString = FString(Converted.Length(), Converted.Get());
 	}
 };


### PR DESCRIPTION
## Summary

Fixes Unicode data loss when C# `string` values are passed into Unreal via UnrealSharp. The previous interop path relied on default runtime marshalling to `char*` (ANSI/ACP), which replaced non-ASCII characters with `?`, causing garbled output in UMG, `PrintString`, and logs.

This change pins the managed UTF-16 buffer and passes a `(char* ptr, int length)` “string view” into native code, where it is converted to `TCHAR` safely.

## Key Changes

- Added a new native exporter API to marshal `FString` from a UTF-16 view:
  `UFStringExporter::MarshalToNativeStringView(FString*, const UTF16CHAR*, int32 Length)`
- Updated `StringMarshaller` to use the UTF-16 view path instead of passing `string` directly to native.
- Updated `FText(string)` to call `FromStringView(char*, len)` (pinned UTF-16) rather than `FromString(string)` to avoid ANSI marshalling.

## How To Test

- Rebuild UnrealSharp managed assemblies and the plugin.
- In C#, call:
  `UObject.PrintString("中文测试：你好世界")`
- Set a UMG `TextBlock` text from a C# string containing Chinese characters.
- Log a Chinese string via UnrealSharp logging APIs.
- Verify the text displays correctly (no `???` or mojibake).