### PR TITLE
Refactor unload error to just a warning

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoader.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoader.cs
@@ -80,9 +80,6 @@ public static class PluginLoader
 
     public static void UnloadPlugin(string assemblyPath)
     {
-        const int warnThresholdMs = 200;
-        const int timeoutMs = 2000;
-
         TaskTracker.WaitForAllActiveTasks();
         
         string assemblyName = Path.GetFileNameWithoutExtension(assemblyPath);
@@ -99,37 +96,33 @@ public static class PluginLoader
             LogUnrealSharpPlugins.Log($"Unloading plugin {assemblyName}...");
 
             Stopwatch stopWatch = Stopwatch.StartNew();
-            bool hasWarned = false;
 
-            while (weakAlc.IsAlive)
+            int maxAttempts = 8;
+            int attempt = 0;
+            
+            while (weakAlc.IsAlive && attempt < maxAttempts)
             {
                 GC.Collect();
                 GC.WaitForPendingFinalizers();
-                GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true, true);
 
                 if (!weakAlc.IsAlive)
                 {
                     break;
                 }
                 
-                if (!hasWarned && stopWatch.ElapsedMilliseconds >= warnThresholdMs)
-                {
-                    LogUnrealSharpPlugins.LogWarning($"Plugin {assemblyName} is taking longer than expected to unload...");
-                    hasWarned = true;
-                }
-
-                if (stopWatch.ElapsedMilliseconds < timeoutMs)
-                {
-                    // https://github.com/dotnet/runtime/issues/124876
-                    LogUnrealSharpPlugins.LogWarning(
-                        $"'{assemblyName}' did not fully unload. " +
-                        "A known Visual Studio/Rider debugger issue may be holding strong references to assembly types, preventing the old assembly from being collected. " +
-                        "Hot reload will continue to work with some additional memory overhead. " +
-                        "Re-attaching the debugger usually releases these references and allows the assembly to be GC'd on the next hot reload.");
-                    return;
-                }
-                
                 Thread.Sleep(1);
+                attempt++;
+            }
+            
+            if (weakAlc.IsAlive)
+            {
+                // https://github.com/dotnet/runtime/issues/124876
+                LogUnrealSharpPlugins.LogWarning(
+                    $"'{assemblyName}' did not fully unload. " +
+                    "A known Visual Studio/Rider debugger issue may be holding strong references to assembly types, preventing the old assembly from being collected. " +
+                    "Hot reload will continue to work with some additional memory overhead. " +
+                    "Re-attaching the debugger usually releases these references and allows the assembly to be GC'd on the next hot reload.");
+                return;
             }
 
             LogUnrealSharpPlugins.Log($"{assemblyName} unloaded successfully in {stopWatch.ElapsedMilliseconds}ms.");

--- a/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoader.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/PluginLoader.cs
@@ -48,7 +48,7 @@ public static class PluginLoader
             
             StartupJobManager.RunForAssembly(loadedAssembly);
             
-            LogUnrealSharpPlugins.Log($"Successfully loaded plugin: {assemblyName}");
+            LogUnrealSharpPlugins.Log($"Successfully loaded plugin: '{assemblyName}' at '{assemblyPath}'");
             return loadedAssembly;
         }
         catch (Exception ex)
@@ -78,7 +78,7 @@ public static class PluginLoader
         return weakRefLoadContext;
     }
 
-    public static bool UnloadPlugin(string assemblyPath)
+    public static void UnloadPlugin(string assemblyPath)
     {
         const int warnThresholdMs = 200;
         const int timeoutMs = 2000;
@@ -91,7 +91,7 @@ public static class PluginLoader
         if (weakAlc == null)
         {
             LogUnrealSharpPlugins.Log($"Plugin {assemblyName} is not loaded or already removed from registry.");
-            return true;
+            return;
         }
 
         try
@@ -114,24 +114,29 @@ public static class PluginLoader
                 
                 if (!hasWarned && stopWatch.ElapsedMilliseconds >= warnThresholdMs)
                 {
+                    LogUnrealSharpPlugins.LogWarning($"Plugin {assemblyName} is taking longer than expected to unload...");
                     hasWarned = true;
-                    LogUnrealSharpPlugins.LogError($"Unloading {assemblyName} is taking longer than expected...");
                 }
 
-                if (stopWatch.ElapsedMilliseconds >= timeoutMs)
+                if (stopWatch.ElapsedMilliseconds < timeoutMs)
                 {
-                    LogUnrealSharpPlugins.LogError($"Failed to unload {assemblyName} within {timeoutMs}ms. Common causes: static references, GCHandles, background threads.");
-                    return false;
+                    // https://github.com/dotnet/runtime/issues/124876
+                    LogUnrealSharpPlugins.LogWarning(
+                        $"'{assemblyName}' did not fully unload. " +
+                        "A known Visual Studio/Rider debugger issue may be holding strong references to assembly types, preventing the old assembly from being collected. " +
+                        "Hot reload will continue to work with some additional memory overhead. " +
+                        "Re-attaching the debugger usually releases these references and allows the assembly to be GC'd on the next hot reload.");
+                    return;
                 }
+                
+                Thread.Sleep(1);
             }
 
             LogUnrealSharpPlugins.Log($"{assemblyName} unloaded successfully in {stopWatch.ElapsedMilliseconds}ms.");
