### PR TITLE
Implementation of WorldContextScope

### DIFF
--- a/Managed/UnrealSharp/UnrealSharp.Core/Interop/Bind_UCSManager.cs
+++ b/Managed/UnrealSharp/UnrealSharp.Core/Interop/Bind_UCSManager.cs
@@ -9,14 +9,21 @@ public static unsafe partial class Bind_UCSManager
     public static delegate* unmanaged<IntPtr, IntPtr, IntPtr> FindOrCreateManagedInterfaceWrapper;
     public static delegate* unmanaged<IntPtr> GetCurrentWorldContext;
     public static delegate* unmanaged<IntPtr> GetCurrentWorldPtr;
+    public static delegate* unmanaged<IntPtr, void> PushWorldContext;
+    public static delegate* unmanaged<void> PopWorldContext;
     
-    public static UnrealSharpObject WorldContextObject
+    public static UnrealSharpObject? WorldContextObject
     {
         get
         {
             IntPtr worldContextObject = CallGetCurrentWorldContext();
+            if (worldContextObject == IntPtr.Zero)
+            {
+                return null;
+            }
+
             IntPtr handle = CallFindManagedObject(worldContextObject);
-            return GCHandleUtilities.GetObjectFromHandlePtr<UnrealSharpObject>(handle)!;
+            return GCHandleUtilities.GetObjectFromHandlePtr<UnrealSharpObject>(handle);
         }
     }
 }

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/World.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/Engine/World.cs
@@ -8,13 +8,27 @@ public partial class UWorld
     /// <summary>
     /// The URL that was used when loading this World.
     /// </summary>
-    public FURL URL => UCSWorldExtensions.WorldURL();
+    public FURL URL
+    {
+        get
+        {
+            using var worldContext = global::UnrealSharp.WorldContext.Push(this);
+            return UCSWorldExtensions.WorldURL();
+        }
+    }
 
     /// <summary>
     /// Get the game mode of this world.
     /// </summary>
     /// <returns>The game mode of this world.</returns>
-    public AGameModeBase GameMode => UGameplayStatics.GameMode;
+    public AGameModeBase GameMode
+    {
+        get
+        {
+            using var worldContext = global::UnrealSharp.WorldContext.Push(this);
+            return UGameplayStatics.GameMode;
+        }
+    }
     
     /// <summary>
     /// Get the game mode of this world as a specific type.
@@ -27,7 +41,14 @@ public partial class UWorld
     /// Get the game instance of this world.
     /// </summary>
     /// <returns>The game instance of this world.</returns>
-    public UGameInstance GameInstance => UGameplayStatics.GameInstance;
+    public UGameInstance GameInstance
+    {
+        get
+        {
+            using var worldContext = global::UnrealSharp.WorldContext.Push(this);
+            return UGameplayStatics.GameInstance;
+        }
+    }
     
     /// <summary>
     /// Get the game instance of this world as a specific type.
@@ -40,7 +61,14 @@ public partial class UWorld
     /// Get the game state of this world.
     /// </summary>
     /// <returns>The game state of this world.</returns>
-    public AGameStateBase GameState => UGameplayStatics.GameState;
+    public AGameStateBase GameState
+    {
+        get
+        {
+            using var worldContext = global::UnrealSharp.WorldContext.Push(this);
+            return UGameplayStatics.GameState;
+        }
+    }
     
     /// <summary>
     /// Get the game state of this world as a specific type.
@@ -57,7 +85,14 @@ public partial class UWorld
     /// <summary>
     /// Returns the type of this world
     /// </summary>
-    public ECSWorldType WorldType => UCSWorldExtensions.WorldType;
+    public ECSWorldType WorldType
+    {
+        get
+        {
+            using var worldContext = global::UnrealSharp.WorldContext.Push(this);
+            return UCSWorldExtensions.WorldType;
+        }
+    }
 
     /// <summary>
     /// Returns true if this world is a game world (Game, PIE, GamePreview, GameRPC)
