### PR TITLE
Use dotnet executable in selected sdk

### DIFF
--- a/Build/Scripts/Processes/DotnetProcess.cs
+++ b/Build/Scripts/Processes/DotnetProcess.cs
@@ -8,6 +8,7 @@ public class DotnetProcess : BuildToolProcess
     public DotnetProcess() : base(DotNetUtilities.DotNetExecutable)
     {
         string LatestDotNetSdkPath = DotNetUtilities.LatestDotNetSdkPath;
+        StartInfo.ArgumentList.Add(Path.Combine(LatestDotNetSdkPath, "dotnet.dll"));
         StartInfo.Environment["MSBuildExtensionsPath"] = LatestDotNetSdkPath;
         StartInfo.Environment["MSBUILD_EXE_PATH"] = Path.Combine(LatestDotNetSdkPath, "MSBuild.dll");
         StartInfo.Environment["MSBuildSDKsPath"] = Path.Combine(LatestDotNetSdkPath, "Sdks");


### PR DESCRIPTION
Otherwise it can collide with newer SDKs installed on the PC, causing the build to fail. 