-            return true;
         }
         catch (Exception exception)
         {
             LogUnrealSharpPlugins.LogError($"An error occurred while unloading the plugin: {exception}");
-            return false;
         }
     }
     

--- a/Managed/UnrealSharp/UnrealSharp.Plugins/PluginsCallbacks.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Plugins/PluginsCallbacks.cs
@@ -9,7 +9,7 @@ namespace UnrealSharp.Plugins;
 public unsafe struct PluginsCallbacks
 {
     public delegate* unmanaged<char*, NativeBool, IntPtr> LoadPlugin;
-    public delegate* unmanaged<char*, NativeBool> UnloadPlugin;
+    public delegate* unmanaged<char*, void> UnloadPlugin;
     
     [UnmanagedCallersOnly]
     private static nint ManagedLoadPlugin(char* assemblyPath, NativeBool isCollectible)
@@ -25,10 +25,9 @@ public unsafe struct PluginsCallbacks
     }
 
     [UnmanagedCallersOnly]
-    private static NativeBool ManagedUnloadPlugin(char* assemblyPath)
+    private static void ManagedUnloadPlugin(char* assemblyPath)
     {
-        string assemblyPathStr = new(assemblyPath);
-        return PluginLoader.UnloadPlugin(assemblyPathStr).ToNativeBool();
+        PluginLoader.UnloadPlugin(new string(assemblyPath));
     }
 
     public static void Initialize(PluginsCallbacks* outCallbacks)

--- a/Source/UnrealSharpCore/Private/CSManagedAssembly.cpp
+++ b/Source/UnrealSharpCore/Private/CSManagedAssembly.cpp
@@ -77,18 +77,18 @@ bool UCSManagedAssembly::LoadAssembly()
 	return true;
 }
 
-bool UCSManagedAssembly::UnloadAssembly()
+void UCSManagedAssembly::UnloadAssembly()
 {
 	if (!bIsCollectible)
 	{
 		UE_LOGFMT(LogUnrealSharp, Warning, "Assembly {0} is not collectible and will not be unloaded. It will be unloaded when the editor shuts down.", GetName());
-		return true;
+		return;
 	}
 	
 	if (!IsAssemblyLoaded())
 	{
 		UE_LOGFMT(LogUnrealSharp, Display, "{0} is already unloaded", GetName());
-		return true;
+		return;
 	}
 	
 	const FGCHandleIntPtr AssemblyHandle = AssemblyGCHandle->GetHandle();
@@ -104,7 +104,7 @@ bool UCSManagedAssembly::UnloadAssembly()
 	AssemblyGCHandle.Reset();
 
 	FCSAssemblyEvents::OnAssemblyUnloaded.Broadcast(this);
-	return GetManagedPluginCallbacks().UnloadPlugin(*AssemblyFilePath);
+	GetManagedPluginCallbacks().UnloadPlugin(*AssemblyFilePath);
 }
 
 TSharedPtr<FGCHandle> UCSManagedAssembly::FindTypeHandle(const FCSFieldName& FieldName)

--- a/Source/UnrealSharpCore/Public/CSManagedAssembly.h
+++ b/Source/UnrealSharpCore/Public/CSManagedAssembly.h
@@ -31,7 +31,7 @@ public:
 	void Initialize(FStringView InAssemblyPath, bool bIsCollectible = false);
 
 	UNREALSHARPCORE_API bool LoadAssembly();
-	UNREALSHARPCORE_API bool UnloadAssembly();
+	UNREALSHARPCORE_API void UnloadAssembly();
 
 	UNREALSHARPCORE_API bool IsAssemblyLoading() const { return bIsLoading; }
 	UNREALSHARPCORE_API bool IsAssemblyLoaded() const { return AssemblyGCHandle.IsValid() && !AssemblyGCHandle->IsNull(); }

--- a/Source/UnrealSharpCore/Public/CSManagedPluginCallbacks.h
+++ b/Source/UnrealSharpCore/Public/CSManagedPluginCallbacks.h
@@ -5,7 +5,7 @@
 struct FCSManagedPluginCallbacks
 {
 	using LoadPluginCallback = FGCHandleIntPtr(__stdcall*)(const TCHAR*, bool);
-	using UnloadPluginCallback = bool(__stdcall*)(const TCHAR*);
+	using UnloadPluginCallback = void(__stdcall*)(const TCHAR*);
 
 	LoadPluginCallback LoadPlugin = nullptr;
 	UnloadPluginCallback UnloadPlugin = nullptr;

--- a/Source/UnrealSharpEditor/Private/HotReload/CSHotReloadSubsystem.cpp
+++ b/Source/UnrealSharpEditor/Private/HotReload/CSHotReloadSubsystem.cpp
@@ -112,13 +112,6 @@ void UCSHotReloadSubsystem::PerformHotReload()
 		return;
 	}
 	