@@ -119,6 +154,7 @@ public partial class UWorld
     /// <param name="bShouldSkipGameNotify">Whether to notify the clients/game or not</param>
     public void ServerTravel(string url, bool bAbsolute = false, bool bShouldSkipGameNotify = false)
 	{
+		using var worldContext = global::UnrealSharp.WorldContext.Push(this);
 		UCSWorldExtensions.ServerTravel(url, bAbsolute, bShouldSkipGameNotify);
 	}
     
@@ -141,6 +177,7 @@ public partial class UWorld
 	/// <param name="isAbsolute">If true, URL is absolute; otherwise, it is relative.</param>
     public void SeamlessTravel(string url, bool isAbsolute = false)
 	{
+		using var worldContext = global::UnrealSharp.WorldContext.Push(this);
 		UCSWorldExtensions.SeamlessTravel(url, isAbsolute);
 	}
 }

--- a/Managed/UnrealSharp/UnrealSharp/Extensions/UnrealSharpAsync/AsyncLoadUtilities.cs
+++ b/Managed/UnrealSharp/UnrealSharp/Extensions/UnrealSharpAsync/AsyncLoadUtilities.cs
@@ -7,13 +7,22 @@ namespace UnrealSharp.UnrealSharpAsync;
 
 internal static class AsyncLoadUtilities
 {
-    internal static UObject WorldContextObject
+    internal static UWorld World
     {
         get
         {
-            IntPtr worldContextObject = Bind_UCSManager.CallGetCurrentWorldContext();
-            IntPtr worldContextHandle = Bind_UCSManager.CallFindManagedObject(worldContextObject);
-            return GCHandleUtilities.GetObjectFromHandlePtr<UObject>(worldContextHandle)!;
+            if (Bind_UCSManager.WorldContextObject is not UObject worldContextObject || !worldContextObject.IsValid())
+            {
+                throw new InvalidOperationException("Async loading requires a valid world context.");
+            }
+
+            UWorld? world = worldContextObject as UWorld ?? worldContextObject.World;
+            if (world is null || !world.IsValid())
+            {
+                throw new InvalidOperationException("The current world context does not resolve to a valid world.");
+            }
+
+            return world;
         }
     }
     
@@ -51,7 +60,7 @@ internal partial class UCSAsyncLoadSoftPtr
     internal static async Task<IReadOnlyList<FSoftObjectPath>> LoadAsync(FSoftObjectPath softObjectPath) => await LoadAsync(new List<FSoftObjectPath> { softObjectPath });
     internal static async Task<IReadOnlyList<FSoftObjectPath>> LoadAsync(IReadOnlyList<FSoftObjectPath> softObjectPaths)
     {
-        UWorld world = AsyncLoadUtilities.WorldContextObject.World;
+        UWorld world = AsyncLoadUtilities.World;
         
         UCSAsyncLoadSoftPtr loader = NewObject<UCSAsyncLoadSoftPtr>(world);
         loader._loadedPaths = softObjectPaths;
@@ -90,7 +99,7 @@ internal partial class UCSAsyncLoadPrimaryDataAssets
     internal static async Task<IList<FPrimaryAssetId>> LoadAsync(FPrimaryAssetId primaryAssetId, IList<FName>? assetBundles = null) => await LoadAsync(new List<FPrimaryAssetId> { primaryAssetId }, assetBundles);
     internal static async Task<IList<FPrimaryAssetId>> LoadAsync(IList<FPrimaryAssetId> primaryAssetIds, IList<FName>? assetBundles = null)
     {
-        UWorld world = AsyncLoadUtilities.WorldContextObject.World;
+        UWorld world = AsyncLoadUtilities.World;
         
         UCSAsyncLoadPrimaryDataAssets loader = NewObject<UCSAsyncLoadPrimaryDataAssets>(world);
         loader._loadedIds = primaryAssetIds;

--- a/Managed/UnrealSharp/UnrealSharp/UnrealSynchronizationContext.cs
+++ b/Managed/UnrealSharp/UnrealSharp/UnrealSynchronizationContext.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using UnrealSharp.Core;
 using UnrealSharp.Core.Interop;
 using UnrealSharp.CoreUObject;
+using UnrealSharp.Engine;
 using UnrealSharp.Interop;
 
 namespace UnrealSharp;
@@ -243,9 +244,15 @@ public sealed class UnrealSynchronizationContext : SynchronizationContext
         {
             throw new InvalidOperationException("World context object is not valid.");
         }
-            
+
+        UWorld? world = worldContext as UWorld ?? worldContext.World;
+        if (world is null || !world.IsValid())
+        {
+            throw new InvalidOperationException("World context object does not resolve to a valid world.");
+        }
+
         _thread = thread;
-        _worldContext = new TWeakObjectPtr<UObject>(worldContext.World);
+        _worldContext = new TWeakObjectPtr<UObject>(world);
     }
 
     public override void Post(SendOrPostCallback d, object? state) => RunOnThread(_worldContext, _thread, () => d(state));

--- a/Managed/UnrealSharp/UnrealSharp/WorldContext.cs
+++ b/Managed/UnrealSharp/UnrealSharp/WorldContext.cs
@@ -1,0 +1,55 @@
+using UnrealSharp.Core.Interop;
+using UnrealSharp.CoreUObject;
+
+namespace UnrealSharp;
+
+/// <summary>
+/// Provides access to the world context active for the current Unreal thread.
+/// </summary>
+public static class WorldContext
+{
+    /// <summary>
+    /// The currently scoped world context.
+    /// </summary>
+    public static UObject? Current => Bind_UCSManager.WorldContextObject as UObject;
+
+    /// <summary>
+    /// Temporarily uses the world resolved from <paramref name="worldContextObject"/> for generated function calls.
+    /// The returned scope must be disposed on the same thread before awaiting.
+    /// </summary>
+    public static FWorldContextScope Push(UObject worldContextObject)
+    {
+        ArgumentNullException.ThrowIfNull(worldContextObject);
+        if (!worldContextObject.IsValid())
+        {
+            throw new ArgumentException("World context object is not valid.", nameof(worldContextObject));
+        }
+
+        return new FWorldContextScope(worldContextObject);
+    }
+}
+
+/// <summary>
+/// A synchronous scope which restores the previous world context when disposed.
+/// </summary>
+public ref struct FWorldContextScope
+{
+    private bool _active;
+
+    internal FWorldContextScope(UObject worldContextObject)
+    {
+        Bind_UCSManager.CallPushWorldContext(worldContextObject.NativeObject);
+        _active = true;
+    }
+
+    public void Dispose()
+    {
+        if (!_active)
+        {
+            return;
+        }
+
+        Bind_UCSManager.CallPopWorldContext();
+        _active = false;
+    }
+}

--- a/Source/UnrealSharpAsync/Private/CSAsyncActionBase.cpp
+++ b/Source/UnrealSharpAsync/Private/CSAsyncActionBase.cpp
@@ -1,8 +1,12 @@
 ﻿#include "CSAsyncActionBase.h"
 
+#include "Engine/GameInstance.h"
+#include "Engine/World.h"
+
 void UCSAsyncActionBase::Destroy()
 {
-	if (UGameInstance* GameInstance = GetWorld()->GetGameInstance())
+	UWorld* World = GetWorld();
+	if (UGameInstance* GameInstance = World ? World->GetGameInstance() : nullptr)
 	{
 		GameInstance->UnregisterReferencedObject(this);
 	}
@@ -30,7 +34,8 @@ void UCSAsyncActionBase::InitializeManagedCallback(FGCHandleIntPtr Callback)
 {
 	ManagedCallback = FGCHandle(Callback);
 
-	if (UGameInstance* GameInstance = GetWorld()->GetGameInstance())
+	UWorld* World = GetWorld();
+	if (UGameInstance* GameInstance = World ? World->GetGameInstance() : nullptr)
 	{
 		GameInstance->RegisterReferencedObject(this);
 	}

--- a/Source/UnrealSharpCore/Private/Binds/Bind_UCSManager.cpp
+++ b/Source/UnrealSharpCore/Private/Binds/Bind_UCSManager.cpp
@@ -20,12 +20,23 @@ DECLARE_UNREALSHARP_BINDER(Bind_UCSManager)
 
 	void* GetCurrentWorldPtr()
 	{
-		UObject* WorldContext = UCSManager::Get().GetCurrentWorldContext();
-		return GEngine->GetWorldFromContextObject(WorldContext, EGetWorldErrorMode::ReturnNull);
+		return UCSManager::Get().GetCurrentWorldContext();
+	}
+
+	void PushWorldContext(UObject* WorldContextObject)
+	{
+		UCSManager::Get().PushWorldContext(WorldContextObject, false);
+	}
+
+	void PopWorldContext()
+	{
+		UCSManager::Get().PopWorldContext();
 	}
 	
 	BIND_UNREALSHARP_FUNCTION(FindManagedObject)
 	BIND_UNREALSHARP_FUNCTION(FindOrCreateManagedInterfaceWrapper)
 	BIND_UNREALSHARP_FUNCTION(GetCurrentWorldContext)
 	BIND_UNREALSHARP_FUNCTION(GetCurrentWorldPtr)
+	BIND_UNREALSHARP_FUNCTION(PushWorldContext)
+	BIND_UNREALSHARP_FUNCTION(PopWorldContext)
 }

--- a/Source/UnrealSharpCore/Private/Binds/Bind_UGameInstance.cpp
+++ b/Source/UnrealSharpCore/Private/Binds/Bind_UGameInstance.cpp
@@ -1,15 +1,25 @@
 ﻿#include "CSManager.h"
 
+#include "Engine/GameInstance.h"
+#include "Engine/World.h"
+
 DECLARE_UNREALSHARP_BINDER(Bind_UGameInstance)
 {
 	void* GetGameInstanceSubsystem(UClass* SubsystemClass, UObject* WorldContextObject)
 	{
-		if (!IsValid(WorldContextObject))
+		if (!IsValid(WorldContextObject) || !IsValid(SubsystemClass))
 		{
 			return nullptr;
 		}
-	
-		UGameInstanceSubsystem* GameInstanceSubsystem = WorldContextObject->GetWorld()->GetGameInstance()->GetSubsystemBase(SubsystemClass);
+
+		UWorld* World = UCSManager::Get().ResolveWorldContext(WorldContextObject);
+		UGameInstance* GameInstance = IsValid(World) ? World->GetGameInstance() : nullptr;
+		if (!IsValid(GameInstance))
+		{
+			return nullptr;
+		}
+
+		UGameInstanceSubsystem* GameInstanceSubsystem = GameInstance->GetSubsystemBase(SubsystemClass);
 		return UCSManager::Get().FindManagedObject(GameInstanceSubsystem);
 	}
 	

--- a/Source/UnrealSharpCore/Private/Binds/Bind_UWorld.cpp
+++ b/Source/UnrealSharpCore/Private/Binds/Bind_UWorld.cpp
@@ -1,4 +1,5 @@
 ﻿#include "CSManager.h"
+#include "Engine/World.h"
 #include "Kismet/KismetSystemLibrary.h"
 
 DECLARE_UNREALSHARP_BINDER(Bind_UWorld)
@@ -17,17 +18,26 @@ DECLARE_UNREALSHARP_BINDER(Bind_UWorld)
 			return;
 		}
 
-		Object->GetWorld()->GetTimerManager().ClearTimer(*TimerHandle);
+		if (UWorld* World = Object->GetWorld())
+		{
+			World->GetTimerManager().ClearTimer(*TimerHandle);
+		}
 	}
 
 	void* GetWorldSubsystem(UClass* SubsystemClass, UObject* WorldContextObject)
 	{
-		if (!IsValid(WorldContextObject))
+		if (!IsValid(WorldContextObject) || !IsValid(SubsystemClass))
 		{
 			return nullptr;
 		}
-	
-		UWorldSubsystem* WorldSubsystem = WorldContextObject->GetWorld()->GetSubsystemBase(SubsystemClass);
+
+		UWorld* World = UCSManager::Get().ResolveWorldContext(WorldContextObject);
+		if (!IsValid(World))
+		{
+			return nullptr;
+		}
+
+		UWorldSubsystem* WorldSubsystem = World->GetSubsystemBase(SubsystemClass);
 		return UCSManager::Get().FindManagedObject(WorldSubsystem);
 	}
 
@@ -37,7 +47,9 @@ DECLARE_UNREALSHARP_BINDER(Bind_UWorld)
 		{
 			return nullptr;
 		}
-		return (void*)WorldContextObject->GetWorld()->GetNetMode();
+
+		UWorld* World = UCSManager::Get().ResolveWorldContext(WorldContextObject);
+		return IsValid(World) ? (void*)World->GetNetMode() : nullptr;
 	}
 	
 	BIND_UNREALSHARP_FUNCTION(SetTimer)

--- a/Source/UnrealSharpCore/Private/CSManagedDelegate.cpp
+++ b/Source/UnrealSharpCore/Private/CSManagedDelegate.cpp
@@ -1,8 +1,7 @@
 ﻿#include "CSManagedDelegate.h"
 
 #include "CSManager.h"
-#include "Engine/World.h"
-
+#include "CSWorldContextScope.h"
 void FCSManagedDelegate::Invoke(UObject* WorldContextObject, bool bDispose)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(FCSManagedDelegate::Invoke);
@@ -13,18 +12,7 @@ void FCSManagedDelegate::Invoke(UObject* WorldContextObject, bool bDispose)
 		return;
 	}
 
