### PR TITLE
Fix Unreal Engine 5.8 laucnher compatibility

### DIFF
--- a/Source/UnrealSharpManagedGlue/Exporters/PreprocessorExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/PreprocessorExporter.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.RegularExpressions;
+using System.Text.Json;
 using System.Xml.Linq;
 using UnrealSharpManagedGlue.SourceGeneration;
 using UnrealSharpManagedGlue.Utilities;
@@ -54,24 +54,17 @@ public static class PreprocessorExporter
 
     private static void AddEngineVersionDefines(string engineDirectory, HashSet<string> definesSet)
     {
-        string versionHeader = Path.Combine(engineDirectory, "Source", "Runtime", "Launch", "Resources", "Version.h");
-        if (!File.Exists(versionHeader))
+        string buildVersionPath = Path.Combine(engineDirectory, "Build", "Build.version");
+        if (!File.Exists(buildVersionPath))
         {
             return;
         }
 
         try
         {
-            string contents = File.ReadAllText(versionHeader);
-            Match majorMatch = Regex.Match(contents, @"^\s*#define\s+ENGINE_MAJOR_VERSION\s+(\d+)", RegexOptions.Multiline);
-            Match minorMatch = Regex.Match(contents, @"^\s*#define\s+ENGINE_MINOR_VERSION\s+(\d+)", RegexOptions.Multiline);
-            if (!majorMatch.Success || !minorMatch.Success)
-            {
-                return;
-            }
-
-            int engineMajor = int.Parse(majorMatch.Groups[1].Value);
-            int engineMinor = int.Parse(minorMatch.Groups[1].Value);
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(buildVersionPath));
+            int engineMajor = document.RootElement.GetProperty("MajorVersion").GetInt32();
+            int engineMinor = document.RootElement.GetProperty("MinorVersion").GetInt32();
 
             // Match UnrealBuildTool's UE_X_Y_OR_LATER convention.
             for (int major = 4; major <= engineMajor; major++)
@@ -86,7 +79,7 @@ public static class PreprocessorExporter
         }
         catch
         {
-            // Keep defines parsed from UE5Rules.csproj if Version.h is unavailable.
+            // Keep defines parsed from UE5Rules.csproj if Build.version is unavailable or invalid.
         }
     }
 

--- a/Source/UnrealSharpManagedGlue/Exporters/PreprocessorExporter.cs
+++ b/Source/UnrealSharpManagedGlue/Exporters/PreprocessorExporter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using UnrealSharpManagedGlue.SourceGeneration;
 using UnrealSharpManagedGlue.Utilities;
@@ -20,43 +21,73 @@ public static class PreprocessorExporter
         HashSet<string> definesSet = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         
         string csproj = Path.Combine(engineDirectory, "Intermediate", "Build", "BuildRulesProjects", "UE5Rules", "UE5Rules.csproj");
-        if (!File.Exists(csproj))
+        if (File.Exists(csproj))
         {
-            return definesSet;
-        }
-
-        XDocument document;
-        try 
-        { 
-            document = XDocument.Load(csproj); 
-        }
-        catch 
-        {
-            return definesSet; 
-        }
-
-        IEnumerable<string> values = document.Descendants("DefineConstants").Select(x => x.Value);
-        foreach (string value in values)
-        {
-            foreach (string raw in value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+            try
             {
-                string s = raw.Trim();
-                
-                if (s.Length == 0)
+                XDocument document = XDocument.Load(csproj);
+                IEnumerable<string> values = document.Descendants("DefineConstants").Select(x => x.Value);
+                foreach (string value in values)
                 {
-                    continue;
-                }
+                    foreach (string raw in value.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        string s = raw.Trim();
 
-                if (s.StartsWith("$(", StringComparison.Ordinal))
-                {
-                    continue;
-                }
+                        if (s.Length == 0 || s.StartsWith("$(", StringComparison.Ordinal))
+                        {
+                            continue;
+                        }
 
-                definesSet.Add(s);
+                        definesSet.Add(s);
+                    }
+                }
+            }
+            catch
+            {
+                // Installed engine builds may omit or restrict access to this generated project.
             }
         }
 
+        AddEngineVersionDefines(engineDirectory, definesSet);
         return definesSet;
+    }
+
+    private static void AddEngineVersionDefines(string engineDirectory, HashSet<string> definesSet)
+    {
+        string versionHeader = Path.Combine(engineDirectory, "Source", "Runtime", "Launch", "Resources", "Version.h");
+        if (!File.Exists(versionHeader))
+        {
+            return;
+        }
+
+        try
+        {
+            string contents = File.ReadAllText(versionHeader);
+            Match majorMatch = Regex.Match(contents, @"^\s*#define\s+ENGINE_MAJOR_VERSION\s+(\d+)", RegexOptions.Multiline);
+            Match minorMatch = Regex.Match(contents, @"^\s*#define\s+ENGINE_MINOR_VERSION\s+(\d+)", RegexOptions.Multiline);
+            if (!majorMatch.Success || !minorMatch.Success)
+            {
+                return;
+            }
+
+            int engineMajor = int.Parse(majorMatch.Groups[1].Value);
+            int engineMinor = int.Parse(minorMatch.Groups[1].Value);
+
+            // Match UnrealBuildTool's UE_X_Y_OR_LATER convention.
+            for (int major = 4; major <= engineMajor; major++)
+            {
+                int firstMinor = major == 4 ? 17 : 0;
+                int lastMinor = major == engineMajor ? engineMinor : 30;
+                for (int minor = firstMinor; minor <= lastMinor; minor++)
+                {
+                    definesSet.Add($"UE_{major}_{minor}_OR_LATER");
+                }
+            }
+        }
+        catch
+        {
+            // Keep defines parsed from UE5Rules.csproj if Version.h is unavailable.
+        }
     }
 
     private static void GenerateMSBuildProps(HashSet<string> defines)

