### PR TITLE
Force `dotnet sln new` to use `sln` format instead of `slnx` for now

### DIFF
--- a/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateSolution.cs
+++ b/Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateSolution.cs
@@ -10,6 +10,9 @@ public class GenerateSolution : BuildToolAction
 
         generateSln.StartInfo.ArgumentList.Add("new");
         generateSln.StartInfo.ArgumentList.Add("sln");
+        
+        generateSln.StartInfo.ArgumentList.Add("--format");
+        generateSln.StartInfo.ArgumentList.Add("sln");
 
         generateSln.StartInfo.ArgumentList.Add("-n");
         generateSln.StartInfo.ArgumentList.Add(Program.GetProjectNameAsManaged());


### PR DESCRIPTION
I have both dotnet 9 and 10 SDKs installed. This causes the `sln new` command used by `Managed/UnrealSharpPrograms/UnrealSharpBuildTool/Actions/GenerateSolution.cs` to generate an `slnx` file instead of `sln` (new default in dotnet 10). 
Some other place still seems to generate an `sln` file. This then causes "multiple project files found" errors.

I experienced these errors when creating a completely new U# project on UE 5.7.2.

This PR forces the format to `sln` for now until you decide to make make `slnx` the new default :)