-	// Prefer using World as context since it's more stable
-	UObject* WorldContext = nullptr;
-	if (IsValid(WorldContextObject))
-	{
-		UWorld* World = WorldContextObject->GetWorld();
-		WorldContext = World ? World : WorldContextObject;
-	}
-
-	if (WorldContext)
-	{
-		UCSManager::Get().SetCurrentWorldContext(WorldContext);
-	}
+	FCSWorldContextScope WorldContextScope(WorldContextObject);
 
 	GetManagedCallbacks().InvokeDelegate(CallbackHandle.GetHandle());
 

--- a/Source/UnrealSharpCore/Private/CSWorldContextScope.cpp
+++ b/Source/UnrealSharpCore/Private/CSWorldContextScope.cpp
@@ -1,0 +1,78 @@
+#include "CSWorldContextScope.h"
+
+#include "CSManager.h"
+#include "UnrealSharpCore.h"
+
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+
+namespace
+{
+	struct FCSWorldContextThreadState
+	{
+		TArray<TWeakObjectPtr<UWorld>> Stack;
+	};
+
+	thread_local FCSWorldContextThreadState GWorldContextThreadState;
+}
+
+UWorld* UCSManager::ResolveWorldContext(UObject* WorldContextObject) const
+{
+	if (!IsValid(WorldContextObject))
+	{
+		return nullptr;
+	}
+
+	if (UWorld* World = Cast<UWorld>(WorldContextObject))
+	{
+		return World;
+	}
+
+	if (UWorld* World = WorldContextObject->GetWorld(); IsValid(World))
+	{
+		return World;
+	}
+
+	return GEngine
+		? GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::ReturnNull)
+		: nullptr;
+}
+
+void UCSManager::PushWorldContext(UObject* WorldContextObject, bool bInheritIfUnresolved)
+{
+	UWorld* World = ResolveWorldContext(WorldContextObject);
+	if (!World && bInheritIfUnresolved && !GWorldContextThreadState.Stack.IsEmpty())
+	{
+		World = GWorldContextThreadState.Stack.Last().Get();
+	}
+
+	GWorldContextThreadState.Stack.Add(World);
+}
+
+void UCSManager::PopWorldContext()
+{
+	if (GWorldContextThreadState.Stack.IsEmpty())
+	{
+		UE_LOG(LogUnrealSharp, Error, TEXT("Attempted to pop an empty world context stack"));
+		return;
+	}
+
+	GWorldContextThreadState.Stack.Pop(EAllowShrinking::No);
+}
+
+UWorld* UCSManager::GetCurrentWorldContext() const
+{
+	return GWorldContextThreadState.Stack.IsEmpty()
+		? nullptr
+		: GWorldContextThreadState.Stack.Last().Get();
+}
+
+FCSWorldContextScope::FCSWorldContextScope(UObject* WorldContextObject, bool bInheritIfUnresolved)
+{
+	UCSManager::Get().PushWorldContext(WorldContextObject, bInheritIfUnresolved);
+}
+
+FCSWorldContextScope::~FCSWorldContextScope()
+{
+	UCSManager::Get().PopWorldContext();
+}

