### PR TITLE
Exclude classes with 'SKEL_' prefix from FCSCompilerContext::TryFakeNativeClass

### DIFF
--- a/Source/UnrealSharpCompiler/Private/CSCompilerContext.cpp
+++ b/Source/UnrealSharpCompiler/Private/CSCompilerContext.cpp
@@ -292,9 +292,9 @@ void FCSCompilerContext::TryFakeNativeClass(UClass* Class)
 	// FGraphNodeClassHelper::BuildClassGraph()
 	// FStateTreeNodeClassCache::CacheClasses()
 	
-	// Ignore "SKEL_" classes, which otherwise may unintentionally show up in the systems reading from the AssetRegistry.
-	// This happened for C# state tree tasks, showing both the SKEL_ class and the "regular" class in the state tree task selection.
-	if (Class->GetName().StartsWith(TEXT("SKEL_")))
+	// Ignore Skeleton classes, which otherwise may unintentionally show up in the systems reading from the AssetRegistry.
+	// This happened for C# state tree tasks, showing both the Skeleton class and the regular class in the state tree task selection.
+	if (Cast<UCSSkeletonClass>(Class))
 	{
 		return;
 	}


### PR DESCRIPTION
It is my understanding that In `FCSCompilerContext::TryFakeNativeClass` the class flag `CLASS_NATIVE` is added to certain subclasses, so that they show up in certain contexts like the state tree task selection.

Internally unreal generates 'SKEL_' classes in addition to the "regular" classes, which also got the `CLASS_NATIVE` flag in `TryFakeNativeClass`. 
This lead to "duplicates" in the state tree task selection (and possibly other places), because both the SKEL_ class and the "regular" class was shown.

This PR adds a check in `TryFakeNativeClass` to exclude class names starting with "SKEL_". Unreal does this check the same way in some other places internally.

**Before PR:**
<img width="1025" height="341" alt="grafik" src="https://github.com/user-attachments/assets/392770ba-8877-4cc3-9e35-633bd284ce6f" />

<img width="1033" height="106" alt="grafik" src="https://github.com/user-attachments/assets/0efea065-627a-46de-a645-7a40ce92966a" />

<img width="1030" height="134" alt="grafik" src="https://github.com/user-attachments/assets/de3cbaf0-dcb3-4e71-a9b8-e234ec7817b4" />

**After PR:**
<img width="1025" height="133" alt="grafik" src="https://github.com/user-attachments/assets/187f184c-eb89-4068-9630-cb4a7385707f" />


I also quickly verified that C# BT tasks still show up in the BT task selection. Not sure if they also were "duplicated" before, since I don't use BTs.