### PR TITLE
Fix extension methods with DetermineOutputType parameter

### DIFF
--- a/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/FunctionExporter.cs
@@ -711,7 +711,11 @@ public class FunctionExporter
             {
                 PropertyTranslator translator = ParameterTranslators[0];
                 string paramType = ClassBeingExtended != null ? ClassBeingExtended.GetFullManagedName() : translator.GetManagedType(SelfParameter!);
-                builder.AppendLine($"{Modifiers}{returnType} {FunctionName}<{genericTypeString}>(this {paramType} {SelfParameter!.GetParameterName()}, {overload.ParamStringApiWithDefaults})");
+                string arguments = $"this {paramType} {SelfParameter!.GetParameterName()}";
+                if (!String.IsNullOrEmpty(overload.ParamStringApiWithDefaults)) {
+                    arguments += $", {overload.ParamStringApiWithDefaults}";
+                }
+                builder.AppendLine($"{Modifiers}{returnType} {FunctionName}<{genericTypeString}>({arguments})");
                 builder.Indent();
                 
                 foreach ((string genericType, string constraint) in genericTypes.Zip(genericConstraints))


### PR DESCRIPTION
I found that extension methods with DetermineOutputType parameter would generate invalid code due to extra commas in the function argument list.

I *think* this is the right fix and in my testing it seems to address the issue but I'm not 100% positive. Hopefully this works.