### PR TITLE
Fix component only compile being skipped during hot reload

### DIFF
--- a/Source/UnrealSharpCompiler/Private/UnrealSharpCompiler.cpp
+++ b/Source/UnrealSharpCompiler/Private/UnrealSharpCompiler.cpp
@@ -56,7 +56,7 @@ void FUnrealSharpCompilerModule::RecompileAndReinstanceBlueprints()
 		return;
 	}
 	
-	if (ManagedClassesToCompile.IsEmpty())
+	if (ManagedClassesToCompile.IsEmpty() && ManagedComponentsToCompile.IsEmpty())
 	{
 		// Nothing to compile.
 		return;


### PR DESCRIPTION
During hot reload, code only checks for `ManagedClassesToCompile` but there is scenarios where there is only `ManagedComponentsToCompile` and compile gets skipped. This pr aims to fix it.

Resolves https://github.com/UnrealSharp/UnrealSharp/issues/706