### PR TITLE
Fixes global namespace

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/FieldName.cs
+++ b/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/FieldName.cs
@@ -21,7 +21,7 @@ public readonly record struct FieldName
         Namespace = nameSpace;
         Assembly = assembly;
         
-        FullName = $"{Namespace}.{Name}";
+        FullName = string.IsNullOrEmpty(Namespace) ? Name : $"{Namespace}.{Name}";
     }
     
     public FieldName(UnrealType type) : this(type.SourceName, type.Namespace, type.AssemblyName)

--- a/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/UnrealType.cs
+++ b/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/UnrealType.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Newtonsoft.Json;
@@ -25,7 +25,7 @@ public record UnrealType
     public virtual string EngineName => SourceName;
     public readonly string AssemblyName = string.Empty;
     
-    public string FullName => Namespace + "." + SourceName;
+    public string FullName => string.IsNullOrEmpty(Namespace) ? SourceName : Namespace + "." + SourceName;
     public string Namespace = string.Empty;
     
     public virtual FieldType FieldType => FieldType.Unknown;

--- a/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/SourceGenUtilities.cs
+++ b/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/SourceGenUtilities.cs
@@ -230,6 +230,11 @@ public static class SourceGenUtilities
     
     public static string GetNamespace(this ISymbol symbol)
     {
+        if (symbol.ContainingNamespace.IsGlobalNamespace)
+        {
+            return string.Empty;
+        }
+
         return symbol.ContainingNamespace.ToDisplayString();
     }
     


### PR DESCRIPTION
Currently there is an issue with global namespaces where it'll return `<global Namespace>` as the Namespace, this PR makes namespaces empty if global and then removes namespace entirely from the FieldName.FullName if the namespace is empty.