### PR TITLE
try to fix problem: exit game but process remains running in the back…

### DIFF
--- a/Source/UnrealSharpCore/Private/CSManager.cpp
+++ b/Source/UnrealSharpCore/Private/CSManager.cpp
@@ -157,11 +157,9 @@ void UCSManager::Initialize()
 		return;
 	}
 
-#if WITH_EDITOR
 	// Remove this listener when the engine is shutting down.
 	// Otherwise, we'll get a crash when the GC cleans up all the UObject.
 	FCoreDelegates::OnPreExit.AddUObject(this, &UCSManager::OnEnginePreExit);
-#endif
 
 	GUObjectArray.AddUObjectDeleteListener(this);
 	FModuleManager::Get().OnModulesChanged().AddUObject(this, &UCSManager::OnModulesChanged);


### PR DESCRIPTION
The pr is try to fix exit game process problem

Operating System: Windows 10
Unreal Engine Version: 5.7.2
Issue Description:
I have a simple empty project with only an exit button(new project with nothing else). After packaging the game, clicking the exit button does not close the game; the process remains running in the background.

Is this caused by the #if WITH_EDITOR directive around line 163 in CSManager.cpp? 
I tried removing #if WITH_EDITOR and repackaging the game, and the game process now exits normally. 

However, I'm not sure if this modification is correct.