--- a/UnrealSharp.Automation.props
+++ b/UnrealSharp.Automation.props
@@ -10,10 +10,10 @@
     </PropertyGroup>
 
     <PropertyGroup Condition="!Exists('$(UE5RulesProjPath)')">
-        <UEVersionHeaderPath>$(EngineDir)\Source\Runtime\Launch\Resources\Version.h</UEVersionHeaderPath>
-        <UEVersionHeaderContent Condition="Exists('$(UEVersionHeaderPath)')">$([System.IO.File]::ReadAllText('$(UEVersionHeaderPath)'))</UEVersionHeaderContent>
-        <UEEngineMajorVersion>$([System.Text.RegularExpressions.Regex]::Match($(UEVersionHeaderContent), 'ENGINE_MAJOR_VERSION\s+(\d+)').Groups[1].Value)</UEEngineMajorVersion>
-        <UEEngineMinorVersion>$([System.Text.RegularExpressions.Regex]::Match($(UEVersionHeaderContent), 'ENGINE_MINOR_VERSION\s+(\d+)').Groups[1].Value)</UEEngineMinorVersion>
+        <UEBuildVersionPath>$(EngineDir)\Build\Build.version</UEBuildVersionPath>
+        <UEBuildVersionContent Condition="Exists('$(UEBuildVersionPath)')">$([System.IO.File]::ReadAllText('$(UEBuildVersionPath)'))</UEBuildVersionContent>
+        <UEEngineMajorVersion>$([System.Text.RegularExpressions.Regex]::Match($(UEBuildVersionContent), '&quot;MajorVersion&quot;\s*:\s*(\d+)').Groups[1].Value)</UEEngineMajorVersion>
+        <UEEngineMinorVersion>$([System.Text.RegularExpressions.Regex]::Match($(UEBuildVersionContent), '&quot;MinorVersion&quot;\s*:\s*(\d+)').Groups[1].Value)</UEEngineMinorVersion>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/UnrealSharp.Automation.props
+++ b/UnrealSharp.Automation.props
@@ -1,4 +1,4 @@
-<Project>
+﻿<Project>
     <PropertyGroup>
         <UE5RulesProjPath>$(EngineDir)\Intermediate\Build\BuildRulesProjects\UE5Rules\UE5Rules.csproj</UE5RulesProjPath>
     </PropertyGroup>
@@ -9,9 +9,16 @@
         <UE5Rules_DefineConstants>$([System.Text.RegularExpressions.Regex]::Replace($(UE5Rules_DefineConstants), '\s+', ''))</UE5Rules_DefineConstants>
     </PropertyGroup>
 
+    <PropertyGroup Condition="!Exists('$(UE5RulesProjPath)')">
+        <UEVersionHeaderPath>$(EngineDir)\Source\Runtime\Launch\Resources\Version.h</UEVersionHeaderPath>
+        <UEVersionHeaderContent Condition="Exists('$(UEVersionHeaderPath)')">$([System.IO.File]::ReadAllText('$(UEVersionHeaderPath)'))</UEVersionHeaderContent>
+        <UEEngineMajorVersion>$([System.Text.RegularExpressions.Regex]::Match($(UEVersionHeaderContent), 'ENGINE_MAJOR_VERSION\s+(\d+)').Groups[1].Value)</UEEngineMajorVersion>
+        <UEEngineMinorVersion>$([System.Text.RegularExpressions.Regex]::Match($(UEVersionHeaderContent), 'ENGINE_MINOR_VERSION\s+(\d+)').Groups[1].Value)</UEEngineMinorVersion>
+    </PropertyGroup>
+
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <TargetFramework Condition="$(UE5Rules_DefineConstants.Contains('UE_5_8_OR_LATER'))">net10.0</TargetFramework>
+        <TargetFramework Condition="$(UE5Rules_DefineConstants.Contains('UE_5_8_OR_LATER')) Or ('$(UEEngineMajorVersion)' == '5' And '$(UEEngineMinorVersion)' == '8')">net10.0</TargetFramework>
     </PropertyGroup>
     
 </Project>


### PR DESCRIPTION
**Cause**: launcher installed UE 5.8 does not  include the generated UE5Rules.csproj UnrealSharp expected, so engine version symbols were empty and FInstancedStruct went into the wrong C# namespace.

**Fix**: fallback detection in UnrealSharp.Automation.props and preprocessorexporter.cs to correctly select net10 in the launcher version.

discord ticket: [here](https://discord.com/channels/1153570806417342466/1530720394531700756)