### PR TITLE
Added Feature “Reload Assembly”

### DIFF
--- a/Source/UnrealSharpEditor/Private/CSUnrealSharpEditorCommands.cpp
+++ b/Source/UnrealSharpEditor/Private/CSUnrealSharpEditorCommands.cpp
@@ -17,6 +17,7 @@ void FCSUnrealSharpEditorCommands::RegisterCommands()
 {
 	UI_COMMAND(CreateNewProject, "Create C# Project", "Create a new C# project with all necessary dependencies and initial setup", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(HotReload, "Force Hot Reload", "Manually reloads any modified C# code into the editor. Only required if Automatic Hot Reloading is disabled", EUserInterfaceActionType::Button, FInputChord(EKeys::F5, EModifierKey::Control | EModifierKey::Alt));
+	UI_COMMAND(HotReloadAssemblyOnly, "Reload Assembly", "Reload managed assemblies from disk without recompiling.", EUserInterfaceActionType::Button, FInputChord(EKeys::F5, EModifierKey::None));
 	UI_COMMAND(RegenerateSolution, "Regenerate Solution", "Rebuild the C# solution file to reflect the latest project changes", EUserInterfaceActionType::Button, FInputChord(EKeys::F9, EModifierKey::Control | EModifierKey::Alt));
 	UI_COMMAND(OpenSolution, "Open C# Solution", "Launch the project's C# solution file in the default IDE.", EUserInterfaceActionType::Button, FInputChord());
 	UI_COMMAND(MergeManagedSlnAndNativeSln, "Merge Managed and Native Solution", "Merges the managed sln and native sln into one mixed.sln, coding in one IDE instance. This will create a new sln in the root folder of your project", EUserInterfaceActionType::Button, FInputChord());

--- a/Source/UnrealSharpEditor/Private/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/Private/UnrealSharpEditor.cpp
@@ -92,7 +92,12 @@ void FUnrealSharpEditorModule::OnCreateNewProject()
 
 void FUnrealSharpEditorModule::OnCompileManagedCode()
 {
-	UCSHotReloadSubsystem::Get()->PerformHotReload();
+	UCSHotReloadSubsystem::Get()->PerformHotReload(true);
+}
+
+void FUnrealSharpEditorModule::OnReloadAssemblyOnly()
+{
+	UCSHotReloadSubsystem::Get()->PerformHotReload(false);
 }
 
 void FUnrealSharpEditorModule::OnRegenerateSolution()
@@ -316,6 +321,9 @@ TSharedRef<SWidget> FUnrealSharpEditorModule::GenerateUnrealSharpToolbar() const
 	MenuBuilder.AddMenuEntry(CSCommands.HotReload, NAME_None, TAttribute<FText>(), TAttribute<FText>(),
 	                         FSlateIcon(FAppStyle::Get().GetStyleSetName(), "LevelEditor.Recompile"));
 
+	MenuBuilder.AddMenuEntry(CSCommands.HotReloadAssemblyOnly, NAME_None, TAttribute<FText>(), TAttribute<FText>(),
+							 FSlateIcon(FAppStyle::Get().GetStyleSetName(), "LevelEditor.Recompile"));
+
 	MenuBuilder.EndSection();
 
 	// Project
@@ -401,6 +409,8 @@ void FUnrealSharpEditorModule::RegisterCommands()
 	                               FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnCreateNewProject));
 	UnrealSharpCommands->MapAction(FCSUnrealSharpEditorCommands::Get().HotReload,
 	                               FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnCompileManagedCode));
+	UnrealSharpCommands->MapAction(FCSUnrealSharpEditorCommands::Get().HotReloadAssemblyOnly,
+								   FExecuteAction::CreateStatic(&FUnrealSharpEditorModule::OnReloadAssemblyOnly));
 	UnrealSharpCommands->MapAction(FCSUnrealSharpEditorCommands::Get().RegenerateSolution,
 	                               FExecuteAction::CreateRaw(this, &FUnrealSharpEditorModule::OnRegenerateSolution));
 	UnrealSharpCommands->MapAction(FCSUnrealSharpEditorCommands::Get().OpenSolution,

--- a/Source/UnrealSharpEditor/Public/CSUnrealSharpEditorCommands.h
+++ b/Source/UnrealSharpEditor/Public/CSUnrealSharpEditorCommands.h
@@ -11,6 +11,7 @@ public:
 
 	TSharedPtr<FUICommandInfo> CreateNewProject;
     TSharedPtr<FUICommandInfo> HotReload;
+    TSharedPtr<FUICommandInfo> HotReloadAssemblyOnly;
 	TSharedPtr<FUICommandInfo> RegenerateSolution;
 	TSharedPtr<FUICommandInfo> OpenSolution;
 	TSharedPtr<FUICommandInfo> MergeManagedSlnAndNativeSln;

--- a/Source/UnrealSharpEditor/Public/HotReload/CSHotReloadSubsystem.h
+++ b/Source/UnrealSharpEditor/Public/HotReload/CSHotReloadSubsystem.h
@@ -58,7 +58,7 @@ public:
 	UNREALSHARPEDITOR_API bool HasPendingHotReloadChanges() const;
 	UNREALSHARPEDITOR_API bool HasHotReloadFailed() const { return CurrentHotReloadStatus == FailedToUnload || CurrentHotReloadStatus == FailedToCompile; }
 	
-	UNREALSHARPEDITOR_API void PerformHotReload();
+	UNREALSHARPEDITOR_API void PerformHotReload(bool bShouldRecompile);
 	
 	void PauseHotReload(const FString& Reason = FString());
 	void ResumeHotReload();

--- a/Source/UnrealSharpEditor/Public/UnrealSharpEditor.h
+++ b/Source/UnrealSharpEditor/Public/UnrealSharpEditor.h
@@ -69,6 +69,7 @@ private:
 
     static void OnCreateNewProject();
     static void OnCompileManagedCode();
+    static void OnReloadAssemblyOnly();
     
     void OnRegenerateSolution();
     void OnOpenSolution();


### PR DESCRIPTION
  - Added “Reload Assembly” (F5): sync and reload managed assemblies from disk without recompiling
  - Kept existing Hot Reload behavior unchanged: automatic/manual hot reload still recompiles (bShouldRecompile=true)

  ### Testing
  - [x] Build the C# project in Rider/VS, return to UE, press F5 / click “Reload Assembly”, verify it shows “Syncing Assemblies” progress and the reload takes effect
  - [x] Verify existing auto hot reload triggers (editor focus regain, after PIE, etc.) still behave the same as before

  ### Impact
  - Editor: UnrealSharpEditor
  - Runtime: none