### PR TITLE
Convert ECSWorldType to enum class to avoid 'redefinition'-errors.

### DIFF
--- a/Source/UnrealSharpCore/Public/Extensions/Libraries/CSWorldExtensions.h
+++ b/Source/UnrealSharpCore/Public/Extensions/Libraries/CSWorldExtensions.h
@@ -51,15 +51,6 @@ enum class ECSWorldType : uint8
 	Inactive = EWorldType::Inactive,
 };
 
-static_assert(static_cast<uint8>(ECSWorldType::None)          == static_cast<uint8>(EWorldType::None),          "ECSWorldType::None mismatch");
-static_assert(static_cast<uint8>(ECSWorldType::Game)          == static_cast<uint8>(EWorldType::Game),          "ECSWorldType::Game mismatch");
-static_assert(static_cast<uint8>(ECSWorldType::Editor)        == static_cast<uint8>(EWorldType::Editor),        "ECSWorldType::Editor mismatch");
-static_assert(static_cast<uint8>(ECSWorldType::PIE)           == static_cast<uint8>(EWorldType::PIE),           "ECSWorldType::PIE mismatch");
-static_assert(static_cast<uint8>(ECSWorldType::EditorPreview) == static_cast<uint8>(EWorldType::EditorPreview), "ECSWorldType::EditorPreview mismatch");
-static_assert(static_cast<uint8>(ECSWorldType::GamePreview)   == static_cast<uint8>(EWorldType::GamePreview),   "ECSWorldType::GamePreview mismatch");
-static_assert(static_cast<uint8>(ECSWorldType::GameRPC)       == static_cast<uint8>(EWorldType::GameRPC),       "ECSWorldType::GameRPC mismatch");
-static_assert(static_cast<uint8>(ECSWorldType::Inactive)      == static_cast<uint8>(EWorldType::Inactive),      "ECSWorldType::Inactive mismatch");
-
 UCLASS(meta = (InternalType))
 class UCSWorldExtensions : public UBlueprintFunctionLibrary
 {


### PR DESCRIPTION
On current main with UE 5.7.2 I experienced compile errors caused by the ECSWorldType enum.

```
CSWorldExtensions.h(30,2): Error C2365 : "None": Erneute Definition; vorherige Definition war "Enumerator".
	None = EWorldType::None,
	^
```
(Sorry for the german, in english it would be `error C2365: 'None': redefinition; previous definition was 'enumerator'`)

I could reproduce this on an new and clean 5.7.2 project.
Seems like some people also reported the same issue on discord.

This PR fixes this issue by converting ECSWorldType to an enum class instead. 

The existing static_casts seem to work fine in my testing. 
I replaced the old static_assert with static_asserts checking each enum value. Not sure how we could catch epic adding new values to their enum though.