### PR TITLE
Organized assetids into an appropriate inner type

### DIFF
--- a/Source/UnrealSharpRuntimeGlue/Private/DefaultGenerators/CSAssetManagerGlueGenerator.cpp
+++ b/Source/UnrealSharpRuntimeGlue/Private/DefaultGenerators/CSAssetManagerGlueGenerator.cpp
@@ -174,14 +174,12 @@ void UCSAssetManagerGlueGenerator::ProcessAssetIds()
 		{
 			FString PrimaryAssetName = AssetType.PrimaryAssetName.ToString();
 			PrimaryAssetName = PrimaryAssetName.Replace(TEXT("Default__"), TEXT(""));
-
-			FString AssetName = ClassName + TEXT("_") + PrimaryAssetName;
-			AssetName = FCSEditorUtilities::ReplaceSpecialCharacters(AssetName);
-			AssetName.RemoveFromEnd(TEXT("_C"));
-
+			PrimaryAssetName.RemoveFromEnd(TEXT("_C"));
+			PrimaryAssetName = FCSEditorUtilities::ReplaceSpecialCharacters(PrimaryAssetName);
+			
 			ScriptBuilder.AppendLine(FString::Printf(
 				TEXT("public static readonly FPrimaryAssetId %s = new(nameof(%s), \"%s\");"),
-				*AssetType.PrimaryAssetName.ToString(), *ClassName, *AssetType.PrimaryAssetName.ToString()));
+				*PrimaryAssetName, *AssetType.PrimaryAssetType.GetName().ToString(), *AssetType.PrimaryAssetName.ToString()));
 		}
 
 		ScriptBuilder.CloseBrace();


### PR DESCRIPTION
This PR reorganizes assetids into a more suitable structure.

Previously:
```CSharp
public static class AssetIds
{
	public static readonly FPrimaryAssetId ItemPrimaryDataAsset_Test = new("ItemPrimaryDataAsset", "Test");
	public static readonly FPrimaryAssetId PrimaryAssetLabel_Test = new("PrimaryAssetLabel", "Test");
}

AssetIds.ItemPrimaryDataAsset_Test
AssetIds.PrimaryAssetLabel_Test
```

Now:


```CSharp
public static class AssetIds
{
	public static class ItemPrimaryDataAsset
	{
		public static readonly FPrimaryAssetId Test = new(nameof(ItemPrimaryDataAsset), "Test");
	}

	public static class PrimaryAssetLabel
	{
		public static readonly FPrimaryAssetId Test = new(nameof(PrimaryAssetLabel), "Test");
	}

}

AssetIds.ItemPrimaryDataAsset.Test
AssetIds.PrimaryAssetLabel.Test
```

