### PR TITLE
Add buffer to reserved words to avoid collisions with local variable names

### DIFF
--- a/Source/UnrealSharpManagedGlue/Utilities/NameMapper.cs
+++ b/Source/UnrealSharpManagedGlue/Utilities/NameMapper.cs
@@ -24,7 +24,7 @@ public static class NameMapper
         "long", "namespace", "new", "null", "object", "operator", "out", "override", "params", "private", "protected", "public", 
         "readonly", "ref", "return", "sbyte", "sealed", "short", "sizeof", "stackalloc", "static", "string", "struct", "switch", 
         "this", "throw", "true", "try", "typeof", "uint", "ulong", "unchecked", "unsafe", "ushort", "using", "virtual",
-        "void", "volatile", "while", "System"
+        "void", "volatile", "while", "System", "buffer",
     };
 
     public static string GetParameterName(this UhtProperty property)


### PR DESCRIPTION
When using UnrealSharp with Hazelight's Angelscript fork of unreal, the glue generation fails due to a function they added which has an argument named InBuffer. This variable gets renamed to buffer which collides with a local variable defined later in the same generated glue function.

This fixes that by making buffer a reserved variable name.