### PR TITLE
Fix static async ufunction crash because of DefaultToSelf metadata

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/UnrealAsyncFunction.cs
+++ b/Managed/UnrealSharp/UnrealSharp.GlueGenerator/UnrealSharp.GlueGenerator/NativeTypes/UnrealAsyncFunction.cs
@@ -353,7 +353,10 @@ public record UnrealAsyncFunction : UnrealFunctionBase
         factory.Properties = new EquatableList<UnrealProperty>(factoryParameters);
         factory.ReturnType = returnValue;
 
-        factory.AddMetaData("DefaultToSelf", TargetParamName);
+        if (!isStatic)
+        {
+            factory.AddMetaData("DefaultToSelf", TargetParamName);
+        }
         factory.AddMetaData("BlueprintInternalUseOnly", "true");
         factory.AddMetaDataRange(MetaData);
 


### PR DESCRIPTION
`UnrealAsyncFunction.cs` line 356 adds `DefaultToSelf` metadata to async functions with `Target` value.
This causes crash in `UK2Node_BaseAsyncTask.cpp` line 369 with `static async ufunctions` because there is no `Target pin` .

 Crash happens after connecting input pin and compiling the bp. This pr aims to fix it. 