### PR TITLE
Fix TargetFramework detection for installed engine builds (UE 5.8)

### DIFF
--- a/UnrealSharp.Automation.props
+++ b/UnrealSharp.Automation.props
@@ -9,6 +9,13 @@
         <UE5Rules_DefineConstants>$([System.Text.RegularExpressions.Regex]::Replace($(UE5Rules_DefineConstants), '\s+', ''))</UE5Rules_DefineConstants>
     </PropertyGroup>
 
+    <!-- Installed builds never generate UE5Rules.csproj, so fall back to the engine's Build.version -->
+    <PropertyGroup Condition="!Exists('$(UE5RulesProjPath)') AND Exists('$(EngineDir)\Build\Build.version')">
+        <UEBuildVersionContent>$([System.IO.File]::ReadAllText('$(EngineDir)\Build\Build.version'))</UEBuildVersionContent>
+        <UEMinorVersion>$([System.Text.RegularExpressions.Regex]::Match($(UEBuildVersionContent), '&quot;MinorVersion&quot;\s*:\s*(\d+)').Groups[1].Value)</UEMinorVersion>
+        <UE5Rules_DefineConstants Condition="'$(UEMinorVersion)' != '' AND '$(UEMinorVersion)' &gt;= '8'">UE_5_8_OR_LATER</UE5Rules_DefineConstants>
+    </PropertyGroup>
+
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
         <TargetFramework Condition="$(UE5Rules_DefineConstants.Contains('UE_5_8_OR_LATER'))">net10.0</TargetFramework>


### PR DESCRIPTION
## Problem

On installed (binary) engine builds of UE 5.8, `UnrealSharp.Automation.props` never detects `UE_5_8_OR_LATER`, so the `TargetFramework` of `UnrealSharpManagedGlue.ubtplugin.csproj` and `UnrealSharp.Automation.csproj` stays at `net8.0`:

- UBT logs `Skipping net8.0 project ...UnrealSharpManagedGlue.ubtplugin.csproj`, and UHT then throws `FileNotFoundException` trying to load the plugin DLL that was never built.
- UAT similarly skips `Build/Scripts/UnrealSharp.Automation.csproj` and fails with `Failed to load script DLL`.
- As a result the managed bindings (`Binaries/Managed/net10.0/UnrealSharp.Plugins.dll`) are never built, and the editor shows the "The bindings library could not be found" dialog at startup.

## Root cause

The `UE_5_8_OR_LATER` detection reads `Engine/Intermediate/Build/BuildRulesProjects/UE5Rules/UE5Rules.csproj`, but that file is only generated for source builds. Installed engines ship the build rules precompiled (`Engine/Intermediate/Build/BuildRules/UE5Rules.dll`), so the condition never matches on installed builds.

## Fix

When the rules project doesn't exist, fall back to reading `Engine/Build/Build.version` (present in every engine install) and enable `net10.0` when `MinorVersion >= 8`. If `Build.version` is missing or cannot be parsed, the previous `net8.0` default is kept, so source builds and older engines are unaffected.

## Testing

Verified on an installed UE 5.8.1 engine:

- `TargetFramework` now evaluates to `net10.0` for the automation and UBT plugin projects.
- UBT builds the UBT plugin instead of skipping it, UHT runs the glue generator, and the managed bindings build completes (`Binaries/Managed/net10.0/UnrealSharp.Plugins.dll` is produced; the editor starts without the missing-bindings dialog).
- A simulated UE 5.7 install still evaluates to `net8.0`.
- A malformed or missing `Build.version` falls back to `net8.0` without errors (the version check is guarded against empty values to avoid MSB4086).