### PR TITLE
Fix array indexof comparing null objects

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp/Array.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Array.cs
@@ -149,7 +149,7 @@ public class TArray<T> : UnrealArrayBase<T>, IList<T>, IReadOnlyList<T>
         int numElements = Count;
         for (int i = 0; i < numElements; ++i)
         {
-            if (this[i].Equals(item))
+            if (this[i] is { } currentItem && currentItem.Equals(item))
             {
                 return i;
             }

--- a/Managed/UnrealSharp/UnrealSharp/Array.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Array.cs
@@ -149,7 +149,7 @@ public class TArray<T> : UnrealArrayBase<T>, IList<T>, IReadOnlyList<T>
         int numElements = Count;
         for (int i = 0; i < numElements; ++i)
         {
-            if (this[i] is { } currentItem && currentItem.Equals(item))
+            if (EqualityComparer<T>.Default.Equals(this[i], item))
             {
                 return i;
             }


### PR DESCRIPTION
I had a list like `IList<AActor?>(same thing happens without nullable)` and sometimes when i tried to remove a element, `UnrealSharp.sln/Array.cs` line 152 was throwing fatal error: `Object reference not set to an instance of an object` because some element is `null`. This pr aims to fix it. 

Im quite rusty on C# so i don't know if this the correct fix for all cases but fixed the problem i explained.