-	if (CurrentHotReloadStatus == FailedToUnload)
-	{
-		// If we failed to unload an assembly, we can't hot reload until the editor is restarted.
-		UE_LOGFMT(LogUnrealSharpEditor, Error, "Hot reload is disabled until the editor is restarted.");
-		return;
-	}
-	
 	UE_LOGFMT(LogUnrealSharpEditor, Display, "Starting C# Hot Reload...");
 	
 	CurrentHotReloadStatus = Active;
@@ -144,23 +137,7 @@ void UCSHotReloadSubsystem::PerformHotReload()
 	
 	for (UCSManagedAssembly* Assembly : AssembliesSortedByDependencies)
 	{
-		if (Assembly->UnloadAssembly())
-		{
-			continue;
-		}
-		
-		CurrentHotReloadStatus = FailedToUnload;
-
-		FString ErrorMessage = FString::Printf(
-			TEXT("Failed to unload assembly: %s\n\n"
-				"C# Hot Reload has been disabled for the remainder of this editor session.\n\n"
-				"Common causes include:\n"
-				"- Active references preventing unload (strong GC handles)\n"
-				"- Running or unfinished managed threads\n"
-				"- Dependent assemblies still loaded\n"), *Assembly->GetName());
-
-		FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(ErrorMessage), LOCTEXT("HotReloadFailure", "C# Hot Reload Failed"));
-		return;
+		Assembly->UnloadAssembly();
 	}
 	
 	for (int32 i = AssembliesSortedByDependencies.Num() - 1; i >= 0; --i)

--- a/Source/UnrealSharpEditor/Private/UnrealSharpEditor.cpp
+++ b/Source/UnrealSharpEditor/Private/UnrealSharpEditor.cpp
@@ -648,11 +648,6 @@ void FUnrealSharpEditorModule::RegisterToolbar()
 		{
 			if (UCSHotReloadSubsystem* HotReloadSubsystem = UCSHotReloadSubsystem::Get())
 			{
-				if (HotReloadSubsystem->HasHotReloadFailed())
-				{
-					return UnrealSharp::Icons::GetUnrealSharpIcon_HotReloadFailed();
-				}
-	
 				if (HotReloadSubsystem->HasPendingHotReloadChanges())
 				{
 					return UnrealSharp::Icons::GetUnrealSharpIcon_Modified();

--- a/Source/UnrealSharpEditor/Public/HotReload/CSHotReloadSubsystem.h
+++ b/Source/UnrealSharpEditor/Public/HotReload/CSHotReloadSubsystem.h
@@ -13,8 +13,6 @@ enum EHotReloadStatus : uint8
 	Inactive,
 	// Actively Hot Reloading
 	Active,
-	// Failed to unload an assembly during Hot Reload
-	FailedToUnload,
 	// Failed to compile the managed code during Hot Reload
 	FailedToCompile
 };
@@ -43,7 +41,6 @@ public:
 
 	UNREALSHARPEDITOR_API bool IsHotReloading() const { return CurrentHotReloadStatus == Active; }
 	UNREALSHARPEDITOR_API bool HasPendingHotReloadChanges() const;
-	UNREALSHARPEDITOR_API bool HasHotReloadFailed() const { return CurrentHotReloadStatus == FailedToUnload || CurrentHotReloadStatus == FailedToCompile; }
 	
 	UNREALSHARPEDITOR_API void PerformHotReload();
 	

--- a/Source/UnrealSharpUtilities/Private/CSBuildUtilties.cpp
+++ b/Source/UnrealSharpUtilities/Private/CSBuildUtilties.cpp
@@ -67,7 +67,7 @@ bool UnrealSharp::Build::BuildUserSolution(const FCSCommandError& OnError)
 	
 	TMap<FString, FString> Arguments;
 	Arguments.Add(TEXT("OutputPath"), Paths::MakeQuotedPath(Paths::GetUserAssemblyDirectory()));
-	Arguments.Add(TEXT("BuildConfig"), LexToString(FApp::GetBuildConfiguration()));
+	Arguments.Add(TEXT("TargetConfiguration"), LexToString(FApp::GetBuildConfiguration()));
 	
 	if (!GetDefault<UCSUnrealSharpUtilitiesSettings>()->bShowBuildWarnings)
 	{


### PR DESCRIPTION
I’ve been investigating some more of the unload issues, and about 99% of the time, it's just Visual Studio or Rider holding hard references to types you’ve inspected while debugging, which I've flagged as an issue before (https://github.com/dotnet/runtime/issues/124876)

I’ve decided to change this to a warning instead of an error, so you won't get annoyed by unload errors. Once U# starts the unload process, C++/C# completely drops the old assembly. The debugger is the only thing still holding onto it in memory, so it won't cause any conflicts with your new code.

Hot reload will keep working fine. You might see a tiny bit of extra memory usage from extra assemblies loaded, but just reattaching your debugger will clear those references and will get cleaned up on next GC.