### PR TITLE
Fixes returns in glue generator

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.GlueGenerator.Tests/TestClass.cs
+++ b/Managed/UnrealSharp/UnrealSharp.GlueGenerator.Tests/TestClass.cs
@@ -1,4 +1,4 @@
-﻿
+
 using UnrealSharp;
 using UnrealSharp.Attributes;
 using UnrealSharp.Core;
@@ -204,16 +204,23 @@ public partial class UTestClass : ACharacter, ITestInterface
     }
 
     [UFunction(FunctionFlags.BlueprintEvent)]
-    public partial float TestFunction(int intParam, string strParam);
-    public partial float TestFunction_Implementation(int intParam, string strParam)
+    public partial IList<string> TestFunction(int intParam, string strParam);
+    public partial IList<string> TestFunction_Implementation(int intParam, string strParam)
     {
-        return 0f;
+        return [];
     }
-    
+
+    [UFunction(FunctionFlags.BlueprintEvent)]
+    public partial string TestFunction2(int intParam, string strParam);
+    public partial string TestFunction2_Implementation(int intParam, string strParam)
+    {
+        return "";
+    }
+
     [UFunction(FunctionFlags.BlueprintCallable)]
     public void CallTestFunction([UMetaData("Test")] int intParam = 7, string strParam = "Hello from C#", ETestEnum test = ETestEnum.FirstValue)
     {
-        float result = TestFunction(42, "Hello from C#");
+        IList<string> result = TestFunction(42, "Hello from C#");
     }
 
     [UFunction(FunctionFlags.RunOnServer)]

--- a/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/UnrealFunctionBase.cs
+++ b/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/UnrealFunctionBase.cs
@@ -371,8 +371,8 @@ public abstract record UnrealFunctionBase : UnrealStruct
             
         if (HasReturnValue)
         {
-            builder.AppendLine($"{ReturnType.ManagedType} returnValue = ");
-            ReturnType.ExportFromNative(builder, SourceGenUtilities.ParamsBuffer);
+            string assignment = $"{ReturnType.ManagedType} returnValue = ";
+            ReturnType.ExportFromNative(builder, SourceGenUtilities.ParamsBuffer, assignment);
             builder.AppendLine("return returnValue;");
         }
             


### PR DESCRIPTION
This PR fixes an issue in glue gen when exporting from native in return where it would just apply everything to `returnValue =` this fixes that by passing in as an assignment operator instead.