### PR TITLE
Fixes startup crash when the compile queue contains only component

### DIFF
--- a/Source/UnrealSharpCompiler/Private/UnrealSharpCompiler.cpp
+++ b/Source/UnrealSharpCompiler/Private/UnrealSharpCompiler.cpp
@@ -56,7 +56,7 @@ void FUnrealSharpCompilerModule::RecompileAndReinstanceBlueprints()
 		return;
 	}
 	
-	if (ManagedClassesToCompile.IsEmpty())
+	if (ManagedClassesToCompile.IsEmpty() && ManagedComponentsToCompile.IsEmpty())
 	{
 		// Nothing to compile.
 		return;


### PR DESCRIPTION
This fixes an issue where if the only managed types queued for compilation are components the editor crashes on startup.