--- a/Source/UnrealSharpCore/Private/Functions/CSFunction.cpp
+++ b/Source/UnrealSharpCore/Private/Functions/CSFunction.cpp
@@ -2,14 +2,86 @@
 #include "CSManagedGCHandle.h"
 #include "CSManager.h"
 #include "CSUnrealSharpSettings.h"
+#include "CSWorldContextScope.h"
 #include "Types/CSClass.h"
 #include "Types/CSSkeletonClass.h"
-#include "Engine/World.h"
+#include "UObject/UnrealType.h"
 
 #include "Blueprint/BlueprintExceptionInfo.h"
 
+FObjectPropertyBase* UCSFunctionBase::FindWorldContextProperty(UFunction* Function, bool& bHasWorldContextMetadata)
+{
+	const FString WorldContextParameterName = Function->GetMetaData(TEXT("WorldContext"));
+	bHasWorldContextMetadata = !WorldContextParameterName.IsEmpty();
+
+	if (bHasWorldContextMetadata)
+	{
+		return FindFProperty<FObjectPropertyBase>(Function, *WorldContextParameterName);
+	}
+
+	// Match the names recognized by the managed glue generator for native APIs
+	// which omit explicit WorldContext metadata.
+	static const FName WorldContextObjectName(TEXT("WorldContextObject"));
+	static const FName WorldContextName(TEXT("WorldContext"));
+	static const FName ContextObjectName(TEXT("ContextObject"));
+
+	for (TFieldIterator<FProperty> PropertyIt(Function, EFieldIteratorFlags::ExcludeSuper); PropertyIt; ++PropertyIt)
+	{
+		FObjectPropertyBase* ObjectProperty = CastField<FObjectPropertyBase>(*PropertyIt);
+		if (!ObjectProperty || !ObjectProperty->HasAnyPropertyFlags(CPF_Parm) || ObjectProperty->HasAnyPropertyFlags(CPF_ReturnParm))
+		{
+			continue;
+		}
+
+		const FName PropertyName = ObjectProperty->GetFName();
+		if (PropertyName == WorldContextObjectName || PropertyName == WorldContextName || PropertyName == ContextObjectName)
+		{
+			return ObjectProperty;
+		}
+	}
+
+	return nullptr;
+}
+
+void UCSFunctionBase::CacheWorldContextProperty()
+{
+	bool bHasWorldContextMetadata = false;
+	CachedWorldContextProperty = FindWorldContextProperty(this, bHasWorldContextMetadata);
+	bHasExplicitWorldContext = CachedWorldContextProperty != nullptr || bHasWorldContextMetadata;
+	bWorldContextPropertyCached = true;
+
+	if (!CachedWorldContextProperty && bHasWorldContextMetadata)
+	{
+		UE_LOGFMT(LogUnrealSharp, Warning,
+			"Function {0} declares WorldContext metadata, but parameter {1} is not an object property",
+			GetName(), GetMetaData(TEXT("WorldContext")));
+	}
+}
+
+bool UCSFunctionBase::TryGetExplicitWorldContext(uint8* ParameterBuffer, UObject*& OutWorldContextObject) const
+{
+	check(bWorldContextPropertyCached);
+
+	if (!bHasExplicitWorldContext)
+	{
+		return false;
+	}
+
+	if (!CachedWorldContextProperty || !ParameterBuffer)
+	{
+		return true;
+	}
+
+	const void* ValueAddress = CachedWorldContextProperty->ContainerPtrToValuePtr<void>(ParameterBuffer);
+	OutWorldContextObject = CachedWorldContextProperty->GetObjectPropertyValue(ValueAddress);
+	return true;
+}
+
 void UCSFunctionBase::Bind()
 {
+	// Cache our world context property so we don't have to look it up every time we invoke this function.
+	CacheWorldContextProperty();
+
 	UClass* ClassToFindFunction = GetOwnerClass();
 
 #if WITH_EDITOR
@@ -68,21 +140,18 @@ void UCSFunctionBase::InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Sta
 	TRACE_CPUPROFILER_EVENT_SCOPE(UCSFunctionBase::InvokeManagedMethod);
 	
 	Stack.Code += !!Stack.Code;
-
-	// Prefer using World as context since it's more stable
-	UObject* WorldContext = nullptr;
-	if (Stack.Object)
-	{
-		UWorld* World = Stack.Object->GetWorld();
-		WorldContext = World ? World : Stack.Object;
-	}
-
-	if (WorldContext)
-	{
-		UCSManager::Get().SetCurrentWorldContext(WorldContext);
-	}
-
 	UCSFunctionBase* ManagedFunction = static_cast<UCSFunctionBase*>(Stack.CurrentNativeFunction);
+
+	UObject* WorldContextObject = nullptr;
+	const bool bHasExplicitWorldContext = ManagedFunction->TryGetExplicitWorldContext(Stack.Locals, WorldContextObject);
+	if (!bHasExplicitWorldContext)
+	{
+		WorldContextObject = IsValid(ObjectToInvokeOn) ? ObjectToInvokeOn : Stack.Object;
+	}
+
+	// An explicit context, including an explicitly null context.
+	// Receiver-less nested calls inherit the caller's active scope.
+	FCSWorldContextScope WorldContextScope(WorldContextObject, !bHasExplicitWorldContext);
 
 #if WITH_EDITOR
 	// After a full reload, method pointers are stale, so we just lazy update them here.

--- a/Source/UnrealSharpCore/Public/CSManager.h
+++ b/Source/UnrealSharpCore/Public/CSManager.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CSBindsRegistry.h"
 #include "CSManagedAssembly.h"
@@ -7,6 +7,7 @@
 
 class UCSScriptStruct;
 class UCSEnum;
+class UWorld;
 
 DECLARE_MULTICAST_DELEGATE_OneParam(FCSClassEvent, UCSClass*);
 DECLARE_MULTICAST_DELEGATE_OneParam(FCSStructEvent, UCSScriptStruct*);
@@ -85,8 +86,10 @@ public:
 	UNREALSHARPCORE_API bool IsManagedType(const UField* Field) const { return IsManagedPackage(Field->GetOutermost()); }
 	UNREALSHARPCORE_API bool IsLoadingAnyAssembly() const;
 	
-	void SetCurrentWorldContext(UObject* WorldContext) { CurrentWorldContext = WorldContext; }
-	UObject* GetCurrentWorldContext() const { return CurrentWorldContext.Get(); }
+	UNREALSHARPCORE_API UWorld* ResolveWorldContext(UObject* WorldContextObject) const;
+	UNREALSHARPCORE_API void PushWorldContext(UObject* WorldContextObject, bool bInheritIfUnresolved = true);
+	UNREALSHARPCORE_API void PopWorldContext();
+	UNREALSHARPCORE_API UWorld* GetCurrentWorldContext() const;
 	
 	TMap<FCSObjectID, TSharedPtr<FGCHandle>>& GetManagedObjectHandles() { return ManagedObjectHandles; }
 	TMap<FCSObjectID, TMap<FCSObjectID, TSharedPtr<FGCHandle>>>& GetManagedInterfaceWrappers() { return ManagedInterfaceWrapperHandles; }
@@ -110,8 +113,6 @@ private:
 	TMap<FCSObjectID, TSharedPtr<FGCHandle>> ManagedObjectHandles;
 	TMap<FCSObjectID, TMap<FCSObjectID, TSharedPtr<FGCHandle>>> ManagedInterfaceWrapperHandles;
 
-	TWeakObjectPtr<UObject> CurrentWorldContext;
-	
 	FCSManagerInitializedEvent OnInitialized;
 
 #if WITH_EDITORONLY_DATA

--- a/Source/UnrealSharpCore/Public/CSWorldContextScope.h
+++ b/Source/UnrealSharpCore/Public/CSWorldContextScope.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "CoreMinimal.h"
+
+/**
+ * World context for the duration of a native-to-managed call.
+ * Contexts are stored per thread and restored when the scope exits, preventing
+ * nested calls from leaking their world into their caller.
+ */
+class UNREALSHARPCORE_API FCSWorldContextScope
+{
+public:
+	explicit FCSWorldContextScope(UObject* WorldContextObject, bool bInheritIfUnresolved = true);
+	~FCSWorldContextScope();
+
+	FCSWorldContextScope(const FCSWorldContextScope&) = delete;
+	FCSWorldContextScope& operator=(const FCSWorldContextScope&) = delete;
+};

--- a/Source/UnrealSharpCore/Public/Functions/CSFunction.h
+++ b/Source/UnrealSharpCore/Public/Functions/CSFunction.h
@@ -5,6 +5,7 @@
 #include "CSFunction.generated.h"
 
 struct FGCHandle;
+class FObjectPropertyBase;
 class UCSClass;
 
 UCLASS()
@@ -27,5 +28,12 @@ public:
 	
 	static void InvokeManagedMethod(UObject* ObjectToInvokeOn, FFrame& Stack, RESULT_DECL);
 private:
+	static FObjectPropertyBase* FindWorldContextProperty(UFunction* Function, bool& bHasWorldContextMetadata);
+	void CacheWorldContextProperty();
+	bool TryGetExplicitWorldContext(uint8* ParameterBuffer, UObject*& OutWorldContextObject) const;
+
 	TSharedPtr<FGCHandle> MethodHandle = nullptr;
+	FObjectPropertyBase* CachedWorldContextProperty = nullptr;
+	bool bHasExplicitWorldContext = false;
+	bool bWorldContextPropertyCached = false;
 };


### PR DESCRIPTION
This PR attempts to fix null, stale, and incorrect WorldContext values during managed function calls.
WorldContext is now resolved from an explicit UFunction parameter or the calling object. Resolved contexts are stored in a thread-local stack and automatically restored when nested calls complete.
A public managed API is also available for cases where the caller must explicitly select a world, such as multi-world systems:

```CSharp
using var worldContextScope = WorldContext.Push(world);
```

Generated function calls made within this scope use the specified world as their implicit WorldContext. Disposing the scope restores the previously active context. The scope is synchronous and should not be held across an await.