### PR TITLE
[WIP] added editor settings to hide warnings in build tool

### DIFF
--- a/Source/UnrealSharpEditor/Public/CSUnrealSharpEditorSettings.h
+++ b/Source/UnrealSharpEditor/Public/CSUnrealSharpEditorSettings.h
@@ -67,13 +67,6 @@ public:
 	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Type Generation")
 	bool bSuffixGeneratedTypes = false;
 
-	/** by: dahai-li-1993
-	* Whether to show build warnings in the build error dialog.
-	* Only affects the full dotnet build (editor startup / manual rebuild), not the incremental hot reload compiler.
-	*/
-	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Build Output")
-	bool bShowBuildWarnings = false;
-
 	FString GetBuildConfigurationString() const;
 
 	FString GetLogVerbosityString() const;

--- a/Source/UnrealSharpProcHelper/Private/CSProcUtilities.cpp
+++ b/Source/UnrealSharpProcHelper/Private/CSProcUtilities.cpp
@@ -1,6 +1,7 @@
 ﻿#include "CSProcUtilities.h"
 
 #include "CSCommonUnrealSharpSettings.h"
+#include "CSUnrealSharpProcHelperSettings.h"
 #include "CSUnrealSharpSettingsUtilities.h"
 #include "UnrealSharpProcHelper.h"
 #include "Misc/App.h"
@@ -145,14 +146,7 @@ bool UCSProcUtilities::BuildUserSolution()
 	TMap<FString, FString> Arguments;
 	Arguments.Add("OutputPath", GetUserAssemblyDirectory());
 	
-	bool bShowBuildWarnings = true;
-	GConfig->GetBool(
-		TEXT("/Script/UnrealSharpEditor.CSUnrealSharpEditorSettings"),
-		TEXT("bShowBuildWarnings"),
-		bShowBuildWarnings,
-		GEditorPerProjectIni
-	);
-
+	bool bShowBuildWarnings = GetDefault<UCSUnrealSharpProcHelperSettings>()->bShowBuildWarnings;
 	if (!bShowBuildWarnings)
 	{
 		Arguments.Add("clp", "ErrorsOnly");

--- a/Source/UnrealSharpProcHelper/Public/CSUnrealSharpProcHelperSettings.h
+++ b/Source/UnrealSharpProcHelper/Public/CSUnrealSharpProcHelperSettings.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+#include "CSUnrealSharpProcHelperSettings.generated.h"
+
+UCLASS(config = EditorPerProjectUserSettings, meta = (DisplayName = "UnrealSharp Proc Helper Settings"))
+class UCSUnrealSharpProcHelperSettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+public:
+	
+	UCSUnrealSharpProcHelperSettings()
+	{
+		CategoryName = "Plugins";
+	}
+	
+	/**
+	* Whether to show build warnings in the build error dialog.
+	* Only affects the full dotnet build (editor startup / manual rebuild), not the incremental hot reload compiler.
+	*/
+	UPROPERTY(EditDefaultsOnly, config, Category = "UnrealSharp | Build Output")
+	bool bShowBuildWarnings = false;
+};

--- a/Source/UnrealSharpProcHelper/UnrealSharpProcHelper.Build.cs
+++ b/Source/UnrealSharpProcHelper/UnrealSharpProcHelper.Build.cs
@@ -23,7 +23,8 @@ public class UnrealSharpProcHelper : ModuleRules
                 "Projects",
                 "Json",
                 "XmlParser",
-                "UnrealSharpUtilities"
+                "UnrealSharpUtilities",
+                "DeveloperSettings"
             }
         );
         


### PR DESCRIPTION
<img width="1978" height="985" alt="image" src="https://github.com/user-attachments/assets/58a4b930-61f4-4672-9c1d-e2cebababa31" />

becomes...

<img width="1806" height="605" alt="image" src="https://github.com/user-attachments/assets/c2f0385a-ea41-4191-aa1f-977e6b18a773" />

I think it is more practical because errors are mantory to be fixed to initialize the edtor. Meanwhile there are too often having null reference, which is already exempted by calling "IsValid()"