### PR TITLE
Disable rollforward on runtime processes

### DIFF
--- a/Managed/Shared/DotNetUtilities.cs
+++ b/Managed/Shared/DotNetUtilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -136,6 +136,9 @@ public static class DotNetUtilities
 		    startInfo.Environment["MSBUILD_EXE_PATH"] = $@"{latestDotNetSdkPath}\MSBuild.dll";
 		    startInfo.Environment["MSBuildSDKsPath"] = $@"{latestDotNetSdkPath}\Sdks";
 	    }
+
+        // Disable roll forward to avoid using wrong .NET runtimes, this propagates to child processes.
+        startInfo.Environment["DOTNET_ROLL_FORWARD"] = "Disable";
 
 	    using Process process = new Process();
 	    process.StartInfo = startInfo;


### PR DESCRIPTION
small PR that fixes an issue where USharpBuildTools will run on a different version of .net runtime, i've tried to disable rollForward in the runtimeconfig.json as well in the csproj however it didn't seem to fix so ended up with setting it as an environment variable instead.