### PR TITLE
Fixes a crash when logging a failure to generate a project.

### DIFF
--- a/Source/UnrealSharpEditor/Private/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/Private/UnrealSharpEditor.cpp
@@ -735,7 +735,7 @@ void FUnrealSharpEditorModule::AddNewProject(const FString& ModuleName, const FS
 
 	if (!UCSProcUtilities::InvokeUnrealSharpBuildTool(BUILD_ACTION_GENERATE_PROJECT, ExtraArguments))
 	{
-		UE_LOGFMT(LogUnrealSharpEditor, Error, "Failed to generate project %s in %s", *ModuleName, *ProjectParentFolder);
+		UE_LOGFMT(LogUnrealSharpEditor, Error, "Failed to generate project {0} in {1}", *ModuleName, *ProjectParentFolder);
 		return;
 	}
 	


### PR DESCRIPTION
`UE_LOGFMT` expects its parameters to be indexed or named using curly braces. The use of this macro in `UnrealSharpEditorModule::AddNewProject` used `%s` to specify parameters.